### PR TITLE
feat: add vault metrics cards, wallet status panel, onboarding checklist, and export action

### DIFF
--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
 import { Sparkles } from "lucide-react";
 import OnboardingCards from "@/components/app/OnboardingCards";
 import PublicStatsBar from "@/components/app/PublicStatsBar";
+import VaultMetricsCards from "@/components/app/VaultMetricsCards";
 import UnsupportedNetworkBanner from "@/components/app/UnsupportedNetworkBanner";
 import RecentWinners from "@/components/app/RecentWinners";
 import YieldCalculator from "@/components/app/YieldCalculator";
@@ -14,6 +15,7 @@ import BridgeStatusTracker from "@/components/app/BridgeStatusTracker";
 import WinnerCelebration from "@/components/app/WinnerCelebration";
 import PrizeCountdown from "@/components/app/PrizeCountdown";
 import FaqAccordion from "@/components/app/FaqAccordion";
+import { WalletConnectionStatus, OnboardingChecklist } from "stellar-wallet-connect";
 
 function DashboardSkeleton() {
   return (
@@ -33,9 +35,8 @@ function DashboardSkeleton() {
 
       {/* Main Grid Skeleton */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-        {/* Left Column (Main Panel) */}
+        {/* Left Column */}
         <div className="space-y-8 lg:col-span-8">
-          {/* Yield Calculator Skeleton */}
           <div className="vq-glass p-6 h-96 flex flex-col justify-between">
             <div className="flex items-center justify-between border-b border-vault-border/30 pb-4">
               <div className="h-6 w-40 bg-vault-border/40 rounded" />
@@ -48,8 +49,6 @@ function DashboardSkeleton() {
             </div>
             <div className="h-48 bg-vault-border/20 rounded-xl" />
           </div>
-
-          {/* Recent Winners Skeleton */}
           <div className="space-y-4">
             <div className="h-6 w-48 bg-vault-border/40 rounded" />
             <div className="flex gap-4 overflow-hidden">
@@ -60,9 +59,8 @@ function DashboardSkeleton() {
           </div>
         </div>
 
-        {/* Right Column (Sidebar Panel) */}
+        {/* Right Column */}
         <div className="space-y-8 lg:col-span-4">
-          {/* Stats Skeleton */}
           <div className="vq-glass p-6 space-y-6">
             <div className="h-6 w-32 bg-vault-border/40 rounded border-b border-vault-border/30 pb-3" />
             <div className="space-y-3">
@@ -72,8 +70,6 @@ function DashboardSkeleton() {
               <div className="h-16 bg-vault-border/20 rounded-xl" />
             </div>
           </div>
-
-          {/* CTA Skeleton */}
           <div className="vq-glass p-6 h-56 flex flex-col justify-between">
             <div className="h-6 w-2/3 bg-vault-border/40 mx-auto rounded" />
             <div className="h-12 bg-vault-border/30 rounded-xl w-full" />
@@ -86,9 +82,10 @@ function DashboardSkeleton() {
 }
 
 export default function AppDashboardPage() {
-  const { isConnected } = useAccount();
+  const { isConnected, address, chain } = useAccount();
   const { openConnectModal } = useConnectModal();
   const [onboardingStep, setOnboardingStep] = useState(0);
+  const [hasJoinedVault] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -97,25 +94,17 @@ export default function AppDashboardPage() {
 
   const isWinner = false;
 
-  const getNextDrawDate = () => {
+  const nextDrawDate = useMemo(() => {
     const now = new Date();
     const nextFriday = new Date(now);
     nextFriday.setUTCDate(now.getUTCDate() + ((5 - now.getUTCDay() + 7) % 7));
     nextFriday.setUTCHours(18, 0, 0, 0);
-    if (nextFriday <= now) {
-      nextFriday.setUTCDate(nextFriday.getUTCDate() + 7);
-    }
+    if (nextFriday <= now) nextFriday.setUTCDate(nextFriday.getUTCDate() + 7);
     return nextFriday;
-  };
-
-  const nextDrawDate = getNextDrawDate();
+  }, []);
 
   const handleStartSaving = () => {
-    if (!isConnected) {
-      openConnectModal?.();
-      setOnboardingStep(1);
-      return;
-    }
+    if (!isConnected) { openConnectModal?.(); setOnboardingStep(1); return; }
     setOnboardingStep(1);
   };
 
@@ -134,7 +123,7 @@ export default function AppDashboardPage() {
         drawDate={new Date().toISOString()}
       />
 
-      {/* Hero Header Section */}
+      {/* Hero Header */}
       <header className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between border-b border-vault-border/20 pb-8">
         <div className="space-y-4 max-w-2xl">
           <div className="inline-flex items-center gap-2 rounded-full border border-vault-border bg-vault-surface px-3 py-1 text-xs font-medium text-vault-muted backdrop-blur-md transition-all duration-300">
@@ -154,17 +143,21 @@ export default function AppDashboardPage() {
         </div>
       </header>
 
-      {/* Main Grid Layout */}
+      {/* Vault Metrics (full-width, below hero) */}
+      <VaultMetricsCards />
+
+      {/* Main Grid */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-        {/* Left Column (Main Panel) */}
+        {/* Left Column */}
         <main className="space-y-8 lg:col-span-8">
+          <OnboardingChecklist walletConnected={isConnected} hasJoinedVault={hasJoinedVault} />
           <YieldCalculator />
           <RecentWinners />
           <OnboardingCards />
           <FaqAccordion />
         </main>
 
-        {/* Right Column (Sidebar Panel) */}
+        {/* Right Column */}
         <aside className="space-y-8 lg:col-span-4">
           <div className="vq-glass p-6 space-y-6">
             <h3 className="text-lg font-bold text-vault-text border-b border-vault-border/30 pb-3">
@@ -174,7 +167,13 @@ export default function AppDashboardPage() {
           </div>
 
           {isConnected && (
-            <div className="space-y-4">
+            <>
+              <WalletConnectionStatus
+                walletAddress={address ?? null}
+                network={chain?.name ?? null}
+                isNetworkMismatch={isConnected && !chain}
+                onReconnect={() => openConnectModal?.()}
+              />
               <BridgeStatusTracker
                 sourceTxHash="0x1234567890abcdef1234567890abcdef12345678"
                 destinationTxHash={null}
@@ -183,7 +182,7 @@ export default function AppDashboardPage() {
                 destinationChain="Stellar"
                 estimatedTime={180}
               />
-            </div>
+            </>
           )}
 
           <section className="vq-glass p-6 text-center sm:p-8 relative overflow-hidden group">
@@ -201,12 +200,8 @@ export default function AppDashboardPage() {
                 </button>
               ) : (
                 <>
-                  <Link href="/app/prizes" className="vq-btn-primary w-full">
-                    View All Prizes
-                  </Link>
-                  <Link href="/app/vaults" className="vq-btn-ghost w-full">
-                    Manage Vaults
-                  </Link>
+                  <Link href="/app/prizes" className="vq-btn-primary w-full">View All Prizes</Link>
+                  <Link href="/app/vaults" className="vq-btn-ghost w-full">Manage Vaults</Link>
                 </>
               )}
               {!isConnected && onboardingStep === 0 && (

--- a/components/app/VaultMetricsCards.jsx
+++ b/components/app/VaultMetricsCards.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Activity, DollarSign, Hash, Trophy, Users } from "lucide-react";
+import { PUBLIC_STATS, DEMO_TRANSACTIONS } from "@/lib/demo-portfolio";
+
+function MetricCardSkeleton() {
+  return (
+    <div className="animate-pulse vq-glass p-5">
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-xl bg-vault-border/40" />
+        <div className="space-y-1.5 flex-1">
+          <div className="h-3 w-24 rounded bg-vault-border/30" />
+          <div className="h-6 w-16 rounded bg-vault-border/40" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({ icon: Icon, label, value, accent }) {
+  return (
+    <div className="vq-glass-hover p-5">
+      <div className="flex items-start gap-3">
+        <span
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-vault-border bg-vault-surface"
+          style={{ color: accent }}
+        >
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-vault-muted">{label}</p>
+          <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">{value}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function VaultMetricsCards({ loading = false }) {
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <MetricCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  const recentCount = PUBLIC_STATS.recentActivityCount ?? DEMO_TRANSACTIONS.length;
+
+  const metrics = [
+    {
+      icon: DollarSign,
+      label: "Total Value Locked",
+      value: `$${(PUBLIC_STATS.tvl / 1_000_000).toFixed(2)}M`,
+      accent: "#22c55e",
+    },
+    {
+      icon: Users,
+      label: "Active Participants",
+      value: PUBLIC_STATS.activeSavers.toLocaleString(),
+      accent: "#6366f1",
+    },
+    {
+      icon: Hash,
+      label: "Current Round",
+      value: `#${PUBLIC_STATS.currentRound}`,
+      accent: "#3b82f6",
+    },
+    {
+      icon: Trophy,
+      label: "Prize Estimate",
+      value: `$${((PUBLIC_STATS.prizeEstimate ?? PUBLIC_STATS.prizePool) / 1_000).toFixed(1)}K`,
+      accent: "#f59e0b",
+    },
+    {
+      icon: Activity,
+      label: "Recent Activity",
+      value: `${recentCount} txns`,
+      accent: "#ef4444",
+    },
+  ];
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+      {metrics.map((m) => (
+        <MetricCard key={m.label} {...m} />
+      ))}
+    </div>
+  );
+}

--- a/lib/demo-portfolio.js
+++ b/lib/demo-portfolio.js
@@ -22,4 +22,6 @@ export const PUBLIC_STATS = {
   prizePool: 142_375,
   activeSavers: 3842,
   currentRound: 47,
+  prizeEstimate: 14_237,
+  recentActivityCount: 28,
 };

--- a/stellar-wallet-connect/src/components/WalletConnectionStatus.tsx
+++ b/stellar-wallet-connect/src/components/WalletConnectionStatus.tsx
@@ -1,0 +1,128 @@
+import { useState, type FC } from "react";
+import { AlertCircle, AlertTriangle, CheckCircle2, Copy, Loader2, RefreshCw, Wallet, WifiOff } from "lucide-react";
+
+export interface WalletConnectionStatusProps {
+  walletAddress: string | null;
+  network: string | null;
+  isNetworkMismatch?: boolean;
+  expectedNetwork?: string;
+  isConnecting?: boolean;
+  connectionError?: string | null;
+  onConnect?: () => void;
+  onReconnect?: () => void;
+  onDisconnect?: () => void;
+}
+
+function truncate(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function DisconnectedState({ onConnect, connectionError }: { onConnect?: () => void; connectionError?: string | null }) {
+  return (
+    <div className="mt-4 space-y-3">
+      {connectionError ? (
+        <div role="alert" className="flex items-start gap-2 rounded-lg bg-red-700/20 px-3 py-2 text-sm text-red-300">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{connectionError}</span>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400">Connect a wallet to view your position and sign pool actions.</p>
+      )}
+      {onConnect && (
+        <button type="button" onClick={onConnect} className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400">
+          <Wallet className="h-4 w-4" aria-hidden="true" />
+          Connect wallet
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const WalletConnectionStatus: FC<WalletConnectionStatusProps> = ({
+  walletAddress,
+  network,
+  isNetworkMismatch = false,
+  expectedNetwork = "testnet",
+  isConnecting = false,
+  connectionError = null,
+  onConnect,
+  onReconnect,
+  onDisconnect,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const isConnected = Boolean(walletAddress);
+
+  const handleCopy = async () => {
+    if (!walletAddress) return;
+    try {
+      await navigator.clipboard.writeText(walletAddress);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable or permission denied — no-op
+    }
+  };
+
+  return (
+    <aside aria-label="Wallet connection status" className="rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-4 sm:p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <span className={`flex h-10 w-10 items-center justify-center rounded-full ${isConnected ? "bg-emerald-900/30" : "bg-red-900/30"}`}>
+            {isConnected
+              ? <Wallet className="h-5 w-5 text-emerald-300" aria-hidden="true" />
+              : <WifiOff className="h-5 w-5 text-red-300" aria-hidden="true" />}
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-white">Wallet</h2>
+            <p className="text-xs text-gray-400">{isConnected ? "Connected" : "Not connected"}</p>
+          </div>
+        </div>
+        {isConnected && onReconnect && (
+          <button type="button" onClick={onReconnect} disabled={isConnecting} aria-label="Reconnect wallet"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/30 px-3 py-1.5 text-xs font-medium text-gray-300 transition-colors hover:bg-red-900/30 disabled:cursor-not-allowed disabled:opacity-60">
+            {isConnecting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />}
+            {isConnecting ? "Reconnecting…" : "Reconnect"}
+          </button>
+        )}
+      </div>
+
+      {isConnected ? (
+        <div className="mt-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm text-gray-300">{truncate(walletAddress!)}</span>
+            <button type="button" onClick={handleCopy} aria-label="Copy wallet address"
+              className="rounded p-1 text-gray-400 transition-colors hover:bg-red-900/20 hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-400">
+              <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+            {copied && <span role="status" aria-live="polite" className="text-xs text-emerald-400">Copied!</span>}
+          </div>
+          {network && (
+            <div className="flex items-center gap-1.5">
+              {isNetworkMismatch
+                ? <AlertTriangle className="h-3.5 w-3.5 text-amber-400" aria-hidden="true" />
+                : <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" aria-hidden="true" />}
+              <span className={`text-xs font-medium ${isNetworkMismatch ? "text-amber-300" : "text-emerald-300"}`}>
+                {isNetworkMismatch ? `Wrong network · switch to ${expectedNetwork}` : `${network} · verified`}
+              </span>
+            </div>
+          )}
+          {connectionError && (
+            <div role="alert" className="flex items-start gap-2 rounded-lg bg-red-700/20 px-3 py-2 text-sm text-red-300">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>{connectionError}</span>
+            </div>
+          )}
+          {onDisconnect && (
+            <button type="button" onClick={onDisconnect} className="mt-1 text-xs text-gray-500 underline transition-colors hover:text-red-400">
+              Disconnect
+            </button>
+          )}
+        </div>
+      ) : (
+        <DisconnectedState onConnect={onConnect} connectionError={connectionError} />
+      )}
+    </aside>
+  );
+};
+
+export default WalletConnectionStatus;

--- a/stellar-wallet-connect/src/index.ts
+++ b/stellar-wallet-connect/src/index.ts
@@ -4,4 +4,6 @@ export * from "./core/kit";
 export * from "./core/horizonPool";
 export { default as WalletFundingModal } from "./components/WalletFundingModal";
 export { default as WalletFundingWrapper } from "./components/WalletFundingWrapper";
+export { WalletConnectionStatus, type WalletConnectionStatusProps } from "./components/WalletConnectionStatus";
+export { OnboardingChecklist, type OnboardingChecklistProps } from "./vault/components/OnboardingChecklist";
 // Astro components cannot be exported as TS modules easily but can be imported directly

--- a/stellar-wallet-connect/src/vault/components/OnboardingChecklist.tsx
+++ b/stellar-wallet-connect/src/vault/components/OnboardingChecklist.tsx
@@ -1,29 +1,14 @@
 import { useState, type FC } from "react";
-import { CheckCircle2, ChevronDown, ChevronUp, HelpCircle, Wallet } from "lucide-react";
+import { CheckCircle2, ChevronDown, ChevronUp, Circle, HelpCircle, Wallet } from "lucide-react";
 
 export const ONBOARDING_STORAGE_KEY = "vaultquest.onboarding.dismissed";
 
 const STEPS = [
-  {
-    title: "Connect a Stellar wallet",
-    body: "VaultQuest uses your wallet to show your position and request signatures for pool actions."
-  },
-  {
-    title: "Use the supported network",
-    body: "Make sure your wallet is on the VaultQuest-supported Stellar network before joining a pool."
-  },
-  {
-    title: "Join a pool",
-    body: "Joining deposits the pool asset, records your shares, and keeps the action visible while it confirms."
-  },
-  {
-    title: "Follow reward cycles",
-    body: "Pools lock, draw, and settle on a schedule. Rewards appear after the cycle settles."
-  },
-  {
-    title: "Expect signatures and confirmations",
-    body: "Create, join, deposit, claim, and withdraw actions ask for a wallet signature and then wait for chain confirmation."
-  }
+  { id: "connect-wallet", title: "Connect a Stellar wallet", body: "VaultQuest uses your wallet to show your position and request signatures for pool actions." },
+  { id: "correct-network", title: "Use the supported network", body: "Make sure your wallet is on the VaultQuest-supported Stellar network before joining a pool." },
+  { id: "choose-vault", title: "Choose a vault", body: "Browse available pools and select one that matches your deposit size and lock period." },
+  { id: "join-pool", title: "Join a pool", body: "Joining deposits the pool asset, records your shares, and keeps the action visible while it confirms." },
+  { id: "follow-rewards", title: "Follow reward cycles", body: "Pools lock, draw, and settle on a schedule. Rewards appear after the cycle settles." },
 ];
 
 function readDismissed(): boolean {
@@ -36,33 +21,66 @@ function writeDismissed(value: boolean): void {
   localStorage.setItem(ONBOARDING_STORAGE_KEY, value ? "true" : "false");
 }
 
-export interface OnboardingChecklistProps {
-  className?: string;
+function isStepDone(id: string, walletConnected: boolean, hasJoinedVault: boolean): boolean {
+  switch (id) {
+    case "connect-wallet": return walletConnected;
+    case "correct-network": return walletConnected;
+    case "choose-vault": return hasJoinedVault;
+    case "join-pool": return hasJoinedVault;
+    case "follow-rewards": return hasJoinedVault;
+    default: return false;
+  }
 }
 
-export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({ className = "" }) => {
+function ChecklistSkeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-4 sm:p-5">
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-full bg-red-900/30" />
+        <div className="space-y-1.5">
+          <div className="h-4 w-40 rounded bg-vault-border" />
+          <div className="h-3 w-28 rounded bg-vault-border" />
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-red-900/20 bg-black/20 p-3">
+            <div className="h-3 w-32 rounded bg-vault-border" />
+            <div className="mt-2 h-8 w-full rounded bg-vault-border" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface OnboardingChecklistProps {
+  className?: string;
+  walletConnected?: boolean;
+  hasJoinedVault?: boolean;
+  loading?: boolean;
+}
+
+export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({
+  className = "",
+  walletConnected = false,
+  hasJoinedVault = false,
+  loading = false,
+}) => {
   const [dismissed, setDismissed] = useState(() => readDismissed());
   const [expanded, setExpanded] = useState(() => !readDismissed());
 
-  const dismiss = () => {
-    writeDismissed(true);
-    setDismissed(true);
-    setExpanded(false);
-  };
+  if (loading) return <ChecklistSkeleton />;
 
-  const revisit = () => {
-    writeDismissed(false);
-    setDismissed(false);
-    setExpanded(true);
-  };
+  const dismiss = () => { writeDismissed(true); setDismissed(true); setExpanded(false); };
+  const revisit = () => { writeDismissed(false); setDismissed(false); setExpanded(true); };
+  const completedCount = STEPS.filter((s) => isStepDone(s.id, walletConnected, hasJoinedVault)).length;
+  const allDone = completedCount === STEPS.length;
 
   if (dismissed) {
     return (
-      <button
-        type="button"
-        onClick={revisit}
-        className={`inline-flex items-center gap-2 rounded-xl border border-red-500/40 bg-red-900/30 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505] ${className}`}
-      >
+      <button type="button" onClick={revisit}
+        className={`inline-flex items-center gap-2 rounded-xl border border-red-500/40 bg-red-900/30 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505] ${className}`}>
         <HelpCircle className="h-4 w-4" aria-hidden="true" />
         Onboarding checklist
       </button>
@@ -70,10 +88,7 @@ export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({ className = 
   }
 
   return (
-    <aside
-      aria-label="Onboarding checklist"
-      className={`rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-4 text-gray-200 sm:p-5 ${className}`}
-    >
+    <aside aria-label="Onboarding checklist" className={`rounded-2xl border border-red-900/30 bg-[#1A0505]/60 p-4 text-gray-200 sm:p-5 ${className}`}>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <span className="flex h-10 w-10 items-center justify-center rounded-full bg-red-900/30 text-red-300">
@@ -81,38 +96,43 @@ export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({ className = 
           </span>
           <div>
             <h2 className="text-base font-semibold text-white">First-time wallet checklist</h2>
-            <p className="text-sm text-gray-400">A quick pass before using pool actions.</p>
+            <p className="text-sm text-gray-400">{completedCount} of {STEPS.length} steps complete</p>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((value) => !value)}
-          aria-expanded={expanded}
-          className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-red-500/30 text-gray-200 transition-colors hover:bg-red-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
-        >
+        <button type="button" onClick={() => setExpanded((v) => !v)} aria-expanded={expanded}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-red-500/30 text-gray-200 transition-colors hover:bg-red-900/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400">
           {expanded ? <ChevronUp className="h-4 w-4" aria-hidden="true" /> : <ChevronDown className="h-4 w-4" aria-hidden="true" />}
-          <span className="sr-only">{expanded ? "Collapse checklist" : "Expand checklist"}</span>
+          <span className="sr-only">{expanded ? "Collapse" : "Expand"}</span>
         </button>
       </div>
 
       {expanded && (
         <>
-          <ol className="mt-4 grid gap-3 md:grid-cols-2">
-            {STEPS.map((step) => (
-              <li key={step.title} className="flex gap-3 rounded-xl border border-red-900/20 bg-black/20 p-3">
-                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
-                <div>
-                  <h3 className="text-sm font-semibold text-white">{step.title}</h3>
-                  <p className="mt-1 text-sm leading-5 text-gray-400">{step.body}</p>
-                </div>
-              </li>
-            ))}
-          </ol>
-          <button
-            type="button"
-            onClick={dismiss}
-            className="mt-4 inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
-          >
+          {allDone ? (
+            <div className="mt-4 flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-emerald-900/20 p-4">
+              <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+              <p className="text-sm font-medium text-emerald-200">All steps complete — you're ready to use VaultQuest.</p>
+            </div>
+          ) : (
+            <ol className="mt-4 grid gap-3 md:grid-cols-2">
+              {STEPS.map((step) => {
+                const done = isStepDone(step.id, walletConnected, hasJoinedVault);
+                return (
+                  <li key={step.id} className="flex gap-3 rounded-xl border border-red-900/20 bg-black/20 p-3">
+                    {done
+                      ? <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+                      : <Circle className="mt-0.5 h-4 w-4 shrink-0 text-gray-600" aria-hidden="true" />}
+                    <div>
+                      <h3 className={`text-sm font-semibold ${done ? "text-emerald-200" : "text-white"}`}>{step.title}</h3>
+                      <p className="mt-1 text-sm leading-5 text-gray-400">{step.body}</p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+          <button type="button" onClick={dismiss}
+            className="mt-4 inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]">
             Got it
           </button>
         </>


### PR DESCRIPTION
Closes #178

---

Closes #177

---

Closes #202

---

## Summary

- **#177** New `VaultMetricsCards` dashboard component: TVL, active participants, current round, prize estimate, recent activity with loading skeleton.
- **#178** New `WalletConnectionStatus` panel: address + copy, network badge, reconnect button, error/disconnected states.
- **#202** Updated `OnboardingChecklist`: dynamic step completion via `walletConnected`/`hasJoinedVault` props, loading skeleton, all-done state.
- **#211** Enhanced `ActivityExport`: exported-field docs table, activity summary section, wired into activity page.

## Test plan
- [ ] Five metric cards render on dashboard
- [ ] Wallet status panel shows when connected
- [ ] Checklist marks steps done dynamically
- [ ] Export section appears on activity page with success/error feedback