### PR TITLE
feat: add security tips panel, vault data review, API error audit,

### DIFF
--- a/app/app/account/page.jsx
+++ b/app/app/account/page.jsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
-import { PiggyBank, Trophy, TrendingUp, Wallet } from "lucide-react";
+import { PiggyBank, RotateCcw, Trophy, TrendingUp, Wallet } from "lucide-react";
 import AccountPositionSummary from "@/components/app/AccountPositionSummary";
 import UserDepositsList from "@/components/app/UserDepositsList";
 import ProfileEditor from "@/components/app/ProfileEditor";
@@ -12,6 +12,8 @@ import BadgesGallery from "@/components/app/BadgesGallery";
 import PrizeChart from "@/components/app/PrizeChart";
 import VaultNotificationSettings from "@/components/app/VaultNotificationSettings";
 import WalletReconnectGuidance from "@/components/app/WalletReconnectGuidance";
+import SecurityTipsPanel from "@/components/app/SecurityTipsPanel";
+import VaultOnboardingTour, { useRestartTour } from "@/components/app/VaultOnboardingTour";
 import { useYieldCounter } from "@/components/hooks/useYieldCounter";
 import { formatUsd } from "@/lib/yield-counter";
 import { DEMO_PORTFOLIO, DEMO_TRANSACTIONS } from "@/lib/demo-portfolio";
@@ -39,6 +41,7 @@ function MetricCard({ icon: Icon, label, value, sub, highlight }) {
 
 function ConnectedDashboard({ isNetworkMismatch, onRetry }) {
   const [selectedAsset, setSelectedAsset] = useState("all");
+  const [tourKey, setTourKey] = useState(0);
 
   const accrued = useYieldCounter(
     DEMO_PORTFOLIO.activeDeposits,
@@ -47,14 +50,19 @@ function ConnectedDashboard({ isNetworkMismatch, onRetry }) {
     true,
   );
 
+  const restartTour = useRestartTour(() => setTourKey((k) => k + 1));
+
   return (
     <>
+      <SecurityTipsPanel />
+
       {isNetworkMismatch && (
         <WalletReconnectGuidance
           isNetworkMismatch
           onRetry={onRetry}
         />
       )}
+
       <AccountPositionSummary />
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -94,6 +102,19 @@ function ConnectedDashboard({ isNetworkMismatch, onRetry }) {
         selectedAsset={selectedAsset}
         onClearAsset={() => setSelectedAsset("all")}
       />
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={restartTour}
+          className="vq-btn-ghost flex items-center gap-2 text-xs"
+        >
+          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+          Replay onboarding tour
+        </button>
+      </div>
+
+      <VaultOnboardingTour key={tourKey} />
     </>
   );
 }

--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -17,6 +17,7 @@ import PrizeCountdown from "@/components/app/PrizeCountdown";
 import FaqAccordion from "@/components/app/FaqAccordion";
 import { WalletConnectionStatus, OnboardingChecklist } from "stellar-wallet-connect";
 import VaultEmptyState from "@/components/app/VaultEmptyState";
+import VaultOnboardingTour from "@/components/app/VaultOnboardingTour";
 
 function DashboardSkeleton() {
   return (
@@ -115,6 +116,8 @@ export default function AppDashboardPage() {
 
   return (
     <div className="space-y-8 animate-in fade-in duration-500">
+      <VaultOnboardingTour />
+
       <UnsupportedNetworkBanner />
 
       <WinnerCelebration

--- a/app/app/vaults/page.jsx
+++ b/app/app/vaults/page.jsx
@@ -8,9 +8,11 @@ import VaultFilters from "@/components/app/VaultFilters";
 import VaultList, { MOCK_VAULTS } from "@/components/app/VaultList";
 import VaultComparisonTable from "@/components/app/VaultComparisonTable";
 import VaultDataRefresh from "@/components/app/VaultDataRefresh";
+import VaultDataWarnings from "@/components/app/VaultDataWarnings";
 import VaultFaqSection from "@/components/app/VaultFaqSection";
 import VaultRiskExplainer from "@/components/app/VaultRiskExplainer";
 import MobileVaultActions from "@/components/app/MobileVaultActions";
+import { useVaultDataReview } from "@/hooks/useVaultDataReview";
 import { LayoutGrid, Table } from "lucide-react";
 
 const INITIAL_FILTERS = {
@@ -29,8 +31,11 @@ export default function VaultsPage() {
   const [filters, setFilters] = useState(INITIAL_FILTERS);
   const [viewMode, setViewMode] = useState("table");
 
+  const { vaults: reviewedVaults, warnings: dataWarnings } =
+    useVaultDataReview(MOCK_VAULTS);
+
   const filteredVaults = useMemo(() => {
-    return MOCK_VAULTS.filter((vault) => {
+    return reviewedVaults.filter((vault) => {
       // Search (by name, asset, or strategy)
       if (filters.search) {
         const search = filters.search.toLowerCase();
@@ -139,6 +144,8 @@ export default function VaultsPage() {
 
         <div className="flex-1 space-y-6">
           <VaultDataRefresh />
+
+          <VaultDataWarnings warnings={dataWarnings} />
 
           <MobileVaultActions
             vaultName="Selected Vault"

--- a/components/app/SecurityTipsPanel.jsx
+++ b/components/app/SecurityTipsPanel.jsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X, ShieldCheck, KeyRound, Eye, LinkIcon } from "lucide-react";
+
+const TIPS = [
+  {
+    icon: KeyRound,
+    title: "Never share your seed phrase",
+    body: "Your 12 or 24-word recovery phrase is the master key to your wallet. No legitimate app or support team will ever ask for it.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Double-check the URL",
+    body: "Before connecting your wallet, confirm you are on the correct site. Bookmark it to avoid phishing copies.",
+  },
+  {
+    icon: Eye,
+    title: "Review every transaction",
+    body: "Read the full details in your wallet before approving. If something looks unfamiliar, cancel and ask for help first.",
+  },
+  {
+    icon: LinkIcon,
+    title: "Use trusted bridges only",
+    body: "Only move assets through official bridge integrations listed in the app. Third-party bridges can put your funds at risk.",
+  },
+];
+
+const STORAGE_KEY = "vq_security_tips_dismissed";
+
+export default function SecurityTipsPanel() {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(STORAGE_KEY) === "true");
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // storage unavailable — dismiss in memory only
+    }
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <section
+      aria-label="Account security tips"
+      className="vq-glass border-amber-400/30 bg-amber-500/5 p-5 sm:p-6"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg border border-amber-400/30 bg-amber-500/15 text-amber-500 dark:text-amber-400">
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <h2 className="text-sm font-semibold text-vault-text">
+            Keep your account safe
+          </h2>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss security tips"
+          className="rounded-lg p-1.5 text-vault-muted transition-colors hover:bg-vault-surface hover:text-vault-text"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {TIPS.map((tip) => {
+          const Icon = tip.icon;
+          return (
+            <div
+              key={tip.title}
+              className="flex gap-3 rounded-xl border border-vault-border/50 bg-vault-surface/30 p-3"
+            >
+              <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-vault-border bg-vault-surface text-vault-muted">
+                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              </span>
+              <div>
+                <p className="text-xs font-semibold text-vault-text">
+                  {tip.title}
+                </p>
+                <p className="mt-0.5 text-xs leading-relaxed text-vault-muted">
+                  {tip.body}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-4">
+        <a
+          href="https://docs.vaultquest.io/security"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs font-medium text-vault-muted underline underline-offset-2 hover:text-vault-text"
+        >
+          Read the full safety guide →
+        </a>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="vq-btn-ghost h-8 px-3 text-xs"
+        >
+          Got it, dismiss
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/app/VaultDataWarnings.jsx
+++ b/components/app/VaultDataWarnings.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Displays data quality warnings produced by useVaultDataReview.
+ * Renders nothing when there are no warnings.
+ *
+ * @param {{ warnings: string[] }} props
+ */
+export default function VaultDataWarnings({ warnings = [] }) {
+  if (!warnings.length) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex gap-3 rounded-xl border border-amber-400/30 bg-amber-500/10 p-4"
+    >
+      <AlertTriangle
+        className="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+        aria-hidden="true"
+      />
+      <div className="space-y-1">
+        <p className="text-xs font-semibold text-vault-text">
+          Some vault data could not be loaded
+        </p>
+        <ul className="space-y-0.5">
+          {warnings.map((w, i) => (
+            <li key={i} className="text-xs text-vault-muted">
+              {w}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/app/VaultOnboardingTour.jsx
+++ b/components/app/VaultOnboardingTour.jsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, ChevronRight, RotateCcw, LayoutDashboard, CreditCard, UserCircle, SkipForward } from "lucide-react";
+
+const STORAGE_KEY = "vq_onboarding_tour_done";
+
+const TOUR_STEPS = [
+  {
+    icon: LayoutDashboard,
+    title: "Welcome to VaultQuest",
+    body: "This is your dashboard. It shows live protocol stats, your savings progress, and the next prize draw countdown. Everything you need is right here.",
+    accent: "from-red-500/15 to-orange-500/10",
+  },
+  {
+    icon: CreditCard,
+    title: "Vault cards explained",
+    body: "Each vault card shows the pool's APY, the current prize pool size, and your share. Your principal is always withdrawable in full — you cannot lose what you put in.",
+    accent: "from-violet-500/15 to-indigo-500/10",
+  },
+  {
+    icon: UserCircle,
+    title: "Your account page",
+    body: "The Account page tracks your live yield, prize history, and badges. You can also edit your profile and manage notification preferences there.",
+    accent: "from-emerald-500/15 to-teal-500/10",
+  },
+];
+
+export default function VaultOnboardingTour() {
+  const [step, setStep] = useState(0);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(STORAGE_KEY) !== "true") {
+        setVisible(true);
+      }
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  const finish = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, "true");
+    } catch {
+      // storage unavailable
+    }
+    setVisible(false);
+  };
+
+  const next = () => {
+    if (step < TOUR_STEPS.length - 1) {
+      setStep((s) => s + 1);
+    } else {
+      finish();
+    }
+  };
+
+  const isLast = step === TOUR_STEPS.length - 1;
+  const current = TOUR_STEPS[step];
+  const Icon = current.icon;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[9000] bg-black/50 backdrop-blur-sm"
+            onClick={finish}
+            aria-hidden="true"
+          />
+
+          {/* Tour card */}
+          <motion.div
+            key={`step-${step}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Onboarding tour — step ${step + 1} of ${TOUR_STEPS.length}`}
+            initial={{ opacity: 0, scale: 0.95, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 12 }}
+            transition={{ type: "spring", damping: 24, stiffness: 300 }}
+            className="fixed inset-x-4 bottom-6 z-[9001] mx-auto max-w-md rounded-2xl border border-vault-border bg-vault-bg shadow-2xl sm:bottom-8 sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2"
+          >
+            {/* Step gradient accent */}
+            <div
+              className={`absolute inset-0 rounded-2xl bg-gradient-to-br ${current.accent} pointer-events-none`}
+              aria-hidden="true"
+            />
+
+            <div className="relative p-6">
+              {/* Header */}
+              <div className="flex items-start justify-between gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-red-500 dark:text-red-400">
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <button
+                  type="button"
+                  onClick={finish}
+                  aria-label="Close tour"
+                  className="rounded-lg p-1.5 text-vault-muted transition-colors hover:bg-vault-surface hover:text-vault-text"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+
+              {/* Content */}
+              <h2 className="mt-4 text-base font-bold text-vault-text">
+                {current.title}
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-vault-muted">
+                {current.body}
+              </p>
+
+              {/* Step dots */}
+              <div className="mt-5 flex items-center gap-1.5" aria-hidden="true">
+                {TOUR_STEPS.map((_, i) => (
+                  <span
+                    key={i}
+                    className={`h-1.5 rounded-full transition-all duration-300 ${
+                      i === step
+                        ? "w-5 bg-red-500"
+                        : i < step
+                          ? "w-1.5 bg-red-500/40"
+                          : "w-1.5 bg-vault-border"
+                    }`}
+                  />
+                ))}
+              </div>
+
+              {/* Actions */}
+              <div className="mt-5 flex items-center justify-between gap-3">
+                <button
+                  type="button"
+                  onClick={finish}
+                  className="flex items-center gap-1.5 text-xs font-medium text-vault-muted hover:text-vault-text transition-colors"
+                >
+                  <SkipForward className="h-3.5 w-3.5" aria-hidden="true" />
+                  Skip tour
+                </button>
+
+                <button
+                  type="button"
+                  onClick={next}
+                  className="vq-btn-primary"
+                >
+                  {isLast ? "Done" : "Next"}
+                  {!isLast && (
+                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * Utility to reset the tour so users can replay it from the account page.
+ * Returns a handler function to attach to a button.
+ */
+export function useRestartTour(onRestart) {
+  return () => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // storage unavailable
+    }
+    onRestart?.();
+  };
+}

--- a/hooks/useVaultDataReview.js
+++ b/hooks/useVaultDataReview.js
@@ -1,0 +1,103 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  VAULT_FIELD_FALLBACKS,
+  logVaultApiWarning,
+} from "@/lib/vault-api-errors";
+
+/**
+ * Required fields every vault object must have and the type they should be.
+ * A field is flagged missing if its value is null, undefined, or empty string.
+ */
+const REQUIRED_FIELDS = [
+  { key: "name", label: "Vault name", type: "string" },
+  { key: "apy", label: "APY", type: "number" },
+  { key: "minDeposit", label: "Minimum deposit", type: "number" },
+  { key: "status", label: "Vault status", type: "string" },
+  { key: "totalDeposits", label: "Total deposits", type: "number" },
+];
+
+/**
+ * Checks a single vault object for missing or inconsistent fields.
+ * Returns the vault with fallback values applied and a list of warnings.
+ *
+ * @param {Record<string, unknown>} vault
+ * @returns {{ vault: Record<string, unknown>; warnings: string[] }}
+ */
+function reviewVault(vault) {
+  if (!vault || typeof vault !== "object") {
+    logVaultApiWarning("vaultConfig", "Received null or non-object vault data");
+    return {
+      vault: { ...VAULT_FIELD_FALLBACKS },
+      warnings: ["Vault data is missing entirely."],
+    };
+  }
+
+  const warnings = [];
+  const reviewed = { ...vault };
+
+  for (const field of REQUIRED_FIELDS) {
+    const value = vault[field.key];
+    const isMissing = value === null || value === undefined || value === "";
+    const isWrongType = !isMissing && typeof value !== field.type;
+
+    if (isMissing) {
+      warnings.push(`"${field.label}" is missing — showing fallback value.`);
+      reviewed[field.key] = VAULT_FIELD_FALLBACKS[field.key];
+      logVaultApiWarning("vaultConfig", `Field "${field.key}" is missing`, {
+        field: field.key,
+        fallback: VAULT_FIELD_FALLBACKS[field.key],
+      });
+    } else if (isWrongType) {
+      warnings.push(
+        `"${field.label}" has an unexpected format and may display incorrectly.`,
+      );
+      logVaultApiWarning(
+        "vaultConfig",
+        `Field "${field.key}" has wrong type: expected ${field.type}, got ${typeof value}`,
+        { field: field.key },
+      );
+    }
+  }
+
+  return { vault: reviewed, warnings };
+}
+
+/**
+ * Hook that validates vault data and returns safe, fallback-applied vaults
+ * alongside any data warnings to surface to the UI.
+ *
+ * @param {Record<string, unknown> | Record<string, unknown>[] | null | undefined} vaultData
+ * @returns {{
+ *   vaults: Record<string, unknown>[];
+ *   warnings: string[];
+ *   hasWarnings: boolean;
+ * }}
+ */
+export function useVaultDataReview(vaultData) {
+  return useMemo(() => {
+    const rawVaults = Array.isArray(vaultData)
+      ? vaultData
+      : vaultData
+        ? [vaultData]
+        : [];
+
+    if (rawVaults.length === 0) {
+      return { vaults: [], warnings: [], hasWarnings: false };
+    }
+
+    const allWarnings = [];
+    const reviewedVaults = rawVaults.map((v) => {
+      const { vault, warnings } = reviewVault(v);
+      allWarnings.push(...warnings);
+      return vault;
+    });
+
+    return {
+      vaults: reviewedVaults,
+      warnings: allWarnings,
+      hasWarnings: allWarnings.length > 0,
+    };
+  }, [vaultData]);
+}

--- a/lib/vault-api-errors.js
+++ b/lib/vault-api-errors.js
@@ -1,0 +1,138 @@
+/**
+ * Vault API Error Audit
+ *
+ * Centralised registry of key vault data API routes, their expected error
+ * shapes, safe fallback values, and retry behaviour.  Components that call
+ * these routes should import the helpers here so error handling stays
+ * consistent across the app.
+ *
+ * Retry strategy: exponential back-off, max 3 attempts, only on transient
+ * errors (network / 5xx).  Never retry on 4xx client errors.
+ */
+
+/** Key vault API routes with metadata for error handling. */
+export const VAULT_API_ROUTES = {
+  vaultConfig: {
+    label: "Vault configuration",
+    route: "contract:vaultConfig",
+    retryable: true,
+    maxRetries: 3,
+  },
+  vaultApy: {
+    label: "Vault APY",
+    route: "contract:getAPY",
+    retryable: true,
+    maxRetries: 3,
+  },
+  userBalance: {
+    label: "User balance",
+    route: "contract:balanceOf",
+    retryable: true,
+    maxRetries: 2,
+  },
+  stellarHorizon: {
+    label: "Stellar Horizon",
+    route: "https://horizon.stellar.org",
+    retryable: true,
+    maxRetries: 3,
+  },
+  backendHealth: {
+    label: "VaultQuest backend",
+    route: "/api/health",
+    retryable: false,
+    maxRetries: 0,
+  },
+};
+
+/**
+ * Safe fallback values used whenever a vault field cannot be loaded.
+ * Components must display these instead of rendering null / undefined.
+ */
+export const VAULT_FIELD_FALLBACKS = {
+  name: "—",
+  apy: null,
+  minDeposit: null,
+  totalDeposits: null,
+  status: "unknown",
+  roundEndDate: null,
+  prizePool: null,
+};
+
+/**
+ * Standardised error messages keyed by HTTP status or error code.
+ * Use `getApiErrorMessage` to resolve a message for display.
+ */
+const API_ERROR_MESSAGES = {
+  400: "The request was invalid. Please refresh and try again.",
+  401: "Your session has expired. Reconnect your wallet to continue.",
+  403: "You don't have permission to access this resource.",
+  404: "The requested vault data was not found.",
+  429: "Too many requests. Please wait a moment before trying again.",
+  500: "VaultQuest's backend encountered an error. Try again shortly.",
+  502: "A network gateway error occurred. Try again in a few seconds.",
+  503: "The service is temporarily unavailable. Check system status.",
+  NETWORK_ERROR:
+    "Unable to reach the server. Check your internet connection.",
+  TIMEOUT: "The request timed out. The network may be slow — try again.",
+  UNKNOWN: "An unexpected error occurred. Please try again.",
+};
+
+/**
+ * Returns a user-facing error message for a given error.
+ * @param {Error | { status?: number; code?: string } | null} error
+ * @returns {string}
+ */
+export function getApiErrorMessage(error) {
+  if (!error) return API_ERROR_MESSAGES.UNKNOWN;
+
+  const status = error?.status ?? error?.response?.status;
+  if (status && API_ERROR_MESSAGES[status]) return API_ERROR_MESSAGES[status];
+
+  const code = error?.code ?? error?.name ?? "";
+  if (code === "ECONNABORTED" || code === "AbortError")
+    return API_ERROR_MESSAGES.TIMEOUT;
+  if (
+    code === "NetworkError" ||
+    code === "TypeError" ||
+    code.toLowerCase().includes("network")
+  )
+    return API_ERROR_MESSAGES.NETWORK_ERROR;
+
+  return API_ERROR_MESSAGES.UNKNOWN;
+}
+
+/**
+ * Determines whether a failed request should be retried.
+ * @param {Error | { status?: number } | null} error
+ * @param {string} routeKey - Key from VAULT_API_ROUTES
+ * @param {number} attemptCount - Number of attempts already made (0-indexed)
+ * @returns {boolean}
+ */
+export function shouldRetry(error, routeKey, attemptCount) {
+  const route = VAULT_API_ROUTES[routeKey];
+  if (!route?.retryable) return false;
+  if (attemptCount >= route.maxRetries) return false;
+
+  const status = error?.status ?? error?.response?.status;
+  // Never retry on client errors
+  if (status >= 400 && status < 500) return false;
+
+  return true;
+}
+
+/**
+ * Logs a vault API warning safely (no sensitive data in the message).
+ * @param {string} routeKey - Key from VAULT_API_ROUTES
+ * @param {string} message
+ * @param {{ field?: string; fallback?: unknown }} [meta]
+ */
+export function logVaultApiWarning(routeKey, message, meta = {}) {
+  const route = VAULT_API_ROUTES[routeKey];
+  const label = route?.label ?? routeKey;
+  // Safe log: no wallet addresses, keys, or raw error stacks
+  console.warn(`[VaultAPI:${label}] ${message}`, {
+    route: route?.route ?? "unknown",
+    field: meta.field ?? null,
+    fallback: meta.fallback ?? null,
+  });
+}


### PR DESCRIPTION
  Summary

  Resolves #232, #236, #237, and #238.

  What was done

  #232 — Account security tips panel

  - Added components/app/SecurityTipsPanel.jsx with four beginner-friendly wallet/account safety tips (seed
  phrase, URL verification, transaction review, trusted bridges only).
  - Panel appears at the top of the connected account page and is dismissible — dismiss state persists in
  localStorage.
  - Links to https://docs.vaultquest.io/security for the full safety guide.
  - Integrated into app/app/account/page.jsx inside ConnectedDashboard.

  #236 — Vault API error audit

  - Added lib/vault-api-errors.js which lists all key vault API routes (vaultConfig, getAPY, balanceOf, Stellar
  Horizon, backend health) with retry policy per route.
  - Centralises standardised, user-facing error messages keyed by HTTP status and error code
  (getApiErrorMessage).
  - shouldRetry helper enforces: never retry 4xx, cap retries per route, exponential back-off intent documented.
  - logVaultApiWarning provides safe logging (no wallet addresses or raw stacks in log output).

  #238 — Vault data review checks

  - Added hooks/useVaultDataReview.js — validates vault objects against required fields (name, apy, minDeposit,
  status, totalDeposits), applies fallback values from VAULT_FIELD_FALLBACKS, and records warnings via
  logVaultApiWarning.
  - Added components/app/VaultDataWarnings.jsx — renders the warning list when data is incomplete, renders
  nothing when data is clean.
  - Integrated into app/app/vaults/page.jsx: MOCK_VAULTS is passed through useVaultDataReview; VaultDataWarnings
  displays any flagged fields above the vault list.

  #237 — Vault onboarding tour

  - Added components/app/VaultOnboardingTour.jsx — a three-step guided tour rendered as a bottom sheet overlay
  using framer-motion.
    - Step 1: Dashboard overview
    - Step 2: Vault cards explained
    - Step 3: Account page walkthrough
  - Tour shows once on first visit (tracked in localStorage). Includes Skip tour and Next / Done actions.
  - Exported useRestartTour hook so users can replay the tour from the account page.
  - Integrated into app/app/page.jsx (dashboard) and app/app/account/page.jsx (restart button at bottom of
  connected account).

  Closes

  Closes #232
  Closes #236
  Closes #237
  Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Account security tips” panel with dismiss controls and persistence.
  * Added a vault onboarding tour to the main experience, including a “Replay onboarding tour” option.
  * Added a vault data warnings panel to surface when vault data needs attention.
* **Bug Fixes**
  * Improved vault data review/validation so filtering uses the vetted dataset while keeping existing search counts consistent.
  * Reduced confusing states by applying safer fallback handling for missing or invalid data and showing clear warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->