### PR TITLE
feat: activity export endpoint, shared tx state machine, export UI, and API docs

### DIFF
--- a/backend/src/routes/actions.ts
+++ b/backend/src/routes/actions.ts
@@ -6,6 +6,7 @@ import {
   cancelBody,
   listQuery,
   dashboardQuery,
+  exportQuery,
   idempotencyKeySchema
 } from "../schemas/actions.js";
 import { AppError } from "../errors.js";
@@ -121,5 +122,59 @@ export const actionsRoutes = (svc: LedgerService): FastifyPluginAsync =>
         latest_activity_at: summary.latestActivityAt,
         latest_confirmed_at: summary.latestConfirmedAt
       });
+    });
+
+    /**
+     * GET /actions/export?wallet=...&format=json|csv&from=...&to=...&limit=...
+     *
+     * Activity export endpoint (#91): returns the authenticated wallet's full
+     * action history as JSON or CSV. Excludes scrubbed rows (redactedAt != null).
+     * Wallet-scoping relies on the `wallet` query param — there is no session
+     * auth on this API; the caller is responsible for passing their own address.
+     *
+     * CSV sets Content-Disposition so browsers trigger a file download.
+     */
+    app.get("/actions/export", async (req, reply) => {
+      const q = exportQuery.parse(req.query);
+      const rows = await svc.exportActivity({
+        walletAddress: q.wallet,
+        from: q.from ? new Date(q.from) : undefined,
+        to: q.to ? new Date(q.to) : undefined,
+        limit: q.limit
+      });
+
+      if (q.format === "csv") {
+        const CSV_HEADERS = [
+          "id", "date", "action_type", "pool_id", "amount", "token",
+          "status", "tx_hash", "error_code", "submitted_at", "confirmed_at"
+        ];
+
+        const csvRows = rows.map((r) => {
+          const payload = (r.actionPayload as Record<string, unknown> | null) ?? {};
+          return [
+            r.id,
+            r.createdAt.toISOString(),
+            r.actionType,
+            String(payload["vault_id"] ?? ""),
+            String(payload["amount"] ?? ""),
+            String(payload["token"] ?? ""),
+            r.status,
+            r.txHash ?? "",
+            r.errorCode ?? "",
+            r.submittedAt?.toISOString() ?? "",
+            r.confirmedAt?.toISOString() ?? ""
+          ].map((v) => `"${String(v).replace(/"/g, '""')}"`).join(",");
+        });
+
+        const csv = [CSV_HEADERS.join(","), ...csvRows].join("\n");
+        const filename = `vaultquest-activity-${q.wallet.slice(0, 8)}.csv`;
+
+        reply
+          .header("Content-Type", "text/csv; charset=utf-8")
+          .header("Content-Disposition", `attachment; filename="${filename}"`);
+        return reply.send(csv);
+      }
+
+      return ok(rows.map(serialize));
     });
   };

--- a/backend/src/schemas/actions.ts
+++ b/backend/src/schemas/actions.ts
@@ -37,3 +37,11 @@ export const dashboardQuery = z.object({
   wallet: walletSchema,
   stale_after_ms: z.coerce.number().int().min(0).max(24 * 60 * 60 * 1000).optional()
 });
+
+export const exportQuery = z.object({
+  wallet: walletSchema,
+  format: z.enum(["json", "csv"]).default("json"),
+  from: z.string().datetime({ offset: true }).optional(),
+  to: z.string().datetime({ offset: true }).optional(),
+  limit: z.coerce.number().int().min(1).max(1000).default(500)
+});

--- a/backend/src/services/ledger.ts
+++ b/backend/src/services/ledger.ts
@@ -314,6 +314,32 @@ export class LedgerService {
     };
   }
 
+  async exportActivity(params: {
+    walletAddress: string;
+    from?: Date;
+    to?: Date;
+    limit: number;
+  }): Promise<ActionRecord[]> {
+    const { walletAddress, from, to, limit } = params;
+    const rows = await this.prisma.actionLedger.findMany({
+      where: {
+        walletAddress,
+        redactedAt: null,
+        ...(from || to
+          ? {
+              createdAt: {
+                ...(from ? { gte: from } : {}),
+                ...(to ? { lte: to } : {})
+              }
+            }
+          : {})
+      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: limit
+    });
+    return rows as unknown as ActionRecord[];
+  }
+
   async scrubWallet(walletAddress: string): Promise<{ scrubbed: number }> {
     const result = await this.prisma.actionLedger.updateMany({
       where: { walletAddress, redactedAt: null },

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,309 @@
+# VaultQuest API Contract Reference
+
+Developer-facing reference for the VaultQuest backend REST API. Covers pool
+actions, dashboard summary, and activity export. Frontend contributors can build
+UI integrations against these shapes without reading the backend source.
+
+All responses use `application/json` unless noted. Successful responses wrap
+data in `{ "data": ... }`. Paginated responses include a `meta.pagination`
+block. Errors return `{ "error": { "code": "...", "message": "..." } }`.
+
+---
+
+## Authentication
+
+There is no session-based auth. Wallet-scoped endpoints accept the connected
+wallet address as a query parameter. The frontend is responsible for passing
+the user's own address — the API trusts this parameter.
+
+---
+
+## Endpoints
+
+### Actions
+
+#### POST /actions
+
+Create a new wallet action intent.
+
+**Headers**
+
+| Header | Required | Description |
+|---|---|---|
+| `Idempotency-Key` | Yes | UUID v4. Reusing the same key with the same payload is a safe no-op (returns 200). Reusing with a different payload returns 409. |
+
+**Request body**
+
+```json
+{
+  "wallet_address": "GABCDEF1234567890",
+  "action_type": "deposit",
+  "action_payload": {
+    "vault_id": "42",
+    "amount": "1000000",
+    "token": "USDC"
+  }
+}
+```
+
+| Field | Type | Values |
+|---|---|---|
+| `wallet_address` | string | Stellar wallet address (max 120 chars) |
+| `action_type` | enum | `deposit` `withdraw` `create_vault` `claim` `select_winner` |
+| `action_payload` | object | Arbitrary JSON; shape depends on `action_type` |
+
+**Response — 201 Created** (new action) or **200 OK** (idempotent replay)
+
+```json
+{
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "idempotency_key": "a4e8b0c2-...",
+    "wallet_address": "GABCDEF1234567890",
+    "action_type": "deposit",
+    "action_payload": { "vault_id": "42", "amount": "1000000", "token": "USDC" },
+    "status": "pending",
+    "tx_hash": null,
+    "soroban_event_id": null,
+    "correlation_id": "...",
+    "error_code": null,
+    "error_detail": null,
+    "retry_count": 0,
+    "created_at": "2025-05-29T12:00:00.000Z",
+    "updated_at": "2025-05-29T12:00:00.000Z",
+    "submitted_at": null,
+    "confirmed_at": null,
+    "redacted_at": null
+  }
+}
+```
+
+---
+
+#### GET /actions
+
+List actions for a wallet, newest first.
+
+**Query parameters**
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `wallet` | Yes | — | Wallet address |
+| `status` | No | — | Filter: `pending` `submitted` `confirmed` `failed` `reverted` `orphaned` |
+| `cursor` | No | — | UUID of the last item from the previous page |
+| `limit` | No | 25 | Items per page (1–100) |
+
+**Response — 200 OK**
+
+```json
+{
+  "data": [ /* array of action objects */ ],
+  "meta": {
+    "pagination": {
+      "next_cursor": "550e8400-...",
+      "limit": 25,
+      "has_more": true
+    }
+  }
+}
+```
+
+---
+
+#### GET /actions/:id
+
+Get a single action by ID.
+
+**Response — 200 OK** — action object (same shape as POST response)
+
+**Response — 404 Not Found**
+
+```json
+{ "error": { "code": "NOT_FOUND", "message": "action <id> not found" } }
+```
+
+---
+
+#### PATCH /actions/:id/submitted
+
+Attach a transaction hash after the wallet has broadcast to the network.
+Advances status from `pending` → `submitted`.
+
+**Request body**
+
+```json
+{ "tx_hash": "abc123..." }
+```
+
+**Response — 200 OK** — updated action object
+
+---
+
+#### POST /actions/:id/cancel
+
+Cancel a pending action (e.g. user rejected the wallet prompt).
+Advances status from `pending` → `failed`.
+
+**Request body**
+
+```json
+{
+  "error_code": "WALLET_REJECTED",
+  "error_detail": "User dismissed the wallet popup"
+}
+```
+
+| `error_code` values | Meaning |
+|---|---|
+| `WALLET_REJECTED` | User explicitly rejected the signing request |
+| `WALLET_TIMEOUT` | Signing timed out with no response |
+| `NETWORK_ERROR` | Could not reach the RPC endpoint |
+
+**Response — 200 OK** — updated action object
+
+---
+
+#### DELETE /actions?wallet=...
+
+Scrub all personal data for a wallet (GDPR / right-to-erasure). Sets
+`action_payload` to null and stamps `redacted_at` on all rows.
+Scrubbed rows are excluded from future export responses.
+
+**Response — 200 OK**
+
+```json
+{ "data": { "scrubbed": 12 } }
+```
+
+---
+
+#### GET /actions/export
+
+Export the wallet's full activity history as JSON or CSV.
+
+**Query parameters**
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `wallet` | Yes | — | Wallet address |
+| `format` | No | `json` | `json` or `csv` |
+| `from` | No | — | ISO 8601 datetime — return actions created at or after this time |
+| `to` | No | — | ISO 8601 datetime — return actions created at or before this time |
+| `limit` | No | 500 | Max rows returned (1–1000) |
+
+**Response — 200 OK (JSON format)**
+
+```json
+{
+  "data": [
+    {
+      "id": "550e8400-...",
+      "wallet_address": "GABCDEF1234567890",
+      "action_type": "deposit",
+      "action_payload": { "vault_id": "42", "amount": "1000000", "token": "USDC" },
+      "status": "confirmed",
+      "tx_hash": "abc123...",
+      "error_code": null,
+      "created_at": "2025-05-29T12:00:00.000Z",
+      "submitted_at": "2025-05-29T12:00:05.000Z",
+      "confirmed_at": "2025-05-29T12:00:30.000Z"
+    }
+  ]
+}
+```
+
+**Response — 200 OK (CSV format)**
+
+Returns `Content-Type: text/csv` with `Content-Disposition: attachment; filename="vaultquest-activity-<wallet-prefix>.csv"`.
+
+```
+"id","date","action_type","pool_id","amount","token","status","tx_hash","error_code","submitted_at","confirmed_at"
+"550e8400-...","2025-05-29T12:00:00.000Z","deposit","42","1000000","USDC","confirmed","abc123...","","2025-05-29T12:00:05.000Z","2025-05-29T12:00:30.000Z"
+```
+
+**Notes**
+- Scrubbed rows (`redacted_at != null`) are never included in export output.
+- Large histories: use `from`/`to` date ranges to paginate manually. The `limit`
+  cap is 1 000 rows per request.
+- Wallet-scoping: the export only returns data for the `wallet` parameter value.
+  Never returns another user's data.
+
+---
+
+### Portfolio / Dashboard
+
+#### GET /dashboard/summary
+
+Aggregated dashboard rollup for a wallet. Provides per-status action counts,
+in-flight tx hashes the wallet should keep polling, and a freshness flag.
+
+**Query parameters**
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `wallet` | Yes | — | Wallet address |
+| `stale_after_ms` | No | 300 000 (5 min) | If the most recent ledger update is older than this, `is_stale` is true |
+
+**Response — 200 OK**
+
+```json
+{
+  "data": {
+    "wallet_address": "GABCDEF1234567890",
+    "total_actions": 14,
+    "by_status": {
+      "pending": 0,
+      "submitted": 1,
+      "confirmed": 11,
+      "failed": 1,
+      "reverted": 1,
+      "orphaned": 0
+    },
+    "pending_tx_hashes": ["abc123..."],
+    "is_stale": false,
+    "latest_activity_at": "2025-05-29T12:00:00.000Z",
+    "latest_confirmed_at": "2025-05-29T11:55:00.000Z"
+  }
+}
+```
+
+---
+
+## Standard errors
+
+| Code | HTTP | Meaning |
+|---|---|---|
+| `NOT_FOUND` | 404 | Resource does not exist |
+| `INVALID_PAYLOAD` | 400 | Request body or query params failed validation |
+| `ILLEGAL_TRANSITION` | 409 | Status transition is not allowed (e.g. cancel a confirmed action) |
+| `IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD` | 409 | Same `Idempotency-Key` used with a different body |
+| `TX_HASH_ALREADY_ATTACHED` | 409 | `tx_hash` is already owned by another action |
+| `UNAUTHORIZED` | 401 | Request lacks required credentials (internal endpoints) |
+
+---
+
+## Action status lifecycle
+
+```
+pending ──► submitted ──► confirmed
+   │               └──────► reverted
+   └──────────────────────► failed
+submitted ────────────────► orphaned
+```
+
+Terminal states (no further transitions): `confirmed`, `failed`, `reverted`, `orphaned`.
+
+---
+
+## Action payload shapes by type
+
+| `action_type` | Payload fields |
+|---|---|
+| `deposit` | `vault_id`, `amount`, `token` |
+| `withdraw` | `vault_id`, `amount`, `token` |
+| `create_vault` | `vault_id`, `amount`, `token` |
+| `claim` | `vault_id` |
+| `select_winner` | `vault_id` |
+
+The `action_payload` is stored verbatim and surfaced as-is in responses and
+exports. Consumers should treat unknown fields as additive and not error on them.

--- a/stellar-wallet-connect/src/vault/components/ActivityExport.tsx
+++ b/stellar-wallet-connect/src/vault/components/ActivityExport.tsx
@@ -1,0 +1,147 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { AlertCircle, CheckCircle2, Download, Loader2 } from "lucide-react";
+import { WalletDisconnectedState } from "../../components/FallbackStates";
+import { useActivityExport, type ExportFormat } from "../hooks";
+
+/**
+ * Activity export controls (#92).
+ *
+ * Lets connected users download their VaultQuest action history as JSON or
+ * CSV. Pairs with `useActivityExport` for the fetch/download side-effect.
+ * Presentational props keep the component testable in isolation.
+ *
+ * Responsive: stacks on mobile, single row on desktop.
+ */
+
+export interface ActivityExportProps {
+  walletAddress: string | null;
+  walletConnected?: boolean;
+  onConnect?: () => void;
+  /** Base URL of the backend API. Defaults to "/api". */
+  apiBaseUrl?: string;
+}
+
+const FORMAT_OPTIONS: { value: ExportFormat; label: string }[] = [
+  { value: "json", label: "JSON" },
+  { value: "csv", label: "CSV" },
+];
+
+export const ActivityExport: FC<ActivityExportProps> = ({
+  walletAddress,
+  walletConnected = true,
+  onConnect,
+  apiBaseUrl = "/api",
+}) => {
+  const { state, trigger, reset } = useActivityExport();
+  const [format, setFormat] = useState<ExportFormat>("csv");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  if (!walletConnected || !walletAddress) {
+    return <WalletDisconnectedState onConnect={onConnect} />;
+  }
+
+  const loading = state.status === "loading";
+
+  const handleExport = () => {
+    trigger({
+      wallet: walletAddress,
+      format,
+      from: from || undefined,
+      to: to || undefined,
+      baseUrl: apiBaseUrl,
+    });
+  };
+
+  return (
+    <section aria-label="Export activity" className="rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-5">
+      <h2 className="text-base font-semibold text-white">Export activity</h2>
+      <p className="mt-1 text-sm text-gray-400">
+        Download your VaultQuest transaction history for personal records or support.
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-end gap-3">
+        {/* Date range */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="export-from" className="text-xs font-medium text-gray-400">
+            From
+          </label>
+          <input
+            id="export-from"
+            type="date"
+            value={from}
+            onChange={(e) => { reset(); setFrom(e.target.value); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="export-to" className="text-xs font-medium text-gray-400">
+            To
+          </label>
+          <input
+            id="export-to"
+            type="date"
+            value={to}
+            onChange={(e) => { reset(); setTo(e.target.value); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500"
+          />
+        </div>
+
+        {/* Format picker */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="export-format" className="text-xs font-medium text-gray-400">
+            Format
+          </label>
+          <select
+            id="export-format"
+            value={format}
+            onChange={(e) => { reset(); setFormat(e.target.value as ExportFormat); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-500"
+          >
+            {FORMAT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Export button */}
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="h-4 w-4" aria-hidden="true" />
+          )}
+          {loading ? "Exporting…" : "Export"}
+        </button>
+      </div>
+
+      {/* Feedback */}
+      {state.status === "success" && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>
+            Downloaded <span className="font-mono">{state.filename}</span>
+          </span>
+        </div>
+      )}
+
+      {state.status === "error" && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg bg-red-700/20 px-3 py-2 text-sm text-red-300">
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{state.message}</span>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ActivityExport;

--- a/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
@@ -9,6 +9,8 @@ import {
 import type { PoolActionType, PoolStatus, PoolSummary, UserPosition } from "../contract/types";
 import { formatAmount, formatDate, truncateAddress } from "../lib/format";
 import { OnboardingChecklist } from "./OnboardingChecklist";
+import { TransactionTimeline } from "../../components/TransactionTimeline";
+import type { TxFlowResult } from "../lib/txStateMachine";
 
 /**
  * Pool detail view (#73): overview, the connected user's position, and the
@@ -29,6 +31,8 @@ export interface PoolDetailProps {
   /** Invoked when the user triggers a pool action. */
   onAction?: (type: PoolActionType) => void;
   showOnboarding?: boolean;
+  /** When provided, renders an inline transaction timeline below the action buttons. */
+  txFlow?: TxFlowResult;
 }
 
 const STATUS_BADGE: Record<PoolStatus, { label: string; className: string }> = {
@@ -83,6 +87,7 @@ export const PoolDetail: FC<PoolDetailProps> = ({
   onRetry,
   onAction,
   showOnboarding = true,
+  txFlow,
 }) => {
   if (error) {
     return <ErrorState title="Couldn't load pool" message={error} onRetry={onRetry} />;
@@ -169,12 +174,25 @@ export const PoolDetail: FC<PoolDetailProps> = ({
               key={action}
               type="button"
               onClick={() => onAction?.(action)}
-              className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+              disabled={txFlow?.busy}
+              className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
             >
               {ACTION_LABEL[action]}
             </button>
           ))}
         </div>
+      )}
+
+      {/* Inline transaction timeline (shown when a txFlow is wired in) */}
+      {txFlow && txFlow.state.stage !== "idle" && (
+        <TransactionTimeline
+          stage={txFlow.state.stage === "failed" ? "failed" : txFlow.state.stage as import("../../components/TransactionTimeline").TimelineStage}
+          failedAtStage={txFlow.state.stage === "failed" ? txFlow.state.failedAt : undefined}
+          txHash={"txHash" in txFlow.state ? txFlow.state.txHash : undefined}
+          errorMessage={txFlow.state.stage === "failed" ? txFlow.state.message : undefined}
+          onRetry={txFlow.state.stage === "failed" ? txFlow.reset : undefined}
+          onDismiss={txFlow.state.stage === "success" || txFlow.state.stage === "failed" ? txFlow.reset : undefined}
+        />
       )}
     </section>
   );

--- a/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
+++ b/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
@@ -9,6 +9,8 @@ import {
 } from "../../components/FallbackStates";
 import type { RewardHistoryEntry, RewardOutcome } from "../contract/types";
 import { explorerTxUrl, formatAmount, formatDate, truncateAddress, type StellarNetwork } from "../lib/format";
+import { TransactionTimeline } from "../../components/TransactionTimeline";
+import type { TxFlowResult } from "../lib/txStateMachine";
 
 /**
  * Reward history for completed pool cycles (#75).
@@ -28,6 +30,9 @@ export interface RewardHistoryProps {
   network?: StellarNetwork;
   onRetry?: () => void;
   onConnect?: () => void;
+  /** When provided, renders an inline claim transaction timeline and wires claim buttons. */
+  claimFlow?: TxFlowResult;
+  onClaim?: (entry: RewardHistoryEntry) => void;
 }
 
 const OUTCOME_BADGE: Record<RewardOutcome, { label: string; className: string }> = {
@@ -69,6 +74,8 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
   network = "testnet",
   onRetry,
   onConnect,
+  claimFlow,
+  onClaim,
 }) => {
   if (!walletConnected) {
     return <WalletDisconnectedState onConnect={onConnect} />;
@@ -110,6 +117,7 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
               <th scope="col" className="px-4 py-3 font-medium">Winner</th>
               <th scope="col" className="px-4 py-3 font-medium">Status</th>
               <th scope="col" className="px-4 py-3 font-medium">Tx</th>
+              {onClaim && <th scope="col" className="px-4 py-3 font-medium">Action</th>}
             </tr>
           </thead>
           <tbody>
@@ -123,6 +131,20 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
                 </td>
                 <td className="px-4 py-3"><OutcomeBadge status={entry.status} /></td>
                 <td className="px-4 py-3"><TxLink txHash={entry.txHash} network={network} /></td>
+                {onClaim && (
+                  <td className="px-4 py-3">
+                    {entry.status === "won" && !entry.txHash && (
+                      <button
+                        type="button"
+                        onClick={() => onClaim(entry)}
+                        disabled={claimFlow?.busy}
+                        className="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
+                      >
+                        Claim
+                      </button>
+                    )}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>
@@ -156,10 +178,34 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
                 <dt className="text-gray-400">Tx</dt>
                 <dd><TxLink txHash={entry.txHash} network={network} /></dd>
               </div>
+              {onClaim && entry.status === "won" && !entry.txHash && (
+                <div className="pt-1">
+                  <button
+                    type="button"
+                    onClick={() => onClaim(entry)}
+                    disabled={claimFlow?.busy}
+                    className="w-full rounded-lg bg-red-600 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
+                  >
+                    Claim reward
+                  </button>
+                </div>
+              )}
             </dl>
           </li>
         ))}
       </ul>
+
+      {/* Claim transaction timeline */}
+      {claimFlow && claimFlow.state.stage !== "idle" && (
+        <TransactionTimeline
+          stage={claimFlow.state.stage === "failed" ? "failed" : claimFlow.state.stage as import("../../components/TransactionTimeline").TimelineStage}
+          failedAtStage={claimFlow.state.stage === "failed" ? claimFlow.state.failedAt : undefined}
+          txHash={"txHash" in claimFlow.state ? claimFlow.state.txHash : undefined}
+          errorMessage={claimFlow.state.stage === "failed" ? claimFlow.state.message : undefined}
+          onRetry={claimFlow.state.stage === "failed" ? claimFlow.reset : undefined}
+          onDismiss={claimFlow.state.stage === "success" || claimFlow.state.stage === "failed" ? claimFlow.reset : undefined}
+        />
+      )}
     </section>
   );
 };

--- a/stellar-wallet-connect/src/vault/hooks.ts
+++ b/stellar-wallet-connect/src/vault/hooks.ts
@@ -1,7 +1,7 @@
 /**
  * Data hooks (adapters) that bind the {@link VaultContractClient} to React
  * state with consistent loading / stale / error handling for the pool detail
- * (#73) and reward history (#75) views.
+ * (#73), reward history (#75), and activity export (#92) views.
  *
  * Kept dependency-light (plain `useState`/`useEffect`) so the components and
  * hooks can be tested with the mock client and no data-fetching library.
@@ -9,11 +9,14 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type {
+  PoolActionInput,
+  PoolActionType,
   PoolSummary,
   RewardHistoryEntry,
   UserPosition,
   VaultContractClient,
 } from "./contract/types";
+import { useTxFlow, type TxFlowOptions, type TxFlowResult } from "./lib/txStateMachine";
 
 export interface AsyncResource<T> {
   data: T | null;
@@ -104,4 +107,103 @@ export function useRewardHistory(
     async () => (walletAddress ? client.listRewardHistory(walletAddress) : []),
     [client, walletAddress],
   );
+}
+
+// ---------------------------------------------------------------------------
+// usePoolAction (#94) — shared transaction flow for all wallet actions.
+// Wraps useTxFlow and binds it to a VaultContractClient so callers don't
+// need to pass the client into run() each time.
+// ---------------------------------------------------------------------------
+
+export interface PoolActionFlow extends TxFlowResult {
+  /** Convenience wrapper — no need to pass `client` on each call. */
+  submit: (type: PoolActionType, input: PoolActionInput, options?: TxFlowOptions) => Promise<void>;
+}
+
+export function usePoolAction(client: VaultContractClient): PoolActionFlow {
+  const flow = useTxFlow();
+  const submit = useCallback(
+    (type: PoolActionType, input: PoolActionInput, options?: TxFlowOptions) =>
+      flow.run(client, type, input, options),
+    [client, flow],
+  );
+  return { ...flow, submit };
+}
+
+// ---------------------------------------------------------------------------
+// useActivityExport (#92) — download wallet activity from the backend REST API.
+// Uses bare fetch() since the frontend has no shared REST client layer.
+// ---------------------------------------------------------------------------
+
+export type ExportFormat = "json" | "csv";
+
+export interface ActivityExportOptions {
+  wallet: string;
+  format: ExportFormat;
+  from?: string;
+  to?: string;
+  /** Base URL of the backend API. Defaults to "/api". */
+  baseUrl?: string;
+}
+
+export type ExportState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; filename: string }
+  | { status: "error"; message: string };
+
+export interface ActivityExportResult {
+  state: ExportState;
+  trigger: (options: ActivityExportOptions) => Promise<void>;
+  reset: () => void;
+}
+
+export function useActivityExport(): ActivityExportResult {
+  const [state, setState] = useState<ExportState>({ status: "idle" });
+
+  const reset = useCallback(() => setState({ status: "idle" }), []);
+
+  const trigger = useCallback(async (options: ActivityExportOptions) => {
+    const { wallet, format, from, to, baseUrl = "/api" } = options;
+    setState({ status: "loading" });
+
+    try {
+      const params = new URLSearchParams({ wallet, format });
+      if (from) params.set("from", from);
+      if (to) params.set("to", to);
+
+      const res = await fetch(`${baseUrl}/actions/export?${params.toString()}`);
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: { message?: string } };
+        throw new Error(body.error?.message ?? `Export failed (${res.status})`);
+      }
+
+      if (format === "csv") {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        const filename = `vaultquest-activity-${wallet.slice(0, 8)}.csv`;
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+        setState({ status: "success", filename });
+      } else {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        const filename = `vaultquest-activity-${wallet.slice(0, 8)}.json`;
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+        setState({ status: "success", filename });
+      }
+    } catch (err) {
+      setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+    }
+  }, []);
+
+  return { state, trigger, reset };
 }

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared transaction state machine for wallet-driven actions (#94).
+ *
+ * All wallet flows (join, drip, claim, withdraw, create) pass through the same
+ * lifecycle. This hook owns that lifecycle so each flow gets consistent state
+ * labels, transitions, and recovery options without duplicating logic.
+ *
+ * The `stage` value is intentionally typed as `TimelineStage` so callers can
+ * pass it straight to `<TransactionTimeline>` with no mapping.
+ */
+
+import { useCallback, useState } from "react";
+import type { TimelineStage } from "../../components/TransactionTimeline";
+import type { PoolActionInput, PoolActionType, VaultContractClient } from "../contract/types";
+
+export type TxFlowState =
+  | { stage: "idle" }
+  | { stage: "preparing" }
+  | { stage: "awaiting-signature" }
+  | { stage: "submitting"; txHash?: string }
+  | { stage: "confirming"; txHash: string }
+  | { stage: "indexing"; txHash: string }
+  | { stage: "success"; txHash: string }
+  | { stage: "failed"; failedAt: Exclude<TimelineStage, "success" | "failed">; message: string };
+
+export interface TxFlowResult {
+  /** Current flow state — pass `state.stage` directly to `<TransactionTimeline stage={...}>`. */
+  state: TxFlowState;
+  /** True while any non-idle, non-terminal stage is active. */
+  busy: boolean;
+  /** Execute a wallet action, driving the machine through its stages. */
+  run: (
+    client: VaultContractClient,
+    type: PoolActionType,
+    input: PoolActionInput,
+    options?: TxFlowOptions,
+  ) => Promise<void>;
+  /** Reset back to idle so the same hook can run another action. */
+  reset: () => void;
+}
+
+export interface TxFlowOptions {
+  /**
+   * Called when the transaction reaches the indexing stage with a confirmed
+   * tx hash. Use this to trigger a data refetch in the parent.
+   */
+  onConfirmed?: (txHash: string) => void;
+  /**
+   * Milliseconds to wait in the `indexing` stage before advancing to
+   * `success`. Defaults to 2 000 ms — enough for the backend reconciler to
+   * pick up the event in most environments.
+   */
+  indexingDelayMs?: number;
+}
+
+const STAGE_ORDER: Record<TimelineStage, number> = {
+  preparing: 0,
+  "awaiting-signature": 1,
+  submitting: 2,
+  confirming: 3,
+  indexing: 4,
+  success: 5,
+  failed: -1,
+};
+
+function isTerminal(stage: TimelineStage): boolean {
+  return stage === "success" || stage === "failed";
+}
+
+function mapError(err: unknown): { failedAt: Exclude<TimelineStage, "success" | "failed">; message: string } {
+  const message = err instanceof Error ? err.message : String(err);
+  // Map known ContractInterfaceError kinds to the stage where they occur.
+  const kind = (err as { kind?: string }).kind ?? "";
+  if (kind === "wallet_disconnected" || kind === "signature_rejected") {
+    return { failedAt: "awaiting-signature", message };
+  }
+  if (kind === "rpc_failure" || kind === "contract_error") {
+    return { failedAt: "submitting", message };
+  }
+  return { failedAt: "confirming", message };
+}
+
+export function useTxFlow(): TxFlowResult {
+  const [state, setState] = useState<TxFlowState>({ stage: "idle" });
+
+  const busy =
+    state.stage !== "idle" && !isTerminal(state.stage as TimelineStage);
+
+  const reset = useCallback(() => setState({ stage: "idle" }), []);
+
+  const run = useCallback(
+    async (
+      client: VaultContractClient,
+      type: PoolActionType,
+      input: PoolActionInput,
+      options: TxFlowOptions = {},
+    ) => {
+      const { onConfirmed, indexingDelayMs = 2_000 } = options;
+
+      // Prevent double-submission.
+      setState((prev) => {
+        if (prev.stage !== "idle" && !isTerminal(STAGE_ORDER[prev.stage as TimelineStage] >= 0 ? prev.stage as TimelineStage : "failed")) {
+          return prev;
+        }
+        return { stage: "preparing" };
+      });
+
+      try {
+        setState({ stage: "awaiting-signature" });
+        const result = await client.submitAction(type, input);
+
+        setState({ stage: "submitting", txHash: result.txHash });
+
+        setState({ stage: "confirming", txHash: result.txHash });
+        onConfirmed?.(result.txHash);
+
+        setState({ stage: "indexing", txHash: result.txHash });
+        await new Promise<void>((resolve) => setTimeout(resolve, indexingDelayMs));
+
+        setState({ stage: "success", txHash: result.txHash });
+      } catch (err) {
+        const { failedAt, message } = mapError(err);
+        setState({ stage: "failed", failedAt, message });
+      }
+    },
+    [],
+  );
+
+  return { state, busy, run, reset };
+}


### PR DESCRIPTION
Closes #91
Closes #92
Closes #93
Closes #94

## What changed

### #91 — Backend activity export endpoint
- Added `GET /actions/export?wallet=...&format=json|csv&from=...&to=...&limit=...`
- JSON response follows existing `{ data: [...] }` envelope; CSV sets `Content-Type: text/csv` and `Content-Disposition: attachment` so browsers trigger a file download
- Excludes scrubbed rows (`redacted_at != null`) — wallet erasure is respected
- Date range filters (`from`/`to`) accept ISO 8601 datetimes; `limit` caps at 1 000 rows
- Added `exportQuery` Zod schema in `schemas/actions.ts` and `LedgerService.exportActivity()` in `services/ledger.ts`

### #92 — Frontend activity export controls
- Added `ActivityExport` component (`stellar-wallet-connect/src/vault/components/ActivityExport.tsx`) with date range pickers, JSON/CSV format selector, and a download button
- Added `useActivityExport` hook in `hooks.ts` — uses `fetch()` directly (no REST client layer exists) and triggers a browser file download on success
- Shows loading spinner, success confirmation with filename, and error message
- Responsive: fields wrap on mobile, single row on desktop
- Wallet-disconnected state handled via existing `WalletDisconnectedState`

### #93 — API contract reference
- Created `docs/API.md` covering all action endpoints (POST/GET/PATCH/DELETE), the dashboard summary endpoint, and the new export endpoint
- Includes request examples, response JSON/CSV shapes, error codes, status lifecycle diagram, and payload field table
- Notes wallet-auth expectations (no session auth — wallet param is trusted)

### #94 — Shared transaction state machine
- Created `stellar-wallet-connect/src/vault/lib/txStateMachine.ts` with `useTxFlow` hook
- States follow `TimelineStage` exactly so callers pass `state.stage` straight to `<TransactionTimeline>` with no mapping
- `ContractInterfaceError.kind` values map to the appropriate failure stage (`awaiting-signature`, `submitting`, or `confirming`)
- Added `usePoolAction` convenience wrapper in `hooks.ts` that binds a `VaultContractClient` to the flow
- Integrated `txFlow` prop into `PoolDetail` — action buttons disable while `busy`, timeline renders inline below actions
- Integrated `claimFlow` + `onClaim` props into `RewardHistory` — claim buttons on `won` rows, inline timeline for claim progress

## How to test

- **Export (backend):** `GET /actions/export?wallet=<addr>&format=csv` — should return CSV with correct headers and no rows where `redacted_at` is set; `format=json` should return the standard envelope
- **Export (UI):** Mount `<ActivityExport walletAddress="..." />`, pick a date range and format, click Export — browser should download the file; disconnected state shows connect prompt
- **Tx state machine:** Mount `<PoolDetail ... txFlow={useTxFlow()} />`, trigger a join/deposit action — `TransactionTimeline` should appear inline and advance through stages; failed action should show retry button
- **RewardHistory claim:** Mount `<RewardHistory ... claimFlow={useTxFlow()} onClaim={...} />` with a `won` entry — Claim button appears, timeline shows on click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export activity history in JSON or CSV formats with optional date range filtering
  * Real-time transaction status tracking with visual timeline display showing preparation through confirmation stages
  * Reward claim transactions with integrated status monitoring
  * Enhanced pool actions interface with transaction progress visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/vaultquest/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->