### PR TITLE
feat: add vault export report action

### DIFF
--- a/app/app/activity/page.jsx
+++ b/app/app/activity/page.jsx
@@ -5,21 +5,16 @@ import { useAccount } from "wagmi";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import {
   ArrowDownRight, ArrowUpRight, Gift, RefreshCw, Wallet,
-  ChevronLeft, ChevronRight, Filter, Clock, AlertCircle
+  ChevronLeft, ChevronRight, Filter, Clock
 } from "lucide-react";
 import { DEMO_TRANSACTIONS } from "@/lib/demo-portfolio";
+import { ActivityExport } from "stellar-wallet-connect/src/vault";
 
 const ACTIVITY_TYPES = {
   deposit: { label: "Deposit", icon: ArrowDownRight, color: "text-emerald-600 dark:text-emerald-400" },
   withdraw: { label: "Withdrawal", icon: ArrowUpRight, color: "text-vault-muted" },
   reward: { label: "Prize Claimed", icon: Gift, color: "text-amber-600 dark:text-amber-400" },
   status: { label: "Status Change", icon: RefreshCw, color: "text-blue-600 dark:text-blue-400" },
-};
-
-const TYPE_LABELS = {
-  deposit: "Deposit",
-  withdraw: "Withdraw",
-  reward: "Prize won",
 };
 
 const STATUS_LABELS = {
@@ -52,12 +47,9 @@ function ActivityFeed({ transactions }) {
         </div>
         <div className="flex items-center gap-2">
           <Filter className="h-4 w-4 text-vault-muted" />
-          <select
-            value={filter}
-            onChange={(e) => { setFilter(e.target.value); setPage(0); }}
+          <select value={filter} onChange={(e) => { setFilter(e.target.value); setPage(0); }}
             className="rounded-xl border border-vault-border bg-vault-surface px-3 py-2 text-sm text-vault-text focus:outline-none focus:ring-2 focus:ring-red-400"
-            aria-label="Filter activity type"
-          >
+            aria-label="Filter activity type">
             <option value="all">All Activity</option>
             <option value="deposit">Deposits</option>
             <option value="withdraw">Withdrawals</option>
@@ -87,19 +79,14 @@ function ActivityFeed({ transactions }) {
                     <p className="font-medium text-vault-text">{typeInfo.label}</p>
                     <span className={`text-xs font-medium ${statusInfo.class}`}>{statusInfo.label}</span>
                   </div>
-                  <p className="text-xs text-vault-muted">
-                    {tx.pool}
-                  </p>
+                  <p className="text-xs text-vault-muted">{tx.pool}</p>
                   <p className="mt-0.5 text-xs text-vault-muted">
-                    {new Date(tx.date).toLocaleString("en-US", {
-                      month: "short", day: "numeric", year: "numeric",
-                      hour: "2-digit", minute: "2-digit"
-                    })}
+                    {new Date(tx.date).toLocaleString("en-US", { month: "short", day: "numeric", year: "numeric", hour: "2-digit", minute: "2-digit" })}
                   </p>
                 </div>
-                <div className="text-right shrink-0">
+                <div className="shrink-0 text-right">
                   <p className={`font-semibold ${tx.type === "withdraw" ? "text-vault-muted" : "text-emerald-600 dark:text-emerald-400"}`}>
-                    {tx.type === "withdraw" ? "\u2212" : "+"}${tx.amount.toLocaleString()}
+                    {tx.type === "withdraw" ? "−" : "+"}${tx.amount.toLocaleString()}
                   </p>
                   <p className="text-xs text-vault-muted">{tx.asset || "USDC"}</p>
                 </div>
@@ -111,26 +98,12 @@ function ActivityFeed({ transactions }) {
 
       {filtered.length > PAGE_SIZE && (
         <div className="mt-4 flex items-center justify-between border-t border-vault-border pt-4">
-          <button
-            type="button"
-            disabled={safePage === 0}
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            className="vq-btn-ghost disabled:opacity-40"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            Prev
+          <button type="button" disabled={safePage === 0} onClick={() => setPage((p) => Math.max(0, p - 1))} className="vq-btn-ghost disabled:opacity-40">
+            <ChevronLeft className="h-4 w-4" /> Prev
           </button>
-          <span className="text-sm text-vault-muted">
-            Page {safePage + 1} of {pageCount}
-          </span>
-          <button
-            type="button"
-            disabled={safePage >= pageCount - 1}
-            onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-            className="vq-btn-ghost disabled:opacity-40"
-          >
-            Next
-            <ChevronRight className="h-4 w-4" />
+          <span className="text-sm text-vault-muted">Page {safePage + 1} of {pageCount}</span>
+          <button type="button" disabled={safePage >= pageCount - 1} onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))} className="vq-btn-ghost disabled:opacity-40">
+            Next <ChevronRight className="h-4 w-4" />
           </button>
         </div>
       )}
@@ -156,33 +129,21 @@ function ActivitySummary({ transactions }) {
   return (
     <div className="grid gap-4 sm:grid-cols-3">
       <div className="vq-glass-hover p-5">
-        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-emerald-500">
-          <ArrowDownRight className="h-5 w-5" />
-        </span>
+        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-emerald-500"><ArrowDownRight className="h-5 w-5" /></span>
         <p className="mt-4 text-xs font-medium uppercase tracking-wide text-vault-muted">Total Deposits</p>
-        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">
-          ${stats.totalDeposits.toLocaleString()}
-        </p>
+        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">${stats.totalDeposits.toLocaleString()}</p>
         <p className="text-sm text-vault-muted">{stats.depositCount} deposits</p>
       </div>
       <div className="vq-glass-hover p-5">
-        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-vault-muted">
-          <ArrowUpRight className="h-5 w-5" />
-        </span>
+        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-vault-muted"><ArrowUpRight className="h-5 w-5" /></span>
         <p className="mt-4 text-xs font-medium uppercase tracking-wide text-vault-muted">Total Withdrawals</p>
-        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">
-          ${stats.totalWithdrawals.toLocaleString()}
-        </p>
+        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">${stats.totalWithdrawals.toLocaleString()}</p>
         <p className="text-sm text-vault-muted">{stats.withdrawCount} withdrawals</p>
       </div>
       <div className="vq-glass-hover p-5">
-        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-amber-500">
-          <Gift className="h-5 w-5" />
-        </span>
+        <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-amber-500"><Gift className="h-5 w-5" /></span>
         <p className="mt-4 text-xs font-medium uppercase tracking-wide text-vault-muted">Total Claims</p>
-        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">
-          ${stats.totalClaims.toLocaleString()}
-        </p>
+        <p className="mt-1 text-2xl font-bold tabular-nums text-vault-text">${stats.totalClaims.toLocaleString()}</p>
         <p className="text-sm text-vault-muted">{stats.claimCount} prizes</p>
       </div>
     </div>
@@ -197,12 +158,9 @@ function EmptyActivity() {
         <Wallet className="h-8 w-8" />
       </span>
       <h2 className="mt-6 text-xl font-semibold text-vault-text">Wallet not connected</h2>
-      <p className="mt-2 max-w-md text-sm text-vault-muted">
-        Connect your wallet to view your account activity, deposits, withdrawals, and prize claims.
-      </p>
+      <p className="mt-2 max-w-md text-sm text-vault-muted">Connect your wallet to view your account activity, deposits, withdrawals, and prize claims.</p>
       <button type="button" onClick={() => openConnectModal?.()} className="vq-btn-primary mt-8">
-        <Wallet className="h-4 w-4" />
-        Connect wallet
+        <Wallet className="h-4 w-4" /> Connect wallet
       </button>
     </div>
   );
@@ -212,19 +170,31 @@ export default function ActivityPage() {
   const { isConnected } = useAccount();
   const enrichedTx = useMemo(() => DEMO_TRANSACTIONS.map((tx) => ({ ...tx })), []);
 
+  const summary = useMemo(() => {
+    if (!isConnected) return null;
+    return {
+      deposits: enrichedTx.filter((t) => t.type === "deposit" && t.status === "confirmed").length,
+      withdrawals: enrichedTx.filter((t) => t.type === "withdraw" && t.status === "confirmed").length,
+      rewards: enrichedTx.filter((t) => t.type === "reward" && t.status === "confirmed").length,
+    };
+  }, [isConnected, enrichedTx]);
+
   return (
     <div className="space-y-8">
       <header>
         <h1 className="text-3xl font-bold text-vault-text">Account Activity</h1>
-        <p className="mt-2 text-vault-muted">
-          Track all deposits, withdrawals, prize claims, and status changes.
-        </p>
+        <p className="mt-2 text-vault-muted">Track all deposits, withdrawals, prize claims, and status changes.</p>
       </header>
 
       {isConnected ? (
         <>
           <ActivitySummary transactions={enrichedTx} />
           <ActivityFeed transactions={enrichedTx} />
+          <ActivityExport
+            walletAddress={null}
+            walletConnected={isConnected}
+            summary={summary}
+          />
         </>
       ) : (
         <EmptyActivity />

--- a/stellar-wallet-connect/src/vault/components/ActivityExport.tsx
+++ b/stellar-wallet-connect/src/vault/components/ActivityExport.tsx
@@ -5,13 +5,22 @@ import { WalletDisconnectedState } from "../../components/FallbackStates";
 import { useActivityExport, type ExportFormat } from "../hooks";
 
 /**
- * Activity export controls (#92).
+ * Activity export controls (#211).
  *
- * Lets connected users download their VaultQuest action history as JSON or
- * CSV. Pairs with `useActivityExport` for the fetch/download side-effect.
- * Presentational props keep the component testable in isolation.
+ * Lets connected users download their VaultQuest action history as JSON or CSV.
+ * Pairs with `useActivityExport` for the fetch/download side-effect.
  *
- * Responsive: stacks on mobile, single row on desktop.
+ * ## Exported fields
+ * | Field        | Type     | Description                                      |
+ * |--------------|----------|--------------------------------------------------|
+ * | id           | string   | Unique action identifier                         |
+ * | type         | string   | "deposit" | "withdraw" | "reward" | "status"      |
+ * | pool         | string   | Human-readable pool name                         |
+ * | asset        | string   | Asset code (e.g. "USDC", "XLM")                 |
+ * | amount       | number   | Token amount (always positive)                   |
+ * | date         | ISO 8601 | UTC timestamp of the on-chain confirmation       |
+ * | status       | string   | "confirmed" | "pending" | "failed"               |
+ * | walletAddress| string   | Stellar public key that signed the action        |
  */
 
 export interface ActivityExportProps {
@@ -20,6 +29,8 @@ export interface ActivityExportProps {
   onConnect?: () => void;
   /** Base URL of the backend API. Defaults to "/api". */
   apiBaseUrl?: string;
+  /** Summary counts shown above the export controls. */
+  summary?: { deposits: number; withdrawals: number; rewards: number } | null;
 }
 
 const FORMAT_OPTIONS: { value: ExportFormat; label: string }[] = [
@@ -32,6 +43,7 @@ export const ActivityExport: FC<ActivityExportProps> = ({
   walletConnected = true,
   onConnect,
   apiBaseUrl = "/api",
+  summary = null,
 }) => {
   const { state, trigger, reset } = useActivityExport();
   const [format, setFormat] = useState<ExportFormat>("csv");
@@ -45,13 +57,7 @@ export const ActivityExport: FC<ActivityExportProps> = ({
   const loading = state.status === "loading";
 
   const handleExport = () => {
-    trigger({
-      wallet: walletAddress,
-      format,
-      from: from || undefined,
-      to: to || undefined,
-      baseUrl: apiBaseUrl,
-    });
+    trigger({ wallet: walletAddress, format, from: from || undefined, to: to || undefined, baseUrl: apiBaseUrl });
   };
 
   return (
@@ -61,81 +67,56 @@ export const ActivityExport: FC<ActivityExportProps> = ({
         Download your VaultQuest transaction history for personal records or support.
       </p>
 
+      {summary && (
+        <dl className="mt-4 grid grid-cols-3 gap-3 rounded-xl border border-red-900/20 bg-black/20 p-3 text-center text-xs">
+          <div>
+            <dt className="text-gray-500">Deposits</dt>
+            <dd className="mt-1 font-semibold text-emerald-300">{summary.deposits}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Withdrawals</dt>
+            <dd className="mt-1 font-semibold text-gray-300">{summary.withdrawals}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Prizes</dt>
+            <dd className="mt-1 font-semibold text-amber-300">{summary.rewards}</dd>
+          </div>
+        </dl>
+      )}
+
       <div className="mt-4 flex flex-wrap items-end gap-3">
-        {/* Date range */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="export-from" className="text-xs font-medium text-gray-400">
-            From
-          </label>
-          <input
-            id="export-from"
-            type="date"
-            value={from}
-            onChange={(e) => { reset(); setFrom(e.target.value); }}
-            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500"
-          />
+          <label htmlFor="export-from" className="text-xs font-medium text-gray-400">From</label>
+          <input id="export-from" type="date" value={from} onChange={(e) => { reset(); setFrom(e.target.value); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500" />
         </div>
-
         <div className="flex flex-col gap-1">
-          <label htmlFor="export-to" className="text-xs font-medium text-gray-400">
-            To
-          </label>
-          <input
-            id="export-to"
-            type="date"
-            value={to}
-            onChange={(e) => { reset(); setTo(e.target.value); }}
-            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500"
-          />
+          <label htmlFor="export-to" className="text-xs font-medium text-gray-400">To</label>
+          <input id="export-to" type="date" value={to} onChange={(e) => { reset(); setTo(e.target.value); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-red-500" />
         </div>
-
-        {/* Format picker */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="export-format" className="text-xs font-medium text-gray-400">
-            Format
-          </label>
-          <select
-            id="export-format"
-            value={format}
-            onChange={(e) => { reset(); setFormat(e.target.value as ExportFormat); }}
-            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-500"
-          >
-            {FORMAT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
+          <label htmlFor="export-format" className="text-xs font-medium text-gray-400">Format</label>
+          <select id="export-format" value={format} onChange={(e) => { reset(); setFormat(e.target.value as ExportFormat); }}
+            className="rounded-lg border border-red-900/30 bg-[#0D0101] px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-500">
+            {FORMAT_OPTIONS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
           </select>
         </div>
-
-        {/* Export button */}
-        <button
-          type="button"
-          onClick={handleExport}
-          disabled={loading}
-          className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
-        >
-          {loading ? (
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          ) : (
-            <Download className="h-4 w-4" aria-hidden="true" />
-          )}
+        <button type="button" onClick={handleExport} disabled={loading}
+          className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Download className="h-4 w-4" aria-hidden="true" />}
           {loading ? "Exporting…" : "Export"}
         </button>
       </div>
 
-      {/* Feedback */}
       {state.status === "success" && (
         <div className="mt-3 flex items-center gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-sm text-emerald-300">
           <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
-          <span>
-            Downloaded <span className="font-mono">{state.filename}</span>
-          </span>
+          <span>Downloaded <span className="font-mono">{state.filename}</span></span>
         </div>
       )}
-
       {state.status === "error" && (
-        <div className="mt-3 flex items-center gap-2 rounded-lg bg-red-700/20 px-3 py-2 text-sm text-red-300">
+        <div role="alert" className="mt-3 flex items-center gap-2 rounded-lg bg-red-700/20 px-3 py-2 text-sm text-red-300">
           <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span>{state.message}</span>
         </div>

--- a/stellar-wallet-connect/src/vault/index.ts
+++ b/stellar-wallet-connect/src/vault/index.ts
@@ -1,11 +1,13 @@
 /**
- * VaultQuest pool UI module: pool detail (#73), reward history (#75), and the
- * saved-pools watchlist (#89/#90), plus the testable contract interface + mock (#67).
+ * VaultQuest pool UI module: pool detail (#73), reward history (#75), saved-pools watchlist (#89/#90),
+ * onboarding checklist (#202 — walletConnected, hasJoinedVault, loading props),
+ * activity export (#211 — ActivityExport component + useActivityExport hook),
+ * and the testable contract interface + mock (#67).
  */
 export * from "./contract/types";
 export { createMockVaultClient, SAMPLE_ADDRESS, type MockVaultConfig } from "./contract/mockClient";
 export * from "./lib/format";
-export { useAccountView, usePoolAction, usePoolDetail, usePoolDiscovery, usePrizeViews, useRewardHistory, useSavedPools, useTransactionStatus, invalidatePoolActionQueries, type AccountView, type AsyncResource, type PoolActionFlow, type PoolDetailResource, type PoolDiscoveryOptions, type PrizeViewsOptions, type SavedPoolsResource, type TransactionStatusResource } from "./hooks";
+export { useAccountView, usePoolAction, usePoolDetail, usePoolDiscovery, usePrizeViews, useRewardHistory, useSavedPools, useTransactionStatus, invalidatePoolActionQueries, useActivityExport, type AccountView, type AsyncResource, type PoolActionFlow, type PoolDetailResource, type PoolDiscoveryOptions, type PrizeViewsOptions, type SavedPoolsResource, type TransactionStatusResource, type ExportFormat, type ExportState, type ActivityExportOptions, type ActivityExportResult } from "./hooks";
 export { VaultApiClient, isTerminalTransaction, type TransactionStatus, type TransactionStatusView } from "./data/apiClient";
 export { createVaultDataConfig, defaultVaultDataConfig, type VaultDataConfig, type VaultFeatureFlags, type VaultNetworkConfig } from "./data/config";
 export { vaultQueryClient, useVaultQuery, type QueryState, type QueryStatus } from "./data/queryClient";
@@ -14,3 +16,4 @@ export { RewardHistory, type RewardHistoryProps } from "./components/RewardHisto
 export { SavedPoolsWatchlist, type SavedPoolsWatchlistProps } from "./components/SavedPoolsWatchlist";
 export { PoolDetail, availableActions, type PoolDetailProps } from "./components/PoolDetail";
 export { OnboardingChecklist, ONBOARDING_STORAGE_KEY, type OnboardingChecklistProps } from "./components/OnboardingChecklist";
+export { ActivityExport, type ActivityExportProps } from "./components/ActivityExport";


### PR DESCRIPTION
Closes #211

---

## Summary

- **#211** Enhanced `ActivityExport`: JSDoc table documenting all exported fields (id, type, pool, asset, amount, date, status, walletAddress), `summary` prop showing deposit/withdrawal/prize counts above the export controls, `role="alert"` on the error state div, and wired into the activity page with computed summary from `enrichedTx`.

## Test plan
- [ ] Export section appears on activity page when wallet is connected
- [ ] Activity summary shows correct deposit, withdrawal, and prize counts
- [ ] Export button triggers download in selected format (JSON / CSV)
- [ ] Error state displays with `role="alert"` for screen readers
- [ ] Success state shows downloaded filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an activity export option on the Activity page.
  * Connected wallets now see a compact activity summary alongside export controls.

* **UI Improvements**
  * Streamlined activity filters, pagination, stats cards, and empty-state layout for a cleaner experience.
  * Refined activity rows to display pool, date, and amount information more clearly.

* **Bug Fixes**
  * Preserved existing activity filtering and paging behavior while simplifying the page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->