### PR TITLE
feat: fallback states, transaction timeline, modal a11y, contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,196 @@
+# Contributing to VaultQuest
+
+Welcome! This guide explains how to choose an issue, set up the project,
+validate your changes, and prepare a pull request that maintainers can merge
+quickly. (#66)
+
+Reading time: ~10 minutes. If something here is wrong or out of date, open
+an issue with the `docs` label — that's the kind of contribution that helps
+every future contributor.
+
+## 1. Pick the right issue
+
+VaultQuest issues live across several surfaces:
+
+| Label / area | What it usually involves | Good for |
+|---|---|---|
+| `good first issue` | Self-contained, well-scoped change with clear acceptance criteria | First-time contributors |
+| `frontend` | React/Astro components, state, accessibility, UI polish | Familiarity with React + Tailwind |
+| `backend` | Fastify routes, Prisma schema, business logic | Node + TypeScript + Postgres |
+| `contract` | Soroban (Rust) contract logic and tests | Rust + Stellar Soroban |
+| `docs` | Guides, READMEs, comments, architecture notes | Any contributor |
+| `devops` | CI, deployment, env management | Infra background helps |
+
+Before claiming an issue:
+
+1. **Skim recent comments** — confirm the issue isn't already in flight.
+2. **Check for blockers** — if the description references "blocked by #N",
+   coordinate with the maintainer on the blocking issue first.
+3. **Confirm dependencies** — frontend issues often depend on backend or
+   contract surfaces; verify those interfaces exist before starting.
+4. **Comment to claim** — a short "I'd like to work on this" comment so two
+   contributors don't duplicate effort.
+
+If the scope feels unclear or the change is large, **ask in the issue thread
+before writing code**. A 5-minute clarification beats a 2-day rewrite.
+
+## 2. Project layout
+
+```
+vaultquest/
+├── backend/                    # Fastify action-ledger + reconciliation service
+├── contracts/                  # Soroban smart contracts (Rust)
+├── stellar-wallet-connect/     # Drop-in wallet module (React + Astro)
+├── services/                   # Shared TypeScript service helpers
+├── e2e/                        # Playwright end-to-end tests
+├── tests/                      # Cross-cutting test utilities
+└── docs/                       # Architecture, state model, testing notes
+```
+
+Each top-level package has its own `README.md` with stack details and a setup
+section — read it before running commands inside that folder.
+
+## 3. Local setup
+
+### Prerequisites
+
+- **Node 20.x** (check with `node --version`)
+- **pnpm 9.x** (`npm install -g pnpm` if missing)
+- **Rust + Cargo** with the `wasm32-unknown-unknown` target (only needed for
+  contract work — `rustup target add wasm32-unknown-unknown`)
+- **Postgres 16** (only for backend work — `docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=dev postgres:16`)
+
+### Bootstrap
+
+```bash
+git clone https://github.com/<your-username>/vaultquest.git
+cd vaultquest
+pnpm install
+```
+
+Then follow the per-package setup that matches your issue:
+
+- **Backend**: `cd backend && cp .env.example .env && pnpm exec prisma migrate deploy && pnpm dev`
+- **Contracts**: `cd contracts && cargo build && cargo test`
+- **Wallet module**: see `stellar-wallet-connect/README.md` for env vars
+
+## 4. Validate before opening a PR
+
+Every PR must show that the change does what the issue asked **and** does not
+break anything else. Run the relevant commands for your area:
+
+| Area | Command | What it checks |
+|---|---|---|
+| Backend | `pnpm --filter backend test` | Vitest suite against real Postgres |
+| Backend | `pnpm --filter backend run lint` | ESLint + TypeScript |
+| Backend | `pnpm --filter backend exec prisma format` | Prisma schema formatting |
+| Frontend | `pnpm test` (root) | Vitest unit tests |
+| Frontend | `pnpm exec playwright test` | E2E smoke tests |
+| Contracts | `cargo test` (in `contracts/`) | Soroban contract tests |
+| Contracts | `cargo fmt --check && cargo clippy -- -D warnings` | Format + lint |
+| Docs | manual preview | Markdown renders correctly on GitHub |
+
+If you skip a check, **say so explicitly in the PR description and why** —
+that's far more useful than silent gaps.
+
+## 5. Pull request expectations
+
+### Title
+
+Use a conventional prefix: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
+`chore:`. Example: `feat(frontend): add transaction timeline component (#63)`.
+
+### Body — copy this checklist into every PR
+
+```markdown
+## Summary
+
+Closes #<issue-number>
+
+<1–3 bullet points describing what changed and why>
+
+## Test plan
+
+- [ ] Ran `<the relevant validation commands above>`
+- [ ] Manually tested <the user flow this affects>
+- [ ] Updated/added tests in <path>
+
+## Screenshots / demo
+
+<UI changes MUST include a before/after screenshot or a short screen recording.
+Backend changes that affect a visible surface should include the curl
+request + response or an API client screenshot.>
+
+## Notes for the reviewer
+
+<Anything non-obvious: trade-offs you weighed, follow-ups deferred to a
+later PR, env vars added, migration order, etc.>
+```
+
+### What gets rejected fast
+
+- PRs that close an issue without including `Closes #N` in the body.
+- UI PRs with no screenshot or recording.
+- "Drive-by" formatting commits unrelated to the issue.
+- Changes to `pnpm-lock.yaml` or `Cargo.lock` that aren't motivated by a
+  dependency change in the same PR.
+- New top-level files added at the repo root without prior discussion.
+
+### What gets merged fast
+
+- A PR that closes exactly the linked issue and nothing more.
+- Tests added or updated to cover the new behaviour.
+- A short, descriptive commit message body that future-you can read in
+  `git log` 6 months from now.
+- One round of review feedback addressed in a follow-up commit (don't
+  force-push to the same branch — let reviewers see what changed).
+
+## 6. When to ask before starting
+
+Send a short comment in the issue thread *before* writing code if:
+
+- The acceptance criteria are ambiguous or contradict each other.
+- The fix appears to span multiple packages (frontend + backend + contract).
+- You think the issue description is wrong or out of date.
+- You'd need to add a new dependency.
+- You'd need to refactor existing public APIs to ship the fix.
+
+Asking saves everyone time — maintainers can redirect you to the right
+approach, or split the issue into smaller pieces.
+
+## 7. Accessibility expectations (frontend PRs)
+
+VaultQuest aims for keyboard-navigable, screen-reader-friendly UI. For any
+frontend change:
+
+- New interactive elements need `aria-label` or visible text.
+- Dialogs use `role="dialog"`, `aria-modal="true"`, trap focus, and restore
+  focus on close.
+- Icon-only buttons need an accessible name.
+- Status messages use `role="status"` (polite) or `role="alert"` (assertive).
+- Form controls have associated `<label>` elements.
+
+See `stellar-wallet-connect/src/components/Modal.tsx` for a worked example
+of a focus-trapped, ARIA-compliant dialog.
+
+## 8. Code style
+
+- **TypeScript**: prefer `interface` for public component props, `type` for
+  unions and aliases. Avoid `any`; use `unknown` when the type is genuinely
+  unknown.
+- **Imports**: group external → internal → relative; one blank line between
+  groups. Don't reorder existing import blocks unless your change touches
+  them.
+- **Comments**: explain *why*, not *what*. Code already says what.
+- **Rust**: run `cargo fmt` before committing; treat clippy warnings as
+  errors.
+
+## 9. Getting help
+
+- **Stuck on an issue?** Comment in the issue thread — tag the assignor.
+- **Found a security problem?** Email the maintainer privately rather than
+  opening a public issue.
+- **Want to propose a larger change?** Open a discussion or draft RFC issue
+  before writing code.
+
+Thanks for contributing to VaultQuest! 🚀

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# VaultQuest
+
+A Stellar/Soroban no-loss prize-savings dApp. Users deposit into pooled
+vaults; yield is awarded to a random winner each round while every deposit
+remains withdrawable in full.
+
+## Packages
+
+| Path | What it does |
+|---|---|
+| [`backend/`](./backend) | Fastify action-ledger and reconciliation service |
+| [`contracts/`](./contracts) | Soroban smart contracts (Rust) |
+| [`stellar-wallet-connect/`](./stellar-wallet-connect) | Drop-in wallet module — React + Astro components |
+| [`services/`](./services) | Shared TypeScript service helpers (escrow, quests, savings) |
+| [`e2e/`](./e2e) | Playwright end-to-end tests |
+| [`docs/`](./docs) | Architecture, state model, testing notes |
+
+## Quick start
+
+```bash
+git clone https://github.com/Obiajulu-gif/vaultquest.git
+cd vaultquest
+pnpm install
+```
+
+For per-package setup, see the README inside each folder.
+
+## Contributing
+
+We welcome contributions from everyone. Before opening a PR, please read
+[**CONTRIBUTING.md**](./CONTRIBUTING.md) — it covers:
+
+- How to choose an issue (good-first, frontend, backend, contracts, docs)
+- Local setup and validation commands
+- PR expectations (screenshots, tests, linked issues)
+- When to ask maintainers before starting
+- Accessibility and code style expectations
+
+## License
+
+See [LICENSE](./LICENSE).

--- a/stellar-wallet-connect/src/components/FallbackStates.tsx
+++ b/stellar-wallet-connect/src/components/FallbackStates.tsx
@@ -1,0 +1,227 @@
+import type { FC, ReactNode } from "react";
+import { AlertTriangle, Inbox, Loader2, RefreshCw, Wallet, WifiOff } from "lucide-react";
+
+/**
+ * Unified empty / loading / error state components for VaultQuest (#61).
+ *
+ * Provides a consistent fallback UI across account, vault, prize, dashboard,
+ * and marketplace surfaces so the app feels polished and contributors do not
+ * re-implement the same patterns on every page.
+ *
+ * All components share:
+ *  - The dark VaultQuest theme (`bg-[#1A0505]` etc.)
+ *  - Accessible labels (`role`, `aria-live`)
+ *  - Optional action / retry CTAs
+ *  - Mobile-first responsive layout
+ *
+ * Usage:
+ * ```tsx
+ * if (isLoading) return <LoadingState label="Loading vaults…" />;
+ * if (error)     return <ErrorState message={error.message} onRetry={refetch} />;
+ * if (!vaults)   return <EmptyState title="No vaults yet" />;
+ * if (!wallet)   return <WalletDisconnectedState onConnect={connect} />;
+ * ```
+ */
+
+// ── Shared shell ─────────────────────────────────────────────────────────────
+
+interface ShellProps {
+  children: ReactNode;
+  className?: string;
+  role?: "status" | "alert";
+  ariaLive?: "polite" | "assertive";
+}
+
+const Shell: FC<ShellProps> = ({ children, className = "", role, ariaLive }) => (
+  <div
+    role={role}
+    aria-live={ariaLive}
+    className={`flex flex-col items-center justify-center gap-4 rounded-2xl border border-red-900/30 bg-[#1A0505]/60 px-6 py-12 text-center sm:px-10 sm:py-16 ${className}`}
+  >
+    {children}
+  </div>
+);
+
+// ── Loading ──────────────────────────────────────────────────────────────────
+
+export interface LoadingStateProps {
+  /** Short label announced to screen readers. */
+  label?: string;
+  /** Optional sub-text shown beneath the spinner. */
+  description?: string;
+  className?: string;
+}
+
+export const LoadingState: FC<LoadingStateProps> = ({
+  label = "Loading",
+  description,
+  className,
+}) => (
+  <Shell role="status" ariaLive="polite" className={className}>
+    <Loader2 className="h-8 w-8 animate-spin text-red-400" aria-hidden="true" />
+    <p className="text-base font-medium text-white">{label}</p>
+    {description && <p className="text-sm text-gray-400">{description}</p>}
+    <span className="sr-only">{label}…</span>
+  </Shell>
+);
+
+// ── Empty ────────────────────────────────────────────────────────────────────
+
+export interface EmptyStateProps {
+  /** Optional custom icon. Defaults to an inbox glyph. */
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  /** Optional action button (e.g. "Create a vault"). */
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  className?: string;
+}
+
+export const EmptyState: FC<EmptyStateProps> = ({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}) => (
+  <Shell className={className}>
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-900/20 text-red-400">
+      {icon ?? <Inbox className="h-7 w-7" aria-hidden="true" />}
+    </div>
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      {description && (
+        <p className="max-w-md text-sm text-gray-400">{description}</p>
+      )}
+    </div>
+    {action && (
+      <button
+        type="button"
+        onClick={action.onClick}
+        className="mt-2 inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+      >
+        {action.label}
+      </button>
+    )}
+  </Shell>
+);
+
+// ── Error ────────────────────────────────────────────────────────────────────
+
+export interface ErrorStateProps {
+  message: string;
+  title?: string;
+  /** Optional retry callback — renders a Retry button when provided. */
+  onRetry?: () => void;
+  className?: string;
+}
+
+export const ErrorState: FC<ErrorStateProps> = ({
+  message,
+  title = "Something went wrong",
+  onRetry,
+  className,
+}) => (
+  <Shell role="alert" ariaLive="assertive" className={className}>
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-600/20 text-red-400 border border-red-500/30">
+      <AlertTriangle className="h-7 w-7" aria-hidden="true" />
+    </div>
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      <p className="max-w-md text-sm text-gray-400">{message}</p>
+    </div>
+    {onRetry && (
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-2 inline-flex items-center gap-2 rounded-xl border border-red-500/40 bg-red-900/30 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+      >
+        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        Try again
+      </button>
+    )}
+  </Shell>
+);
+
+// ── Wallet-disconnected ──────────────────────────────────────────────────────
+
+export interface WalletDisconnectedStateProps {
+  /** Optional callback wired to your Connect Wallet flow. */
+  onConnect?: () => void;
+  className?: string;
+}
+
+export const WalletDisconnectedState: FC<WalletDisconnectedStateProps> = ({
+  onConnect,
+  className,
+}) => (
+  <Shell className={className}>
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-900/20 text-red-400">
+      <Wallet className="h-7 w-7" aria-hidden="true" />
+    </div>
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold text-white">Wallet not connected</h3>
+      <p className="max-w-md text-sm text-gray-400">
+        Connect your Stellar wallet to view your vaults, prizes, and transaction history.
+      </p>
+    </div>
+    {onConnect && (
+      <button
+        type="button"
+        onClick={onConnect}
+        className="mt-2 inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+      >
+        <Wallet className="h-4 w-4" aria-hidden="true" />
+        Connect wallet
+      </button>
+    )}
+  </Shell>
+);
+
+// ── Stale-data indicator (inline, not full-shell) ────────────────────────────
+
+export interface StaleIndicatorProps {
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Inline pill shown when stale data is visible during a background refresh.
+ * Use alongside existing data — do not replace data with this component.
+ */
+export const StaleIndicator: FC<StaleIndicatorProps> = ({
+  label = "Refreshing…",
+  className = "",
+}) => (
+  <span
+    role="status"
+    aria-live="polite"
+    className={`inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-300 ${className}`}
+  >
+    <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+    {label}
+  </span>
+);
+
+// ── Offline banner ───────────────────────────────────────────────────────────
+
+export interface OfflineStateProps {
+  className?: string;
+}
+
+export const OfflineState: FC<OfflineStateProps> = ({ className }) => (
+  <Shell role="alert" ariaLive="assertive" className={className}>
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-900/20 text-red-400">
+      <WifiOff className="h-7 w-7" aria-hidden="true" />
+    </div>
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold text-white">You're offline</h3>
+      <p className="max-w-md text-sm text-gray-400">
+        Check your internet connection and try again. We'll automatically retry once you're back online.
+      </p>
+    </div>
+  </Shell>
+);

--- a/stellar-wallet-connect/src/components/Modal.tsx
+++ b/stellar-wallet-connect/src/components/Modal.tsx
@@ -1,13 +1,46 @@
 import type { FC, ReactNode } from "react";
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 
 export interface ModalProps {
   children?: ReactNode;
   onClose: () => void;
   className?: string;
+  /**
+   * Accessible label for the dialog. Required for screen readers when no
+   * heading is provided via `aria-labelledby`.
+   */
+  ariaLabel?: string;
+  /** id of the element labelling the dialog (e.g. the modal heading). */
+  ariaLabelledBy?: string;
+  /** id of the element describing the dialog. */
+  ariaDescribedBy?: string;
 }
 
-const Modal: FC<ModalProps> = ({ children, onClose, className = "" }) => {
+/**
+ * Accessible dialog (#64).
+ *
+ * Improvements over the original implementation:
+ *  - `role="dialog"` + `aria-modal="true"` so assistive tech treats it as a modal
+ *  - Initial focus moved to the first focusable element inside the dialog
+ *  - Focus trap — Tab and Shift+Tab cycle within the dialog only
+ *  - Returns focus to the previously focused element when the dialog closes
+ *  - Escape still closes, click-on-backdrop still closes
+ *  - Close button is keyboard-reachable with a visible focus ring
+ */
+const FOCUSABLE_SELECTOR =
+  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable]';
+
+const Modal: FC<ModalProps> = ({
+  children,
+  onClose,
+  className = "",
+  ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
   const handleEsc = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
@@ -15,29 +48,90 @@ const Modal: FC<ModalProps> = ({ children, onClose, className = "" }) => {
     [onClose],
   );
 
+  // Focus-trap: keep Tab/Shift+Tab inside the dialog
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    if (event.key !== "Tab") return;
+    const root = dialogRef.current;
+    if (!root) return;
+
+    const focusables = root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }, []);
+
   useEffect(() => {
+    // Capture the previously focused element so we can restore it on close
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+
     window.addEventListener("keydown", handleEsc);
+    window.addEventListener("keydown", handleKeyDown);
     document.body.style.overflow = "hidden";
+
+    // Move focus into the dialog
+    requestAnimationFrame(() => {
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusable = root.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      (focusable ?? root).focus();
+    });
+
     return () => {
       window.removeEventListener("keydown", handleEsc);
+      window.removeEventListener("keydown", handleKeyDown);
       document.body.style.overflow = "";
+      // Restore focus to the trigger that opened the dialog
+      previouslyFocusedRef.current?.focus();
     };
-  }, [handleEsc]);
+  }, [handleEsc, handleKeyDown]);
 
   return (
     <div
       className="fixed inset-0 bg-black/60 backdrop-blur-md flex justify-center items-center z-[100] p-4 animate-in fade-in duration-300"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className={`bg-[#1A0505] border border-red-900/40 rounded-2xl shadow-2xl max-w-md w-full relative overflow-hidden animate-in zoom-in-95 duration-300 ${className}`}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabelledBy ? undefined : ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        tabIndex={-1}
+        className={`bg-[#1A0505] border border-red-900/40 rounded-2xl shadow-2xl max-w-md w-full relative overflow-hidden animate-in zoom-in-95 duration-300 outline-none ${className}`}
+      >
         <div className="p-8">{children}</div>
         <button
-          className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors p-2 hover:bg-white/10 rounded-full"
+          type="button"
+          className="absolute top-4 right-4 text-gray-500 hover:text-white transition-colors p-2 hover:bg-white/10 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
           onClick={onClose}
-          aria-label="Close modal"
+          aria-label="Close dialog"
         >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         </button>
       </div>

--- a/stellar-wallet-connect/src/components/TransactionTimeline.tsx
+++ b/stellar-wallet-connect/src/components/TransactionTimeline.tsx
@@ -1,0 +1,270 @@
+import type { FC } from "react";
+import {
+  AlertCircle,
+  Check,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  X,
+} from "lucide-react";
+
+/**
+ * Transaction timeline component (#63).
+ *
+ * Reusable visual progress tracker for any flow that crosses the wallet →
+ * network → indexer → UI boundary (create, join, drip, claim, withdraw…).
+ *
+ * Stages map to the typical lifecycle of a Soroban transaction:
+ *
+ *  1. **preparing**         — building the transaction in JS
+ *  2. **awaiting-signature** — wallet popup is open, waiting on user
+ *  3. **submitting**         — broadcast to Stellar RPC
+ *  4. **confirming**         — waiting for ledger inclusion
+ *  5. **indexing**           — backend/indexer catching up
+ *  6. **success** / **failed**
+ *
+ * The component is fully controlled — the parent picks the current stage and
+ * optionally the failed stage so the timeline can highlight where the failure
+ * occurred. Retry buttons appear only when the parent provides `onRetry`.
+ */
+
+export type TimelineStage =
+  | "preparing"
+  | "awaiting-signature"
+  | "submitting"
+  | "confirming"
+  | "indexing"
+  | "success"
+  | "failed";
+
+interface StageMeta {
+  id: TimelineStage;
+  label: string;
+  description: string;
+}
+
+const STAGES: StageMeta[] = [
+  { id: "preparing", label: "Preparing", description: "Building the transaction" },
+  { id: "awaiting-signature", label: "Awaiting signature", description: "Approve in your wallet" },
+  { id: "submitting", label: "Submitting", description: "Broadcasting to Stellar" },
+  { id: "confirming", label: "Confirming", description: "Waiting for ledger inclusion" },
+  { id: "indexing", label: "Indexing", description: "Updating app state" },
+  { id: "success", label: "Complete", description: "Transaction confirmed" },
+];
+
+const STAGE_ORDER: Record<TimelineStage, number> = {
+  preparing: 0,
+  "awaiting-signature": 1,
+  submitting: 2,
+  confirming: 3,
+  indexing: 4,
+  success: 5,
+  failed: -1,
+};
+
+export interface TransactionTimelineProps {
+  /** Current stage of the flow. */
+  stage: TimelineStage;
+  /** When `stage` is "failed", the stage where it failed (used to highlight the row). */
+  failedAtStage?: Exclude<TimelineStage, "success" | "failed">;
+  /** Transaction hash (shown with an Explorer link once `submitting` or later). */
+  txHash?: string;
+  /** Builder for the explorer link from a tx hash. */
+  explorerUrl?: (txHash: string) => string;
+  /** Human-readable error message rendered when `stage === "failed"`. */
+  errorMessage?: string;
+  /** Optional retry callback rendered when the flow has failed or stalled. */
+  onRetry?: () => void;
+  /** Optional dismiss/cancel callback. */
+  onDismiss?: () => void;
+  className?: string;
+}
+
+function rowState(
+  stage: TimelineStage,
+  rowId: TimelineStage,
+  failedAtStage?: TransactionTimelineProps["failedAtStage"],
+): "complete" | "active" | "pending" | "failed" {
+  if (stage === "failed" && failedAtStage === rowId) return "failed";
+  const current = STAGE_ORDER[stage];
+  const row = STAGE_ORDER[rowId];
+  if (row < current) return "complete";
+  if (row === current) return "active";
+  return "pending";
+}
+
+interface StageRowProps {
+  meta: StageMeta;
+  state: "complete" | "active" | "pending" | "failed";
+  isLast: boolean;
+}
+
+const StageRow: FC<StageRowProps> = ({ meta, state, isLast }) => {
+  const styles = {
+    complete: {
+      icon: <Check className="h-4 w-4" aria-hidden="true" />,
+      iconBg: "bg-green-600 text-white",
+      label: "text-green-300",
+      line: "bg-green-600/60",
+    },
+    active: {
+      icon: <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />,
+      iconBg: "bg-red-600 text-white",
+      label: "text-white",
+      line: "bg-red-900/40",
+    },
+    pending: {
+      icon: <span className="h-2 w-2 rounded-full bg-gray-500" aria-hidden="true" />,
+      iconBg: "bg-gray-800 text-gray-500 border border-gray-700",
+      label: "text-gray-500",
+      line: "bg-gray-800",
+    },
+    failed: {
+      icon: <X className="h-4 w-4" aria-hidden="true" />,
+      iconBg: "bg-red-700 text-white",
+      label: "text-red-300",
+      line: "bg-red-900/40",
+    },
+  }[state];
+
+  return (
+    <li className="relative flex gap-4 pb-6 last:pb-0">
+      {!isLast && (
+        <span
+          aria-hidden="true"
+          className={`absolute left-3.5 top-7 h-full w-px ${styles.line}`}
+        />
+      )}
+      <span
+        aria-hidden="true"
+        className={`relative z-10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${styles.iconBg}`}
+      >
+        {styles.icon}
+      </span>
+      <div className="min-w-0 pt-0.5">
+        <p className={`text-sm font-medium ${styles.label}`}>{meta.label}</p>
+        <p className="mt-0.5 text-xs text-gray-500">{meta.description}</p>
+      </div>
+    </li>
+  );
+};
+
+export const TransactionTimeline: FC<TransactionTimelineProps> = ({
+  stage,
+  failedAtStage,
+  txHash,
+  explorerUrl,
+  errorMessage,
+  onRetry,
+  onDismiss,
+  className = "",
+}) => {
+  const isFailed = stage === "failed";
+  const isSuccess = stage === "success";
+
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-label={
+        isFailed
+          ? "Transaction failed"
+          : isSuccess
+            ? "Transaction completed"
+            : "Transaction in progress"
+      }
+      className={`rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-6 ${className}`}
+    >
+      {/* Header */}
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold text-white">
+            {isFailed
+              ? "Transaction failed"
+              : isSuccess
+                ? "Transaction confirmed"
+                : "Processing transaction"}
+          </h2>
+          {txHash && (
+            <p className="mt-1 font-mono text-xs text-gray-500 break-all">
+              {explorerUrl ? (
+                <a
+                  href={explorerUrl(txHash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-red-400 hover:text-red-300 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 rounded"
+                >
+                  {txHash.slice(0, 12)}…{txHash.slice(-8)}
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                </a>
+              ) : (
+                <>
+                  {txHash.slice(0, 12)}…{txHash.slice(-8)}
+                </>
+              )}
+            </p>
+          )}
+        </div>
+
+        {/* Status badge */}
+        {isSuccess ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-600/20 px-2.5 py-1 text-xs font-medium text-green-300">
+            <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+            Success
+          </span>
+        ) : isFailed ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-red-700/20 px-2.5 py-1 text-xs font-medium text-red-300">
+            <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+            Failed
+          </span>
+        ) : null}
+      </header>
+
+      {/* Stages list */}
+      <ol className="ml-1">
+        {STAGES.map((s, idx) => (
+          <StageRow
+            key={s.id}
+            meta={s}
+            state={rowState(stage, s.id, failedAtStage)}
+            isLast={idx === STAGES.length - 1}
+          />
+        ))}
+      </ol>
+
+      {/* Failure detail */}
+      {isFailed && errorMessage && (
+        <div className="mt-4 rounded-xl border border-red-700/40 bg-red-900/20 p-4 text-sm text-red-200">
+          <p className="font-semibold text-red-300">Why it failed</p>
+          <p className="mt-1 leading-relaxed">{errorMessage}</p>
+        </div>
+      )}
+
+      {/* Actions */}
+      {(onRetry || onDismiss) && (
+        <div className="mt-6 flex flex-wrap items-center justify-end gap-3">
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded-xl px-4 py-2 text-sm font-medium text-gray-400 hover:bg-white/5 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+            >
+              {isSuccess ? "Done" : "Close"}
+            </button>
+          )}
+          {onRetry && (isFailed || !isSuccess) && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              Retry
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};


### PR DESCRIPTION
## Summary

- **Closes #61** — Unified empty / loading / error state components: `stellar-wallet-connect/src/components/FallbackStates.tsx` exports `LoadingState`, `EmptyState`, `ErrorState`, `WalletDisconnectedState`, `OfflineState`, and `StaleIndicator`. All share consistent VaultQuest dark theming, `role="status"` / `role="alert"`, `aria-live`, optional retry/action CTAs, and mobile-first responsive layout.

- **Closes #63** — Transaction timeline component: `stellar-wallet-connect/src/components/TransactionTimeline.tsx` renders a six-stage vertical timeline (preparing → awaiting-signature → submitting → confirming → indexing → success/failed). Highlights the row where the flow failed via `failedAtStage`, shows tx hash with optional explorer link, exposes retry/dismiss callbacks, and adapts `aria-label` to the current stage.

- **Closes #64** — Modal accessibility audit and rewrite: added `role="dialog"`, `aria-modal="true"`, `aria-label`/`labelledby`/`describedby` props; full focus trap (Tab and Shift+Tab cycle within the dialog only); initial focus moved into the dialog on open; focus restored to the triggering element on close; close button gets visible focus ring via `focus-visible:ring`.

- **Closes #66** — Contributor onboarding guide: new `CONTRIBUTING.md` at the repo root covering issue selection by label, project layout, per-package setup, validation commands per area, a copy-able PR checklist with screenshot requirements, when to ask maintainers before starting, accessibility expectations, and code style notes. New root `README.md` links to it.

## Test plan

- [ ] Render `<Modal>` and Tab through it — focus stays inside; Shift+Tab from first focusable returns to last; Escape closes; focus returns to opener.
- [ ] Render `<LoadingState />`, `<EmptyState />`, `<ErrorState onRetry={…} />` — all announce correctly with VoiceOver / NVDA.
- [ ] Render `<TransactionTimeline stage="confirming" />` and step through each value — correct row is highlighted, completed rows turn green, pending rows stay grey.
- [ ] Render `<TransactionTimeline stage="failed" failedAtStage="submitting" errorMessage="…" onRetry={…} />` — error banner appears, Retry button works.
- [ ] CONTRIBUTING.md renders correctly on GitHub and links from README.

## Notes for the reviewer

The `stellar-wallet-connect/` folder has no local `package.json` (it's a drop-in module per its README), so TypeScript errors for missing `react` types appear in-folder for **all** existing `.tsx` files in that directory — this PR does not introduce new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README with project overview and quick start guide.
  * Added detailed contribution guidelines for developers.

* **New Features**
  * Introduced reusable UI state components for loading, empty, error, offline, and wallet disconnection scenarios.
  * Enhanced modal dialog with improved accessibility features, focus management, and keyboard navigation.
  * Added transaction progress timeline component for visual transaction tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/vaultquest/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->