### PR TITLE
Add smoke tests for core app routes after migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ break anything else. Run the relevant commands for your area:
 | Backend | `pnpm --filter backend run lint` | ESLint + TypeScript |
 | Backend | `pnpm --filter backend exec prisma format` | Prisma schema formatting |
 | Frontend | `pnpm test` (root) | Vitest unit tests |
-| Frontend | `pnpm exec playwright test` | E2E smoke tests |
+| Frontend | `pnpm run test:smoke:routes` | Critical route smoke tests |
+| Frontend | `pnpm run test:e2e` | Full Playwright E2E suite |
 | CI / docs | `pnpm run check:terms` | Legacy product name and import guard |
 | Contracts | `cargo test` (in `contracts/`) | Soroban contract tests |
 | Contracts | `cargo fmt --check && cargo clippy -- -D warnings` | Format + lint |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,17 +22,34 @@ To run in watch mode:
 npm run test:watch
 ```
 
-### E2E & Quality Gates (Playwright)
+### Route Smoke Tests (Playwright)
 
-Make sure the dev server is running (or it will be started automatically):
+Route smoke tests live in `e2e/route-smoke.spec.ts`. They cover the initial critical public and app routes:
+
+- `/` — marketing landing page
+- `/app` — app dashboard in a disconnected-wallet state
+- `/app/prizes` — prizes index in a disconnected-wallet state
+- `/app/vaults` — vaults index in a disconnected-wallet state
+
+The app-route tests clear browser storage, mock common wallet globals as disconnected, and fulfill `/api/*` requests with empty fixture data so route-level provider, import, and render failures surface consistently. Test names include the route path so CI failures identify the regressed route.
+
+Run only the route smoke tests:
 
 ```bash
-npx playwright test
+pnpm run test:smoke:routes
+```
+
+### E2E & Quality Gates (Playwright)
+
+Make sure the dev server is running (or let Playwright start it via `playwright.config.ts`):
+
+```bash
+pnpm run test:e2e
 ```
 
 To see the test results UI:
 ```bash
-npx playwright test --ui
+pnpm exec playwright test --ui
 ```
 
 ## Mocking Wallet States

--- a/e2e/route-smoke.spec.ts
+++ b/e2e/route-smoke.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type SmokeRoute = {
+  name: string;
+  path: string;
+  expectedContent: RegExp;
+  requiresDisconnectedWalletState?: boolean;
+};
+
+const publicRoutes: SmokeRoute[] = [
+  {
+    name: 'marketing landing page',
+    path: '/',
+    expectedContent: /VaultQuest|Launch DApp/i,
+  },
+];
+
+const appRoutes: SmokeRoute[] = [
+  {
+    name: 'app dashboard',
+    path: '/app',
+    expectedContent: /Start Saving|Dashboard|VaultQuest/i,
+    requiresDisconnectedWalletState: true,
+  },
+  {
+    name: 'prizes index',
+    path: '/app/prizes',
+    expectedContent: /Prizes|Prize Pools|VaultQuest/i,
+    requiresDisconnectedWalletState: true,
+  },
+  {
+    name: 'vaults index',
+    path: '/app/vaults',
+    expectedContent: /Vaults|Manage Vaults|VaultQuest/i,
+    requiresDisconnectedWalletState: true,
+  },
+];
+
+const routeLevelCrashPatterns = [
+  /Application error/i,
+  /Unhandled Runtime Error/i,
+  /This page could not be found/i,
+  /404(?:\s|$)/i,
+  /500(?:\s|$)/i,
+];
+
+async function mockDisconnectedWalletAndNetwork(page: Page) {
+  await page.addInitScript(() => {
+    const walletWindow = window as Window & {
+      freighterApi?: {
+        isAllowed: () => Promise<boolean>;
+        isConnected: () => Promise<boolean>;
+        getPublicKey: () => Promise<null>;
+      };
+    };
+
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    Object.defineProperty(window, 'ethereum', {
+      configurable: true,
+      value: undefined,
+    });
+
+    Object.defineProperty(walletWindow, 'freighterApi', {
+      configurable: true,
+      value: {
+        isAllowed: async () => false,
+        isConnected: async () => false,
+        getPublicKey: async () => null,
+      },
+    });
+  });
+
+  await page.route(/\/api\//, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        account: null,
+        actions: [],
+        entries: [],
+        pools: [],
+        prizes: [],
+        quests: [],
+        walletConnected: false,
+      }),
+    });
+  });
+}
+
+async function expectRouteToRender(page: Page, route: SmokeRoute) {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const response = await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+
+  expect(
+    response,
+    `${route.name} (${route.path}) should return a document response`,
+  ).not.toBeNull();
+  expect(
+    response?.status(),
+    `${route.name} (${route.path}) should return a successful document response`,
+  ).toBeLessThan(400);
+
+  await expect(
+    page.locator('body'),
+    `${route.name} (${route.path}) should render a non-empty page body`,
+  ).not.toBeEmpty();
+
+  await expect(
+    page.locator('body'),
+    `${route.name} (${route.path}) should show route-specific content`,
+  ).toContainText(route.expectedContent);
+
+  for (const pattern of routeLevelCrashPatterns) {
+    await expect(
+      page.locator('body'),
+      `${route.name} (${route.path}) should not show ${pattern.toString()}`,
+    ).not.toContainText(pattern);
+  }
+
+  expect(
+    pageErrors,
+    `${route.name} (${route.path}) should not throw route-level runtime errors`,
+  ).toEqual([]);
+}
+
+test.describe('route smoke tests', () => {
+  for (const route of publicRoutes) {
+    test(`${route.name} renders at ${route.path}`, async ({ page }) => {
+      await expectRouteToRender(page, route);
+    });
+  }
+
+  for (const route of appRoutes) {
+    test(
+      `${route.name} renders at ${route.path} with no wallet connected`,
+      async ({ page }) => {
+        await mockDisconnectedWalletAndNetwork(page);
+        await expectRouteToRender(page, route);
+
+        if (route.requiresDisconnectedWalletState) {
+          await expect(
+            page.locator('body'),
+            `${route.name} (${route.path}) should expose a disconnected-wallet or app-start state`,
+          ).toContainText(
+            /Connect Wallet|wallet not connected|Start Saving|Manage Vaults|View All Prizes/i,
+          );
+        }
+      },
+    );
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "npm --prefix backend run build",
-    "check:terms": "node ./scripts/check-product-terms.js"
+    "check:terms": "node ./scripts/check-product-terms.js",
+    "test:e2e": "playwright test",
+    "test:smoke:routes": "playwright test e2e/route-smoke.spec.ts"
   }
 }


### PR DESCRIPTION
## Summary

- Added Playwright route smoke tests for critical public and app routes: `/`, `/app`, `/app/prizes`, and `/app/vaults`.
- Covered disconnected-wallet app-route states by clearing browser storage, mocking wallet globals, and stubbing `/api/*` requests with empty fixture data.
- Added root scripts for running the full E2E suite and the route-only smoke suite.
- Updated contributor and testing documentation with smoke-test commands and route coverage details.

## Linked Issue
#60 

## Validation

- [ ] `npm run lint`
- [ ] `npm run build`
- [x] `pnpm run check:terms`
- [x] `git diff --check`
- [ ] `pnpm run test:smoke:routes` — blocked locally because the Playwright CLI is not installed in this workspace image (`sh: 1: playwright: not found`), and installing `@playwright/test` failed with a registry 403.

## UI Evidence

- [x] Not applicable
- [ ] Screenshots attached
- [ ] Demo video/GIF attached

## Notes

- No visible UI changes were made.
- No new environment variables, contract IDs, or deployment steps were introduced.
- The route smoke tests are documented in `docs/TESTING.md` and can be run with `pnpm run test:smoke:routes`.


Closes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with new frontend validation test commands.
  * Enhanced testing documentation with revised test instructions and updated command references.

* **Tests**
  * Added route smoke tests to verify key application routes render successfully with expected content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->