### PR TITLE
feat(ui): add VaultEmptyState component for dashboard, vault list, and activity pages

### DIFF
--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -16,6 +16,7 @@ import WinnerCelebration from "@/components/app/WinnerCelebration";
 import PrizeCountdown from "@/components/app/PrizeCountdown";
 import FaqAccordion from "@/components/app/FaqAccordion";
 import { WalletConnectionStatus, OnboardingChecklist } from "stellar-wallet-connect";
+import VaultEmptyState from "@/components/app/VaultEmptyState";
 
 function DashboardSkeleton() {
   return (
@@ -151,6 +152,9 @@ export default function AppDashboardPage() {
         {/* Left Column */}
         <main className="space-y-8 lg:col-span-8">
           <OnboardingChecklist walletConnected={isConnected} hasJoinedVault={hasJoinedVault} />
+          {isConnected && !hasJoinedVault && (
+            <VaultEmptyState variant="dashboard" />
+          )}
           <YieldCalculator />
           <RecentWinners />
           <OnboardingCards />

--- a/app/app/vaults/page.jsx
+++ b/app/app/vaults/page.jsx
@@ -203,6 +203,7 @@ export default function VaultsPage() {
                 sortBy={filters.sortBy}
                 suggestions={generateSuggestions()}
                 onSuggestionClick={handleSuggestionClick}
+                onClearFilters={clearFilters}
               />
             ) : (
               <VaultList

--- a/components/app/VaultComparisonTable.jsx
+++ b/components/app/VaultComparisonTable.jsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { ArrowUpDown, ArrowUpRight, Wallet, Info } from "lucide-react";
+import VaultEmptyState from "@/components/app/VaultEmptyState";
 
-export default function VaultComparisonTable({ vaults = [], sortBy = "apy", suggestions = null, onSuggestionClick = null }) {
+export default function VaultComparisonTable({ vaults = [], sortBy = "apy", suggestions = null, onSuggestionClick = null, onClearFilters = null }) {
   const [sortConfig, setSortConfig] = useState({ key: sortBy, direction: "desc" });
 
   const sortedVaults = [...vaults].sort((a, b) => {
@@ -47,14 +48,10 @@ export default function VaultComparisonTable({ vaults = [], sortBy = "apy", sugg
 
   if (vaults.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-vault-surface text-vault-muted border border-vault-border">
-          <Info size={32} />
-        </div>
-        <h3 className="text-xl font-semibold text-vault-text">No vaults found</h3>
-        <p className="text-vault-muted mb-6">Try adjusting your filters to find more opportunities.</p>
+      <div className="space-y-4">
+        <VaultEmptyState variant="vaultList" onClearFilters={onClearFilters ?? undefined} />
         {suggestions && suggestions.length > 0 && (
-          <div className="max-w-md">
+          <div className="text-center">
             <p className="text-sm font-semibold text-vault-muted mb-3">Did you mean:</p>
             <div className="flex flex-wrap gap-2 justify-center">
               {suggestions.map((suggestion) => (

--- a/components/app/VaultEmptyState.jsx
+++ b/components/app/VaultEmptyState.jsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { Vault, Search, Clock, TrendingUp, ArrowRight, PlusCircle, RefreshCw } from "lucide-react";
+
+/**
+ * Reusable empty-state component for vault pages.
+ *
+ * variant options:
+ *   "dashboard"  – connected wallet, no active vault positions
+ *   "vaultList"  – filter/search returned zero results
+ *   "activity"   – connected wallet, no transaction history yet
+ */
+
+const VARIANTS = {
+  dashboard: {
+    Icon: Vault,
+    iconBg: "bg-red-500/10",
+    iconColor: "text-red-500",
+    title: "No active positions yet",
+    description:
+      "You haven't joined any prize savings vaults. Deposit to start earning yield tickets and enter weekly prize draws — your principal is always withdrawable.",
+    actions: [
+      { label: "Browse vaults", href: "/app/vaults", primary: true, Icon: ArrowRight },
+      { label: "Learn how it works", href: "/docs", primary: false, Icon: TrendingUp },
+    ],
+  },
+  vaultList: {
+    Icon: Search,
+    iconBg: "bg-blue-500/10",
+    iconColor: "text-blue-400",
+    title: "No vaults match your filters",
+    description:
+      "Try clearing some filters or broadening your search. There are active vaults available — adjust the criteria to find them.",
+    actions: [
+      { label: "Clear filters", onClick: true, primary: true, Icon: RefreshCw },
+      { label: "View all vaults", href: "/app/vaults", primary: false, Icon: ArrowRight },
+    ],
+  },
+  activity: {
+    Icon: Clock,
+    iconBg: "bg-amber-500/10",
+    iconColor: "text-amber-400",
+    title: "No activity yet",
+    description:
+      "Your deposits, withdrawals, and prize claims will appear here once you start saving. Make your first deposit to get started.",
+    actions: [
+      { label: "Make a deposit", href: "/app/vaults", primary: true, Icon: PlusCircle },
+      { label: "View vaults", href: "/app/vaults", primary: false, Icon: Vault },
+    ],
+  },
+};
+
+export default function VaultEmptyState({ variant = "dashboard", onClearFilters }) {
+  const config = VARIANTS[variant] ?? VARIANTS.dashboard;
+  const { Icon, iconBg, iconColor, title, description, actions } = config;
+
+  return (
+    <div className="vq-glass flex flex-col items-center px-6 py-16 text-center sm:px-12">
+      {/* Icon */}
+      <span
+        className={`flex h-16 w-16 items-center justify-center rounded-full border border-vault-border ring-2 ring-vault-border/30 ${iconBg} ${iconColor}`}
+      >
+        <Icon className="h-8 w-8" aria-hidden="true" />
+      </span>
+
+      {/* Copy */}
+      <h2 className="mt-6 text-xl font-semibold text-vault-text">{title}</h2>
+      <p className="mt-2 max-w-md text-sm leading-relaxed text-vault-muted">{description}</p>
+
+      {/* Actions */}
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+        {actions.map((action) => {
+          const ActionIcon = action.Icon;
+          const cls = action.primary
+            ? "vq-btn-primary inline-flex items-center gap-2"
+            : "vq-btn-ghost inline-flex items-center gap-2";
+
+          if (action.onClick) {
+            return (
+              <button key={action.label} type="button" onClick={onClearFilters} className={cls}>
+                <ActionIcon className="h-4 w-4" aria-hidden="true" />
+                {action.label}
+              </button>
+            );
+          }
+
+          return (
+            <Link key={action.label} href={action.href} className={cls}>
+              <ActionIcon className="h-4 w-4" aria-hidden="true" />
+              {action.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #227
Closes #233
Closes #234
Closes #235

## What was done

### New component — `components/app/VaultEmptyState.jsx`

A reusable empty-state component with three variants, each with a distinct icon, title, description, and clear next actions:

| Variant | Shown when | Primary CTA |
|---|---|---|
| `dashboard` | Wallet connected, no vault positions | Browse vaults |
| `vaultList` | Filter/search returns zero results | Clear filters |
| `activity` | Wallet connected, no transaction history | Make a deposit |

The component follows the existing design system (`vq-glass`, `vq-btn-primary`, `vq-btn-ghost`, `vault-*` colour tokens) and is fully accessible with `aria-hidden` on decorative icons.

### Dashboard page (`app/app/page.jsx`)

Renders `<VaultEmptyState variant="dashboard" />` between the onboarding checklist and the yield calculator when the user is connected but has no vault positions (`isConnected && !hasJoinedVault`). Gives new users a clear prompt to explore vaults instead of a blank content area.

### Vault list (`components/app/VaultComparisonTable.jsx` + `app/app/vaults/page.jsx`)

Replaces the previous inline empty `<div>` (plain text, no action) with `<VaultEmptyState variant="vaultList" />`. The existing "Did you mean" suggestions are preserved below the empty state. Passes `onClearFilters` from `vaults/page.jsx` so the "Clear filters" button works end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable empty-state experience for vault pages, with tailored views for the dashboard and vault list.
  * The dashboard now shows an empty-state message when a connected wallet hasn’t joined a vault yet.
  * The vault comparison view can now clear active filters directly from the empty-state screen.

* **Bug Fixes**
  * Improved the “no vaults found” experience by replacing custom fallback content with a consistent shared layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->