### PR TITLE
[codex] Add Drip Wave README and GitHub contribution scaffolding

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+
+languages:
+  javascript:
+    enabled: true
+  typescript:
+    enabled: true
+  python:
+    enabled: true
+
+rules:
+  - "Focus on logic bugs, security issues, and performance."
+  - "Avoid nitpicking formatting if Prettier/ESLint is used."
+  - "Be strict on smart contract safety and edge cases."
+  - "Highlight risky blockchain interactions."
+
+pull_requests:
+  auto_review: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Drip Wave Contribution Guide
+    url: https://github.com/Obiajulu-gif/vaultquest/blob/main/CONTRIBUTING.md
+    about: Review contribution expectations, validation steps, and UI evidence requirements.

--- a/.github/ISSUE_TEMPLATE/implementation-task.md
+++ b/.github/ISSUE_TEMPLATE/implementation-task.md
@@ -1,0 +1,25 @@
+---
+name: Implementation task
+about: Engineering-ready implementation issue for Drip Wave
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Title
+
+## Labels
+
+## Priority
+
+## Summary
+
+## Problem Statement
+
+## Technical Scope
+
+## Implementation Details
+
+## Acceptance Criteria
+
+## Dependencies

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+-
+
+## Linked Issue
+
+-
+
+## Validation
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] Additional contract/backend checks listed below when applicable
+
+## UI Evidence
+
+- [ ] Not applicable
+- [ ] Screenshots attached
+- [ ] Demo video/GIF attached
+
+## Notes
+
+- Include before/after screenshots where applicable for visible UI changes.
+- Include a short demo video/GIF for interactive wallet or transaction flows.
+- Document any new environment variables, contract IDs, or deployment steps introduced by this PR.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,65 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  soroban:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect Soroban workspace
+        id: detect
+        shell: bash
+        run: |
+          if find . -maxdepth 3 -name Cargo.toml | grep -q .; then
+            echo "has_workspace=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_workspace=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Rust
+        if: steps.detect.outputs.has_workspace == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run Soroban tests
+        if: steps.detect.outputs.has_workspace == 'true'
+        shell: bash
+        run: cargo test --workspace
+
+      - name: Skip when no Soroban workspace exists
+        if: steps.detect.outputs.has_workspace != 'true'
+        run: echo "No Soroban workspace detected yet."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing To Drip Wave
+
+This repository is in active migration from a legacy `VaultQuest` prototype to a Stellar/Soroban implementation of `Drip Wave`.
+
+## Working Rules
+
+- Prioritize issues related to wallet connection, core product logic, and Soroban contract implementation.
+- Avoid adding new functionality to legacy Cosmos/EVM paths unless the change is explicitly part of migration cleanup.
+- Keep frontend wallet state, transaction orchestration, contract clients, and backend reads separated by clear interfaces.
+- Prefer small, issue-scoped pull requests.
+
+## Before Opening A Pull Request
+
+1. Link the GitHub issue the work addresses.
+2. Describe the technical approach and any migration tradeoffs.
+3. List the validation steps you ran locally.
+4. If the PR changes visible UI or user interaction behavior, include screenshots or a short demo video/GIF.
+
+## UI Evidence Requirement
+
+For changes that affect wallet connection UI, dashboard UI, transaction flow screens, user interaction flows, frontend components, or any other visible product behavior:
+
+- Include before/after screenshots where applicable.
+- Include a short demo video or GIF for interactive flows.
+
+## Local Validation
+
+Run the checks that apply to your change before opening a PR:
+
+```sh
+npm run lint
+npm run build
+```
+
+If you introduce a Soroban workspace, also run the relevant Rust and contract checks for that workspace and include them in the PR description.
+
+## Implementation Notes
+
+- Keep naming aligned with `Drip Wave`, `Stellar`, and `Soroban`.
+- Treat the current Solidity contract and EVM wallet code as legacy reference only.
+- Document any new environment variables, contract IDs, or deployment steps in the same PR.

--- a/README.md
+++ b/README.md
@@ -1,202 +1,103 @@
-# VaultQuest
+# Drip Wave
 
-VaultQuest is a no-loss prize-saving protocol where users deposit funds in prize vaults. Instead of earning traditional interest, users stand a chance to win prizes drawn from the collective yield. This innovative approach gives users potential rewards while keeping their deposited funds intact.
+Drip Wave is a prize-linked savings and recurring contribution product being rebuilt for the Stellar network with Soroban smart contracts.
 
----
+This repository still contains legacy `VaultQuest` frontend and EVM/Cosmos-era code paths. The current development goal is to migrate the product into a clean Stellar/Soroban architecture with a stable wallet flow, explicit core product logic, and production-ready smart contracts.
 
-## Table of Contents
+## Current Focus
 
-- [VaultQuest](#vaultquest)
-  - [Table of Contents](#table-of-contents)
-  - [How VaultQuest Works](#how-vaultquest-works)
-  - [Protocol Life Cycle](#protocol-life-cycle)
-  - [User Life Cycle](#user-life-cycle)
-  - [Project Structure](#project-structure)
-  - [Detailed Code Overview](#detailed-code-overview)
-    - [VaultPage (page.js)](#vaultpage-pagejs)
-  - [Getting Started](#getting-started)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
-    - [Running the Application](#running-the-application)
-  - [Building and Deployment](#building-and-deployment)
-  - [Technologies Used](#technologies-used)
-  - [Contributing](#contributing)
-  - [License](#license)
-  - [Contact](#contact)
+The implementation roadmap in this repository is centered on three primary workstreams:
 
----
+1. Stellar wallet connection and transaction signing.
+2. Core Drip Wave product logic for pool participation, recurring contributions, payouts, and recovery states.
+3. Soroban smart contract design, implementation, deployment, and testing.
 
-## How VaultQuest Works
+Supporting workstreams cover backend event syncing and GitHub quality automation where they directly unblock the three priorities above.
 
-VaultQuest leverages tokenized vaults built on the ERC4626 standard—a modern ERC20 implementation that standardizes yield-bearing vaults. The workflow is as follows:
+## Product Direction
 
-1. **Deposit Funds:** Users deposit into a vault using tokens such as USDC.
-2. **Yield Generation:** Deposited funds are allocated to various DeFi strategies (e.g., lending/borrowing platforms, DEX liquidity, yield farming) generating yield over time.
-3. **Prize Mechanism:** Instead of traditional interest, the accumulated yield is periodically converted and awarded as prizes in regular draws.
-4. **Withdrawal & Claim:** Users can withdraw their deposits at any time; winners of the draws must claim their rewards.
+Drip Wave is intended to provide a no-loss or capital-preserving contribution experience where users participate in shared pools and interact with on-chain rules for deposits, payout eligibility, claims, and withdrawals.
 
----
+The exact contract and frontend boundaries are being normalized during the Stellar migration. Contributors should treat the current repository as a transition codebase, not as a finished architectural reference.
 
-## Protocol Life Cycle
+## Why Stellar And Soroban
 
-1. **Deposit:** Users select a vault and deposit their funds.
-2. **Yield Accrual:** The vault invests deposits in integrated DeFi protocols, accruing yield over time.
-3. **Draw & Distribution:** At regular intervals, the accrued yield is converted and randomly awarded to one or more participants.
-4. **Claiming Rewards:** Winners need to claim their rewards while other users maintain control over their deposits.
+- Stellar provides fast settlement and strong support for asset movement and payment-centric applications.
+- Soroban gives Drip Wave a smart-contract environment that can encode pool rules, user positions, payout logic, and event emission on-chain.
+- A Stellar-native wallet flow is required; the current Cosmos/EVM wallet setup is legacy and should be phased out of active implementation.
 
----
+## Repository Status
 
-## User Life Cycle
+Today the repository includes:
 
-- **Deposit:** Initiate participation by depositing funds in your chosen vault.
-- **Accrue Yield:** Let your deposit generate yield through automated DeFi strategies.
-- **Win Prizes:** Periodically, a prize draw is conducted to distribute the yield.
-- **Withdrawal:** At any time, you can withdraw your principal deposit.
-- **Reward Claim:** If selected, claim the prize reward as part of your yield.
+- A Next.js frontend prototype with legacy `VaultQuest` branding in several routes and components.
+- Legacy wallet integrations built around Cosmos Kit, RainbowKit, and `wagmi`.
+- A Solidity contract and ABI that document prior assumptions but do not match the target Soroban implementation.
+- No committed `.github` automation baseline before this project-management pass.
 
----
+That means contributors working on new implementation should align with the GitHub issues for the Stellar migration rather than extending the old chain-specific paths.
 
-## Project Structure
+## Target Architecture
 
-```
-├── .gitignore
-├── next.config.mjs
-├── package.json
-├── postcss.config.mjs
-├── tailwind.config.js
-├── tsconfig.json
-├── README.md
-├── app
-│   └── app
-│       └── vault
-│           └── page.js          // The vault interface and deposit handling (see detailed code overview below)
-├── components
-│   ├── app
-│   │   ├── AppNav.jsx
-│   │   ├── CreateVaultModal.jsx
-│   │   └── DepositModal.jsx
-│   ├── icons
-│   │   └── EthIcon.jsx
-│   └── ... (additional components)
-├── hooks
-├── lib
-├── public
-│   └── images
-│       ├── avax.png
-│       ├── usdc.png
-│       └── usdt.png
-└── styles
-```
+The intended architecture is:
 
-- **app/**: Contains Next.js pages, including the vault interface that handles displaying vaults, deposit actions, filtering, and search.
-- **components/**: Reusable UI components such as navigation, modals, and icons used throughout the VaultQuest interface.
-- **hooks/** and **lib/**: Application logic and utility functions.
-- **public/**: Static assets including images for Eth, USDC, and Cosmo.
-- **styles/**: Global styles and component-specific styling.
+1. `frontend`
+   A Next.js application for connect wallet, pool discovery, contribution flows, dashboard views, transaction progress, and recovery UX.
+2. `soroban contracts`
+   Rust/Soroban contracts that define pool state, participant accounting, payout rules, admin controls, and events.
+3. `backend/indexer`
+   Supporting services that ingest contract events, track transaction status, and serve dashboard-friendly reads.
 
----
+## Priority Implementation Order
 
-## Detailed Code Overview
+1. Replace the current wallet stack with a Stellar-native provider and connection flow.
+2. Define the core Drip Wave state model used across frontend, backend, and contract work.
+3. Specify and implement the Soroban contract architecture and lifecycle.
+4. Add deployment/config tooling so the frontend and backend can target real contract IDs.
+5. Build indexing, dashboard APIs, and quality automation around the core flow.
 
-### VaultPage (page.js)
-
-The `VaultPage` component is the primary interface where users interact with prize vaults:
-
-- **State Management:**  
-  Uses React hooks (`useState`) for handling modal visibility, selected vaults, search queries, and filtering by network.
-
-- **Vault Data:**  
-  The page initializes an array of vaults. Each vault has properties like name, network, APY, TVL, user count, and deposit history. For example, the "Prize DAI" vault includes a list of recent deposits.
-
-- **Filtering and Search:**  
-  Users have the ability to filter vaults based on the network (e.g., Cosmos) or search by name/token using controlled inputs.
-
-- **Deposit Handling:**  
-  When the "Deposit" button is clicked, the selected vault is stored and a deposit modal is shown. This modal enables users to deposit funds, which then update the vault’s balance, TVL, and deposit history.
-
-- **UI Layout:**  
-  The interface leverages Tailwind CSS for styling and lucide-react for icons. It also displays statistics such as total value locked (TVL), total users, and average APY in a tabbed section.
-
----
-
-## Getting Started
+## Local Development
 
 ### Prerequisites
 
-- Node.js (v14+)
+- Node.js 20+
 - npm
 
-### Installation
+### Install
 
-1. **Clone the Repository:**
-    ```sh
-    git clone https://github.com/Obiajulu-gif/vaultquest
-    ```
-2. **Navigate to the Project Directory:**
-    ```sh
-    cd vaultquest
-    ```
-3. **Install Dependencies:**
-    ```sh
-    npm install
-    ```
+```sh
+npm install
+```
 
-### Running the Application
+### Run The Frontend
 
-Start the Next.js development server:
 ```sh
 npm run dev
 ```
-Open [http://localhost:3000](http://localhost:3000) in your browser to interact with VaultQuest.
 
----
+### Build
 
-## Building and Deployment
-
-To build the project for production:
 ```sh
 npm run build
 ```
-Then, start the production server:
-```sh
-npm run start
-```
 
----
+## Contributor Guidance
 
-## Technologies Used
+- Start from the GitHub issues created for the Stellar/Soroban migration.
+- Do not extend the legacy EVM/Cosmos wallet path for new features.
+- Keep wallet logic, product logic, and contract logic separated by clear interfaces.
+- UI-related pull requests must include screenshots or a short demo video/GIF.
+- Keep README, issue bodies, and implementation notes aligned with `Drip Wave`, `Stellar`, and `Soroban` terminology.
 
-- **Next.js:** Framework for server-rendered React applications.
-- **React:** JavaScript library for building user interfaces.
-- **Tailwind CSS:** Utility-first CSS framework that accelerates UI development.
-- **lucide-react:** A versatile icon library integrated into the UI.
-- **ERC4626:** Standard for tokenized, yield-bearing vaults.
-- **DeFi Protocols:** Integration with decentralized finance strategies such as lending, liquidity provision, and yield farming.
-- **Cosmo:** A decentralized blockchain platform designed for innovative decentralized applications and cross-chain integration.
-- **Eth:** The native token of the Ethereum ecosystem, integrated into VaultQuest to facilitate secure and efficient operations within the decentralized network.
+Additional contributor workflow guidance lives in [CONTRIBUTING.md](CONTRIBUTING.md).
 
----
+## Near-Term Cleanup Targets
 
-## Contributing
-
-Contributions are always welcome! To contribute:
-1. Fork the repository.
-2. Create a branch for your feature or bug fix.
-3. Commit your changes and open a pull request describing your modifications.
-4. Follow the established style guidelines and ensure that all tests pass.
-
----
+- Replace legacy `VaultQuest` branding in user-facing routes and metadata.
+- Remove or isolate `wagmi`, RainbowKit, Cosmos Kit, and Solidity-specific assumptions from active flows.
+- Introduce Soroban contract source, tests, and deployment configuration.
+- Add backend event indexing and dashboard APIs that match the new state model.
 
 ## License
 
 This project is licensed under the MIT License.
-
----
-
-## Contact
-
-For any questions or inquiries, please open an issue in the repository or contact the project maintainers.
-
----
-
-VaultQuest leverages advanced DeFi concepts and robust multi-chain integration—including support for Eth and Cosmo—to offer users an exciting, risk-free opportunity to earn potential rewards through participation. Enjoy exploring and contributing to VaultQuest!

--- a/components/Hero.jsx
+++ b/components/Hero.jsx
@@ -21,7 +21,7 @@ export default function Hero() {
           <div className="absolute bottom-40 left-60 top-20 animate-float">
             <Image
               src="/aval.png"
-              alt="Avalanche"
+              alt="Stellar"
               width={120}
               height={120}
             />
@@ -29,7 +29,7 @@ export default function Hero() {
           <div className="absolute bottom-40 right-60 top-20 animate-float">
             <Image
               src="/avall.png"
-              alt="Avalanche"
+              alt="Stellar"
               width={50}
               height={50}
             />
@@ -47,11 +47,11 @@ export default function Hero() {
 
         {/* Mobile Background Elements */}
          <div className="md:hidden">
-           {/* Top Left Avalanche */}
+           {/* Top Left Stellar */}
            <div className="absolute top-20 left-4 opacity-80">
              <Image
                src="/aval.png"
-               alt="Avalanche"
+               alt="Stellar"
                width={80}
                height={80}
              />
@@ -69,11 +69,11 @@ export default function Hero() {
                height={60}
              />
            </div>
-           {/* Right Edge Small Avalanche */}
+           {/* Right Edge Small Stellar */}
            <div className="absolute top-2/3 -right-4">
              <Image
                src="/avall.png"
-               alt="Avalanche"
+               alt="Stellar"
                width={40}
                height={40}
              />

--- a/components/SupportedChains.jsx
+++ b/components/SupportedChains.jsx
@@ -9,10 +9,10 @@ export default function SupportedChains() {
   // Blockchain data with logos and names
  const blockchains = [
 		{
-			name: "Eth",
+			name: "Stellar",
 			logo: "/images/avax.png",
 			color: "bg-gradient-to-r from-cyan-500 to-blue-500",
-			description: "Interoperable blockchain for the Cosmos ecosystem",
+			description: "Fast asset movement and payment-focused blockchain network",
 		},
 		{
 			name: "USDC",

--- a/components/Technology.jsx
+++ b/components/Technology.jsx
@@ -3,9 +3,9 @@ import Image from "next/image"
 export default function Technology() {
   const technologies = [
 		{
-			name: "ETH",
+			name: "Stellar",
 			description:
-				" a revolutionary ecosystem within the Cosmos network, comprising a collection of partially sovereign blockchains.",
+				"Payment-focused blockchain infrastructure for fast, low-friction asset movement and settlement.",
 			icon: "/images/avax.png",
 		},
 		{
@@ -20,9 +20,9 @@ export default function Technology() {
       icon: "/images/nextjs.png",
     },
     {
-      name: "The Eth Economic Zone (EEZ)",
+      name: "Soroban",
       description:
-        "Leveraging the power of ETH to create innovative economic models that drive blockchain adoption.",
+        "Smart contract platform for building Stellar-native applications with explicit on-chain logic.",
       icon: "/images/aeze.png",
     },
 	];


### PR DESCRIPTION
## What changed
- rewrote the README to align the repo with the Drip Wave Stellar/Soroban migration
- added a contribution guide with screenshot/demo expectations for UI work
- added an implementation issue template and PR template
- added a baseline GitHub Actions workflow for frontend quality checks plus conditional Soroban checks

## Why
The repository still presents itself as a VaultQuest EVM/Cosmos project even though the active implementation direction is Drip Wave on Stellar/Soroban. Contributors also lacked issue/PR structure and baseline GitHub automation.

## Validation
- Created the prioritized implementation issues directly in GitHub
- `npm run lint` currently fails in this environment because `next` is not available locally (`'next' is not recognized as an internal or external command`), which indicates dependencies are not installed in the current shell session

## Impact
This PR does not change runtime product behavior. It gives contributors a cleaner source of truth for the migration and establishes lightweight GitHub workflow guardrails.