### PR TITLE
[codex] Add vault engagement placeholders and docs links

### DIFF
--- a/app/app/notifications/page.jsx
+++ b/app/app/notifications/page.jsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Bell, Check, CheckCircle2, Clock, Inbox, MailOpen } from "lucide-react";
+
+const NOTIFICATIONS = [
+  {
+    id: "notif-001",
+    title: "Weekly draw completed",
+    vault: "USDC Stable Pool",
+    date: "2026-06-24T18:30:00.000Z",
+    status: "unread",
+    type: "Prize draw",
+    message: "Prize winners were selected and the next round is now open.",
+  },
+  {
+    id: "notif-002",
+    title: "Deposit confirmed",
+    vault: "ETH Growth Pool",
+    date: "2026-06-24T15:10:00.000Z",
+    status: "read",
+    type: "Deposit",
+    message: "Your 0.42 ETH deposit was confirmed and tickets were updated.",
+  },
+  {
+    id: "notif-003",
+    title: "Vault APY updated",
+    vault: "XLM Drip Vault",
+    date: "2026-06-21T09:20:00.000Z",
+    status: "unread",
+    type: "Vault update",
+    message: "Projected APY changed after the latest strategy rebalance.",
+  },
+  {
+    id: "notif-004",
+    title: "Withdrawal window opened",
+    vault: "BTC Reserve",
+    date: "2026-06-18T12:00:00.000Z",
+    status: "read",
+    type: "Account",
+    message: "Your lockup period ended and principal is available to withdraw.",
+  },
+];
+
+function formatDateLabel(dateValue) {
+  return new Date(dateValue).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatTime(dateValue) {
+  return new Date(dateValue).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function VaultNotificationsPage() {
+  const [readIds, setReadIds] = useState(() =>
+    new Set(NOTIFICATIONS.filter((notification) => notification.status === "read").map((notification) => notification.id))
+  );
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+
+  const notifications = useMemo(() => {
+    return NOTIFICATIONS.map((notification) => ({
+      ...notification,
+      status: readIds.has(notification.id) ? "read" : "unread",
+    }));
+  }, [readIds]);
+
+  const visibleNotifications = useMemo(() => {
+    if (!showUnreadOnly) return notifications;
+    return notifications.filter((notification) => notification.status === "unread");
+  }, [notifications, showUnreadOnly]);
+
+  const groupedNotifications = useMemo(() => {
+    return visibleNotifications.reduce((groups, notification) => {
+      const label = formatDateLabel(notification.date);
+      if (!groups[label]) groups[label] = [];
+      groups[label].push(notification);
+      return groups;
+    }, {});
+  }, [visibleNotifications]);
+
+  const unreadCount = notifications.filter((notification) => notification.status === "unread").length;
+
+  const markRead = (id) => {
+    setReadIds((current) => {
+      const next = new Set(current);
+      next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-3 text-red-500">
+            <Bell className="h-7 w-7" aria-hidden="true" />
+            <h1 className="text-3xl font-bold text-vault-text">Vault Notifications</h1>
+          </div>
+          <p className="mt-2 max-w-2xl text-vault-muted">
+            Review past vault notices, status changes, deposits, draw updates, and account reminders.
+          </p>
+        </div>
+        <Link href="/app/activity" className="vq-btn-ghost self-start sm:self-auto">
+          View activity
+        </Link>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-3" aria-label="Notification summary">
+        <div className="vq-glass-hover p-5">
+          <Inbox className="h-5 w-5 text-red-500" aria-hidden="true" />
+          <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-vault-muted">Total notifications</p>
+          <p className="mt-1 text-2xl font-bold text-vault-text">{notifications.length}</p>
+        </div>
+        <div className="vq-glass-hover p-5">
+          <MailOpen className="h-5 w-5 text-amber-500" aria-hidden="true" />
+          <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-vault-muted">Unread</p>
+          <p className="mt-1 text-2xl font-bold text-vault-text">{unreadCount}</p>
+        </div>
+        <div className="vq-glass-hover p-5">
+          <CheckCircle2 className="h-5 w-5 text-emerald-500" aria-hidden="true" />
+          <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-vault-muted">Read</p>
+          <p className="mt-1 text-2xl font-bold text-vault-text">{notifications.length - unreadCount}</p>
+        </div>
+      </section>
+
+      <section className="vq-glass p-4 sm:p-6" aria-labelledby="notification-history-title">
+        <div className="flex flex-col gap-4 border-b border-vault-border pb-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 id="notification-history-title" className="text-lg font-semibold text-vault-text">
+              Notification History
+            </h2>
+            <p className="text-sm text-vault-muted">Grouped by date with current read status.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowUnreadOnly((current) => !current)}
+            className="vq-btn-ghost self-start sm:self-auto"
+          >
+            {showUnreadOnly ? "Show all" : "Unread only"}
+          </button>
+        </div>
+
+        {visibleNotifications.length === 0 ? (
+          <div className="flex flex-col items-center px-4 py-16 text-center">
+            <CheckCircle2 className="h-10 w-10 text-vault-muted" aria-hidden="true" />
+            <h3 className="mt-4 text-lg font-semibold text-vault-text">No notifications to show</h3>
+            <p className="mt-2 max-w-md text-sm text-vault-muted">
+              Empty states will appear when a user has no history or when filters hide every notification.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6 pt-5">
+            {Object.entries(groupedNotifications).map(([dateLabel, items]) => (
+              <div key={dateLabel}>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-vault-muted">{dateLabel}</h3>
+                <ul className="mt-3 divide-y divide-vault-border rounded-xl border border-vault-border bg-vault-surface/30" role="list">
+                  {items.map((notification) => {
+                    const isRead = notification.status === "read";
+                    return (
+                      <li key={notification.id} className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="flex gap-3">
+                          <span className={`mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-vault-border ${isRead ? "bg-vault-surface text-vault-muted" : "bg-red-500/10 text-red-500"}`}>
+                            {isRead ? <Check className="h-4 w-4" aria-hidden="true" /> : <Bell className="h-4 w-4" aria-hidden="true" />}
+                          </span>
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="font-semibold text-vault-text">{notification.title}</p>
+                              <span className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${isRead ? "border-vault-border text-vault-muted" : "border-red-400/30 bg-red-500/10 text-red-500"}`}>
+                                {isRead ? "Read" : "Unread"}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-sm text-vault-muted">{notification.message}</p>
+                            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-vault-muted">
+                              <span>{notification.type}</span>
+                              <span aria-hidden="true">·</span>
+                              <span>{notification.vault}</span>
+                              <span aria-hidden="true">·</span>
+                              <span className="inline-flex items-center gap-1">
+                                <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+                                {formatTime(notification.date)}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        {!isRead && (
+                          <button
+                            type="button"
+                            onClick={() => markRead(notification.id)}
+                            className="vq-btn-primary w-full sm:w-auto"
+                          >
+                            <Check className="h-4 w-4" aria-hidden="true" />
+                            Mark read
+                          </button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -20,6 +20,8 @@ import VaultEmptyState from "@/components/app/VaultEmptyState";
 import VaultOnboardingTour from "@/components/app/VaultOnboardingTour";
 import VaultGoalTracker from "@/components/app/VaultGoalTracker";
 import VaultRewardsExplanationModal from "@/components/app/VaultRewardsExplanationModal";
+import VaultDocsQuickLinks from "@/components/app/VaultDocsQuickLinks";
+import VaultLeaderboardPlaceholder from "@/components/app/VaultLeaderboardPlaceholder";
 
 function DashboardSkeleton() {
   return (
@@ -162,6 +164,8 @@ export default function AppDashboardPage() {
           )}
           <YieldCalculator />
           <RecentWinners />
+          <VaultLeaderboardPlaceholder />
+          <VaultDocsQuickLinks />
           <OnboardingCards />
           <FaqAccordion />
         </main>

--- a/app/app/vaults/[id]/page.jsx
+++ b/app/app/vaults/[id]/page.jsx
@@ -14,7 +14,10 @@ import {
   AlertCircle,
   Copy,
   Check,
-  Server
+  CircleDollarSign,
+  Clock,
+  Server,
+  Ticket,
 } from "lucide-react";
 import { MOCK_VAULTS } from "@/components/app/VaultList";
 import DepositModal from "@/components/app/DepositModal";
@@ -22,6 +25,39 @@ import RoundStatusBadge from "@/components/app/RoundStatusBadge";
 import VaultHealthStatusPanel from "@/components/app/VaultHealthStatusPanel";
 import VaultRewardsExplanationModal from "@/components/app/VaultRewardsExplanationModal";
 import VaultKeyboardNavAudit from "@/components/app/VaultKeyboardNavAudit";
+import VaultDocsQuickLinks from "@/components/app/VaultDocsQuickLinks";
+
+function MetricTile({ label, value, tone = "default" }) {
+  const toneClass = tone === "success" ? "text-emerald-600 dark:text-emerald-400" : "text-vault-text";
+
+  return (
+    <div className="rounded-xl border border-vault-border bg-vault-surface/40 p-4">
+      <p className="text-xs font-bold uppercase tracking-wide text-vault-muted">{label}</p>
+      <p className={`mt-1.5 text-xl font-black sm:text-2xl ${toneClass}`}>{value}</p>
+    </div>
+  );
+}
+
+function DetailSection({ icon: Icon, title, description, children }) {
+  const titleId = `${title.toLowerCase().replace(/\s+/g, "-")}-title`;
+
+  return (
+    <section className="vq-glass space-y-5 p-4 sm:p-6" aria-labelledby={titleId}>
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-red-500">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <h2 id={titleId} className="text-lg font-bold text-vault-text">
+            {title}
+          </h2>
+          {description && <p className="mt-1 text-sm text-vault-muted">{description}</p>}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
 
 function DetailSkeleton() {
   return (
@@ -163,44 +199,44 @@ export default function VaultDetailPage({ params }) {
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
         {/* Left Column: Metrics & Estimator */}
         <main className="space-y-8 lg:col-span-8">
-          {/* Key Metrics Section */}
-          <section className="vq-glass p-6 space-y-6" aria-label="Vault stats">
-            <h3 className="text-lg font-bold text-vault-text flex items-center gap-2">
-              <Coins className="h-5 w-5 text-red-500" /> Vault Key Metrics
-            </h3>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="vq-glass bg-vault-surface/40 p-4 border border-vault-border/50">
-                <p className="text-xs font-bold uppercase tracking-wider text-vault-muted">Est. APY</p>
-                <p className="mt-1.5 text-2xl font-black text-emerald-500">{vault.apy}%</p>
+          <DetailSection
+            icon={Coins}
+            title="Vault Data Overview"
+            description="Key vault data grouped for faster review before depositing."
+          >
+            <div className="space-y-5">
+              <div>
+                <h3 className="text-sm font-semibold text-vault-text">Performance</h3>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <MetricTile label="Est. APY" value={`${vault.apy}%`} tone="success" />
+                  <MetricTile label="Deposits (TVL)" value={`$${(vault.tvl / 1000000).toFixed(2)}M`} />
+                </div>
               </div>
 
-              <div className="vq-glass bg-vault-surface/40 p-4 border border-vault-border/50">
-                <p className="text-xs font-bold uppercase tracking-wider text-vault-muted">Deposits (TVL)</p>
-                <p className="mt-1.5 text-2xl font-black text-vault-text">
-                  ${(vault.tvl / 1000000).toFixed(2)}M
-                </p>
+              <div>
+                <h3 className="text-sm font-semibold text-vault-text">Access</h3>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <MetricTile label="Lockup Period" value={vault.lockup === 0 ? "Flexible" : `${vault.lockup} Days`} />
+                  <MetricTile label="Slippage Tier" value="0.10%" />
+                </div>
               </div>
 
-              <div className="vq-glass bg-vault-surface/40 p-4 border border-vault-border/50">
-                <p className="text-xs font-bold uppercase tracking-wider text-vault-muted">Lockup Period</p>
-                <p className="mt-1.5 text-2xl font-black text-vault-text">
-                  {vault.lockup === 0 ? "Flexible" : `${vault.lockup} Days`}
-                </p>
-              </div>
-
-              <div className="vq-glass bg-vault-surface/40 p-4 border border-vault-border/50">
-                <p className="text-xs font-bold uppercase tracking-wider text-vault-muted">Slippage Tier</p>
-                <p className="mt-1.5 text-2xl font-black text-vault-text">0.10%</p>
+              <div>
+                <h3 className="text-sm font-semibold text-vault-text">Round State</h3>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <MetricTile label="Network" value={vault.network} />
+                  <MetricTile label="Strategy" value={vault.strategy} />
+                </div>
               </div>
             </div>
-          </section>
+          </DetailSection>
 
           {/* Dynamic Estimator */}
-          <section className="vq-glass p-6 space-y-6" aria-label="Interactive yield estimator">
-            <div className="flex items-center gap-2">
-              <Calculator className="h-5 w-5 text-red-500" />
-              <h3 className="text-lg font-bold text-vault-text">Vault Yield Projection</h3>
-            </div>
+          <DetailSection
+            icon={Calculator}
+            title="Vault Yield Projection"
+            description="Estimate how much yield your principal could generate over time."
+          >
             <p className="text-sm text-vault-muted">
               Enter a custom deposit amount below to see the estimated non-loss yields generated by your principal over time.
             </p>
@@ -236,13 +272,14 @@ export default function VaultDetailPage({ params }) {
                 </div>
               </div>
             </div>
-          </section>
+          </DetailSection>
 
           {/* Technical Specs */}
-          <section className="vq-glass p-6 space-y-4" aria-label="Technical details">
-            <h3 className="text-lg font-bold text-vault-text flex items-center gap-2">
-              <Server className="h-5 w-5 text-red-500" /> Contract Specifications
-            </h3>
+          <DetailSection
+            icon={Server}
+            title="Contract Specifications"
+            description="Operational contract data and audit context for this vault."
+          >
             <div className="divide-y divide-vault-border/30 text-sm">
               <div className="py-3 flex justify-between gap-4">
                 <span className="text-vault-muted">Contract Standard</span>
@@ -267,32 +304,64 @@ export default function VaultDetailPage({ params }) {
                 </div>
               </div>
             </div>
-          </section>
+          </DetailSection>
+
+          <VaultDocsQuickLinks />
         </main>
 
         {/* Right Column: Account metrics & CTAs */}
         <aside className="space-y-8 lg:col-span-4">
           <VaultHealthStatusPanel />
-          <section className="vq-glass p-6 space-y-6 relative overflow-hidden group">
+          <section className="vq-glass p-4 sm:p-6 space-y-6 relative overflow-hidden group">
             <div className="absolute -right-20 -top-20 h-40 w-40 rounded-full bg-red-500/10 blur-[80px]" />
-            <h3 className="text-lg font-bold text-vault-text flex items-center gap-2">
-              <Shield className="h-5 w-5 text-red-500" /> Your Positions
-            </h3>
+            <div>
+              <h2 className="text-lg font-bold text-vault-text flex items-center gap-2">
+                <Shield className="h-5 w-5 text-red-500" /> Your Position Data
+              </h2>
+              <p className="mt-1 text-sm text-vault-muted">
+                Wallet-specific vault metrics load after connection.
+              </p>
+            </div>
 
             {isConnected ? (
               <div className="space-y-6">
-                <div className="space-y-4">
-                  <div className="flex justify-between items-center text-sm">
-                    <span className="text-vault-muted">Your Deposits</span>
-                    <span className="font-bold text-vault-text">1,250.00 {vault.asset}</span>
+                <div className="grid gap-3">
+                  <div className="rounded-xl border border-vault-border bg-vault-surface/40 p-4">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-vault-text">
+                      <CircleDollarSign className="h-4 w-4 text-red-500" aria-hidden="true" />
+                      Balance
+                    </div>
+                    <div className="mt-3 flex justify-between items-center text-sm">
+                      <span className="text-vault-muted">Your Deposits</span>
+                      <span className="font-bold text-vault-text">1,250.00 {vault.asset}</span>
+                    </div>
                   </div>
-                  <div className="flex justify-between items-center text-sm">
-                    <span className="text-vault-muted">Active Tickets</span>
-                    <span className="font-bold text-vault-text">125 tickets</span>
+
+                  <div className="rounded-xl border border-vault-border bg-vault-surface/40 p-4">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-vault-text">
+                      <Ticket className="h-4 w-4 text-red-500" aria-hidden="true" />
+                      Draw Eligibility
+                    </div>
+                    <div className="mt-3 space-y-2">
+                      <div className="flex justify-between items-center text-sm">
+                        <span className="text-vault-muted">Active Tickets</span>
+                        <span className="font-bold text-vault-text">125 tickets</span>
+                      </div>
+                      <div className="flex justify-between items-center text-sm">
+                        <span className="text-vault-muted">Draw Win Chance</span>
+                        <span className="font-bold text-emerald-500">~ 0.023%</span>
+                      </div>
+                    </div>
                   </div>
-                  <div className="flex justify-between items-center text-sm">
-                    <span className="text-vault-muted">Draw Win Chance</span>
-                    <span className="font-bold text-emerald-500">~ 0.023%</span>
+
+                  <div className="rounded-xl border border-dashed border-vault-border bg-vault-bg/30 p-4">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-vault-text">
+                      <Clock className="h-4 w-4 text-vault-muted" aria-hidden="true" />
+                      History
+                    </div>
+                    <p className="mt-2 text-sm text-vault-muted">
+                      No user-specific vault events are loaded in this placeholder account view.
+                    </p>
                   </div>
                 </div>
 

--- a/app/docs/page.jsx
+++ b/app/docs/page.jsx
@@ -17,7 +17,7 @@ export default function ProtocolDocsPage() {
       </div>
 
       <div className="space-y-16">
-        <section className="space-y-6">
+        <section id="product-overview" className="scroll-mt-24 space-y-6">
           <h2 className="flex items-center gap-2 text-2xl font-semibold text-vault-text">
             <Shield className="text-vault-accent" /> Product Overview
           </h2>
@@ -36,7 +36,7 @@ export default function ProtocolDocsPage() {
           </div>
         </section>
 
-        <section className="space-y-6">
+        <section id="round-lifecycle" className="scroll-mt-24 space-y-6">
           <h2 className="flex items-center gap-2 text-2xl font-semibold text-vault-text">
             <RefreshCw className="text-vault-accent" /> Round Lifecycle
           </h2>

--- a/components/app/AppNav.jsx
+++ b/components/app/AppNav.jsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { Contrast, Gift, Menu, Server, User, Wallet, X, Activity, Shield } from "lucide-react";
+import { Bell, Contrast, Gift, Menu, Server, User, Wallet, X, Activity, Shield } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
 import BalanceAutoRefresh from "./BalanceAutoRefresh";
@@ -17,6 +17,7 @@ const LINKS = [
   { href: "/app/vaults", label: "Vaults", icon: Wallet },
   { href: "/app/account", label: "Account", icon: User },
   { href: "/app/activity", label: "Activity", icon: Activity },
+  { href: "/app/notifications", label: "Notifications", icon: Bell },
   { href: "/app/trust", label: "Trust", icon: Shield },
   { href: "/app/admin/proposals", label: "Admin", icon: Menu },
 ];

--- a/components/app/VaultDocsQuickLinks.jsx
+++ b/components/app/VaultDocsQuickLinks.jsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, BookOpen, Code, FileText, Shield } from "lucide-react";
+
+const DOC_GROUPS = [
+  {
+    topic: "Product",
+    icon: Shield,
+    links: [
+      { label: "Protocol overview", href: "/docs#product-overview" },
+      { label: "Round lifecycle", href: "/docs#round-lifecycle" },
+    ],
+  },
+  {
+    topic: "Operations",
+    icon: FileText,
+    links: [
+      { label: "Indexer runbook", href: "https://github.com/Obiajulu-gif/vaultquest/blob/main/docs/INDEXER_RUNBOOK.md" },
+      { label: "State model", href: "https://github.com/Obiajulu-gif/vaultquest/blob/main/docs/STATE_MODEL.md" },
+    ],
+  },
+  {
+    topic: "Developers",
+    icon: Code,
+    links: [
+      { label: "API notes", href: "https://github.com/Obiajulu-gif/vaultquest/blob/main/docs/API.md" },
+      { label: "Testing guide", href: "https://github.com/Obiajulu-gif/vaultquest/blob/main/docs/TESTING.md" },
+    ],
+  },
+];
+
+export default function VaultDocsQuickLinks({ compact = false }) {
+  return (
+    <section className="vq-glass p-4 sm:p-6" aria-labelledby="vault-docs-title">
+      <div className="flex items-start gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-red-500">
+          <BookOpen className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <h2 id="vault-docs-title" className="text-lg font-bold text-vault-text">
+            Vault Documentation
+          </h2>
+          <p className="mt-1 text-sm text-vault-muted">
+            Quick links for savers, operators, and contributors.
+          </p>
+        </div>
+      </div>
+
+      <div className={`mt-5 grid gap-4 ${compact ? "grid-cols-1" : "sm:grid-cols-3"}`}>
+        {DOC_GROUPS.map(({ topic, icon: Icon, links }) => (
+          <div key={topic} className="rounded-xl border border-vault-border bg-vault-surface/40 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-vault-text">
+              <Icon className="h-4 w-4 text-red-500" aria-hidden="true" />
+              {topic}
+            </div>
+            <div className="mt-3 flex flex-col gap-2">
+              {links.map((link) => {
+                const external = link.href.startsWith("http");
+                return (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    target={external ? "_blank" : undefined}
+                    rel={external ? "noreferrer" : undefined}
+                    className="flex min-h-10 items-center justify-between gap-3 rounded-lg border border-vault-border/60 bg-vault-bg/30 px-3 py-2 text-sm font-medium text-vault-text transition-colors hover:border-red-400/40 hover:text-red-500"
+                  >
+                    <span>{link.label}</span>
+                    <ArrowUpRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/app/VaultKeyboardNavAudit.jsx
+++ b/components/app/VaultKeyboardNavAudit.jsx
@@ -13,6 +13,7 @@ import {
   LayoutDashboard,
   FileText,
   Menu,
+  RefreshCw,
 } from "lucide-react";
 
 const AUDIT_CHECKS = [

--- a/components/app/VaultLeaderboardPlaceholder.jsx
+++ b/components/app/VaultLeaderboardPlaceholder.jsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Award, Info, Minus, TrendingUp, UserPlus } from "lucide-react";
+
+const SAMPLE_RANKINGS = [
+  {
+    rank: 1,
+    name: "0xA17...92C",
+    vault: "USDC Stable Pool",
+    engagement: "14 deposits",
+    score: "9,840 pts",
+    state: "rising",
+  },
+  {
+    rank: 2,
+    name: "0x91B...E10",
+    vault: "ETH Growth Pool",
+    engagement: "8 week streak",
+    score: "8,120 pts",
+    state: "holding",
+  },
+  {
+    rank: 3,
+    name: "New saver",
+    vault: "XLM Drip Vault",
+    engagement: "First deposit",
+    score: "Pending",
+    state: "new",
+  },
+];
+
+const STATE_STYLES = {
+  rising: {
+    label: "Rising",
+    icon: TrendingUp,
+    className: "text-emerald-600 dark:text-emerald-400",
+  },
+  holding: {
+    label: "Holding",
+    icon: Minus,
+    className: "text-vault-muted",
+  },
+  new: {
+    label: "New",
+    icon: UserPlus,
+    className: "text-blue-600 dark:text-blue-400",
+  },
+};
+
+export default function VaultLeaderboardPlaceholder({ rankings = SAMPLE_RANKINGS }) {
+  const hasRankings = rankings.length > 0;
+
+  return (
+    <section className="vq-glass p-4 sm:p-6" aria-labelledby="vault-leaderboard-title">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-vault-border bg-vault-surface text-amber-500">
+            <Award className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h2 id="vault-leaderboard-title" className="text-lg font-bold text-vault-text">
+              Vault Leaderboard
+            </h2>
+            <p className="mt-1 text-sm text-vault-muted">
+              Placeholder ranking model for future vault engagement features.
+            </p>
+          </div>
+        </div>
+        <span className="self-start rounded-full border border-vault-border bg-vault-surface px-3 py-1 text-xs font-semibold text-vault-muted">
+          Preview data
+        </span>
+      </div>
+
+      {hasRankings ? (
+        <div className="mt-5 space-y-3">
+          {rankings.map((ranking) => {
+            const state = STATE_STYLES[ranking.state] || STATE_STYLES.holding;
+            const Icon = state.icon;
+            return (
+              <div
+                key={`${ranking.rank}-${ranking.name}`}
+                className="grid gap-3 rounded-xl border border-vault-border bg-vault-surface/40 p-4 sm:grid-cols-[auto_1fr_auto]"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full border border-vault-border bg-vault-bg text-sm font-black text-vault-text">
+                  #{ranking.rank}
+                </div>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-semibold text-vault-text">{ranking.name}</p>
+                    <span className={`inline-flex items-center gap-1 text-xs font-semibold ${state.className}`}>
+                      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                      {state.label}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-vault-muted">
+                    {ranking.vault} · {ranking.engagement}
+                  </p>
+                </div>
+                <p className="text-left font-bold text-vault-text sm:text-right">{ranking.score}</p>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-5 flex flex-col items-center rounded-xl border border-dashed border-vault-border bg-vault-surface/30 px-4 py-10 text-center">
+          <Info className="h-8 w-8 text-vault-muted" aria-hidden="true" />
+          <h3 className="mt-3 text-base font-semibold text-vault-text">No leaderboard activity yet</h3>
+          <p className="mt-1 max-w-md text-sm text-vault-muted">
+            Rankings will appear after engagement scoring, wallet identity, and vault participation data are connected.
+          </p>
+        </div>
+      )}
+
+      <div className="mt-5 rounded-xl border border-vault-border bg-vault-bg/30 p-4">
+        <h3 className="text-sm font-semibold text-vault-text">Future data requirements</h3>
+        <ul className="mt-2 space-y-1 text-sm text-vault-muted">
+          <li>Wallet identity, vault ID, score, rank delta, and eligibility status.</li>
+          <li>Deposit streaks, ticket counts, prize participation, and last activity timestamp.</li>
+          <li>Privacy controls for anonymized names and opt-in public rankings.</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/docs/VAULT_ENGAGEMENT_DATA.md
+++ b/docs/VAULT_ENGAGEMENT_DATA.md
@@ -1,0 +1,17 @@
+# Vault Engagement Data Requirements
+
+The leaderboard and notification history UI added for vault engagement uses sample data until live services are available.
+
+## Leaderboard
+
+- Wallet identifier or anonymized display name.
+- Vault ID, asset, network, and eligibility status.
+- Rank, previous rank, rank delta, and score.
+- Engagement inputs such as deposit streaks, tickets, prize participation, referrals, and last activity timestamp.
+- Privacy preference for public display.
+
+## Notifications
+
+- Notification ID, wallet ID, vault ID, title, body, type, status, created timestamp, and read timestamp.
+- Delivery channel metadata for in-app, email, push, or wallet-message notifications.
+- Retention policy and pagination cursor for history views.


### PR DESCRIPTION
## Summary
- Add a dashboard leaderboard placeholder with sample ranking states, empty-state copy, and future engagement data requirements.
- Improve vault detail data layout with grouped metrics, section headings, mobile spacing, loading/not-found handling, and position empty history copy.
- Add a vault notification history page with date grouping, read/unread status, mark-read action, filtering, and empty state.
- Add grouped VaultQuest documentation quick links on the dashboard and vault detail pages.

Closes #302.
Closes #303.
Closes #304.
Closes #305.

## Validation
- pnpm lint: passes with existing hook dependency warnings in app/app/vaults/page.jsx and components/app/SystemStatusBanner.jsx.
- pnpm test: 62 tests pass; stellar-wallet-connect/src/core/horizonPool.test.ts fails during import analysis because @creit.tech/stellar-wallets-kit does not export ./modules/ledger.module.
- pnpm build: blocked by existing workspace package resolution for stellar-wallet-connect and .js relative imports inside stellar-wallet-connect/src/components/NetworkDiagnostics.tsx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Notifications page with unread/all filtering, read status actions, grouped dates, summary counts, and empty states.
  * Added dashboard preview sections for a leaderboard and documentation quick links.
  * Expanded vault detail pages with clearer overview, yield, technical info, and position sections.

* **Documentation**
  * Added anchor links for key docs sections.
  * Added guidance for vault engagement and notification data fields.

* **Bug Fixes**
  * Improved navigation with a direct link to Notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->