### PR TITLE
feat: vault liquidity warning, fee breakdown, activity export, and action checklist

### DIFF
--- a/components/app/VaultActionChecklist.jsx
+++ b/components/app/VaultActionChecklist.jsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { CheckSquare, Square, AlertTriangle, Receipt, Wallet, Info } from "lucide-react";
+
+/**
+ * VaultActionChecklist — pre-confirmation checklist for major vault actions.
+ *
+ * Forces users to acknowledge key details before submitting a transaction.
+ *
+ * Props:
+ *   action        string  — human-readable action label (e.g. "Withdraw 500 USDC")
+ *   balanceBefore string  — wallet balance before the action
+ *   balanceAfter  string  — estimated wallet balance after the action
+ *   feeEstimate   string  — fee estimate string (e.g. "~0.001 XLM"), or null
+ *   onConfirm     fn      — called when all items are checked and user presses confirm
+ *   onCancel      fn      — called when user cancels
+ *   loading       boolean — disables the confirm button while a tx is in flight
+ */
+
+const CHECKLIST_ITEMS = [
+  { id: "action", label: "I have reviewed the action summary above." },
+  { id: "balance", label: "I understand the balance impact shown." },
+  { id: "fees", label: "I accept the estimated fee." },
+  { id: "irreversible", label: "I understand on-chain actions cannot be reversed." },
+];
+
+export default function VaultActionChecklist({
+  action = "Vault action",
+  balanceBefore = null,
+  balanceAfter = null,
+  feeEstimate = null,
+  onConfirm,
+  onCancel,
+  loading = false,
+}) {
+  const [checked, setChecked] = useState(() => Object.fromEntries(CHECKLIST_ITEMS.map((i) => [i.id, false])));
+
+  const allChecked = CHECKLIST_ITEMS.every((i) => checked[i.id]);
+
+  function toggle(id) {
+    setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+  }
+
+  return (
+    <div className="vq-glass space-y-5 p-5 sm:p-6">
+      {/* Action summary */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <Info className="h-4 w-4 text-vault-accent" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-vault-text">Action summary</h3>
+        </div>
+        <div className="rounded-xl border border-vault-border bg-vault-bg/40 px-4 py-3">
+          <p className="text-sm font-medium text-vault-text">{action}</p>
+        </div>
+      </div>
+
+      {/* Balance impact */}
+      {(balanceBefore != null || balanceAfter != null) && (
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <Wallet className="h-4 w-4 text-vault-accent" aria-hidden="true" />
+            <h3 className="text-sm font-semibold text-vault-text">Balance impact</h3>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-xl border border-vault-border bg-vault-bg/40 px-4 py-3 text-center">
+              <p className="text-xs text-vault-muted mb-1">Before</p>
+              <p className="text-sm font-semibold text-vault-text tabular-nums">{balanceBefore ?? "—"}</p>
+            </div>
+            <div className="rounded-xl border border-vault-border bg-vault-bg/40 px-4 py-3 text-center">
+              <p className="text-xs text-vault-muted mb-1">After</p>
+              <p className="text-sm font-semibold text-vault-accent tabular-nums">{balanceAfter ?? "—"}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Fee estimate */}
+      <div>
+        <div className="flex items-center gap-2 mb-3">
+          <Receipt className="h-4 w-4 text-vault-accent" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-vault-text">Fee estimate</h3>
+        </div>
+        <div className="rounded-xl border border-vault-border bg-vault-bg/40 px-4 py-3 flex items-center justify-between">
+          <p className="text-xs text-vault-muted">Estimated network fee</p>
+          <p className="text-sm font-semibold text-vault-text tabular-nums">
+            {feeEstimate ?? <span className="text-vault-muted">Unavailable</span>}
+          </p>
+        </div>
+      </div>
+
+      {/* Confirmation checklist */}
+      <fieldset>
+        <legend className="mb-3 flex items-center gap-2 text-sm font-semibold text-vault-text">
+          <AlertTriangle className="h-4 w-4 text-amber-400" aria-hidden="true" />
+          Please confirm before submitting
+        </legend>
+        <ul className="space-y-2" role="list">
+          {CHECKLIST_ITEMS.map((item) => (
+            <li key={item.id}>
+              <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-vault-border bg-vault-bg/30 px-4 py-3 transition-colors hover:bg-vault-surface/60">
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked[item.id]}
+                  onChange={() => toggle(item.id)}
+                  aria-label={item.label}
+                />
+                {checked[item.id] ? (
+                  <CheckSquare className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" aria-hidden="true" />
+                ) : (
+                  <Square className="mt-0.5 h-4 w-4 shrink-0 text-vault-muted" aria-hidden="true" />
+                )}
+                <span className="text-sm text-vault-text">{item.label}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </fieldset>
+
+      {/* Actions */}
+      <div className="flex gap-3 pt-1">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 rounded-xl border border-vault-border bg-vault-surface px-4 py-2.5 text-sm font-semibold text-vault-text transition-colors hover:bg-white/5 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={!allChecked || loading}
+          className="flex-1 rounded-xl bg-vault-accent px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {loading ? "Submitting…" : "Confirm & Submit"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/app/VaultActivityExport.jsx
+++ b/components/app/VaultActivityExport.jsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { Download, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+
+/**
+ * VaultActivityExport — client-side export of vault activity records.
+ *
+ * Generates a CSV or JSON file from the provided `activities` array and
+ * triggers a browser download. No API call required.
+ *
+ * Props:
+ *   activities  Array of activity objects (required)
+ *   filename    Base filename without extension (default "vault-activity")
+ */
+
+const FIELDS = ["id", "type", "pool", "asset", "amount", "date", "status"];
+
+function toCsv(activities) {
+  const header = FIELDS.join(",");
+  const rows = activities.map((a) =>
+    FIELDS.map((f) => {
+      const v = a[f] ?? "";
+      const str = String(v);
+      return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+    }).join(",")
+  );
+  return [header, ...rows].join("\r\n") + "\r\n";
+}
+
+function download(content, filename, mime) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function VaultActivityExport({ activities = [], filename = "vault-activity" }) {
+  const [format, setFormat] = useState("csv");
+  const [status, setStatus] = useState("idle"); // idle | loading | success | error
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleExport = () => {
+    if (!activities.length) {
+      setStatus("error");
+      setErrorMsg("No activity records to export.");
+      return;
+    }
+
+    setStatus("loading");
+    try {
+      if (format === "csv") {
+        download(toCsv(activities), `${filename}.csv`, "text/csv");
+      } else {
+        download(JSON.stringify(activities, null, 2), `${filename}.json`, "application/json");
+      }
+      setStatus("success");
+    } catch {
+      setStatus("error");
+      setErrorMsg("Export failed. Please try again.");
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-vault-border bg-vault-surface/60 p-5">
+      <h3 className="text-sm font-semibold text-vault-text">Export activity</h3>
+      <p className="mt-1 text-xs text-vault-muted">
+        Download your vault history including action type, date, and amount.
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-end gap-3">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="vae-format" className="text-xs font-medium text-vault-muted">
+            Format
+          </label>
+          <select
+            id="vae-format"
+            value={format}
+            onChange={(e) => { setFormat(e.target.value); setStatus("idle"); }}
+            className="rounded-lg border border-vault-border bg-vault-bg px-3 py-2 text-sm text-vault-text focus:outline-none focus:ring-2 focus:ring-vault-accent"
+          >
+            <option value="csv">CSV</option>
+            <option value="json">JSON</option>
+          </select>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={status === "loading"}
+          className="inline-flex items-center gap-2 rounded-xl bg-vault-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {status === "loading" ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="h-4 w-4" aria-hidden="true" />
+          )}
+          {status === "loading" ? "Exporting…" : "Export"}
+        </button>
+      </div>
+
+      {status === "success" && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-sm text-emerald-400">
+          <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>Downloaded <span className="font-mono">{filename}.{format}</span> successfully.</span>
+        </div>
+      )}
+
+      {status === "error" && (
+        <div role="alert" className="mt-3 flex items-center gap-2 rounded-lg bg-red-500/10 px-3 py-2 text-sm text-red-400">
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{errorMsg}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/app/VaultFeeBreakdown.jsx
+++ b/components/app/VaultFeeBreakdown.jsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Info, AlertCircle, Zap, Building2, Receipt } from "lucide-react";
+
+/**
+ * VaultFeeBreakdown — displays a structured fee estimate before vault actions.
+ *
+ * Props:
+ *   networkFee      string | null  — estimated network / gas fee (e.g. "~0.001 XLM")
+ *   platformFeePct  number | null  — platform fee as a percentage (e.g. 0.5 for 0.5 %)
+ *   amount          number | null  — action amount used to compute platform fee total
+ *   currency        string         — display currency label (default "USDC")
+ *   unavailable     boolean        — show the "fee data unavailable" state
+ */
+export default function VaultFeeBreakdown({
+  networkFee = null,
+  platformFeePct = null,
+  amount = null,
+  currency = "USDC",
+  unavailable = false,
+}) {
+  const platformFeeTotal =
+    platformFeePct != null && amount != null
+      ? ((amount * platformFeePct) / 100).toFixed(4)
+      : null;
+
+  const hasAnyFee = networkFee != null || platformFeeTotal != null;
+
+  const rows = [
+    {
+      Icon: Zap,
+      label: "Estimated network fee",
+      value: networkFee ?? "—",
+      sub: "Paid to Stellar validators",
+    },
+    {
+      Icon: Building2,
+      label: `Platform fee${platformFeePct != null ? ` (${platformFeePct}%)` : ""}`,
+      value:
+        platformFeeTotal != null
+          ? `${platformFeeTotal} ${currency}`
+          : platformFeePct != null
+          ? "Enter amount to estimate"
+          : "—",
+      sub: "Retained by VaultQuest protocol",
+    },
+  ];
+
+  return (
+    <div className="rounded-2xl border border-vault-border bg-vault-surface/60 p-5 backdrop-blur-md">
+      <div className="flex items-center gap-2 mb-4">
+        <Receipt className="h-4 w-4 text-vault-accent" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-vault-text">Fee breakdown</h3>
+        <span title="Fees are estimates and may vary at confirmation time.">
+          <Info className="h-3.5 w-3.5 text-vault-muted" aria-hidden="true" />
+        </span>
+      </div>
+
+      {unavailable ? (
+        <div className="flex items-start gap-3 rounded-xl border border-vault-border bg-vault-bg/40 px-4 py-3">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-vault-muted" aria-hidden="true" />
+          <div>
+            <p className="text-sm font-medium text-vault-text">Fee data unavailable</p>
+            <p className="mt-0.5 text-xs text-vault-muted">
+              Estimated fees couldn&apos;t be loaded right now. You can still proceed — actual fees will be shown in your wallet before you sign.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ul className="space-y-3">
+            {rows.map(({ Icon, label, value, sub }) => (
+              <li
+                key={label}
+                className="flex items-start justify-between gap-4 rounded-xl border border-vault-border bg-vault-bg/30 px-4 py-3"
+              >
+                <div className="flex items-start gap-3 min-w-0">
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-vault-muted" aria-hidden="true" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-vault-text">{label}</p>
+                    <p className="text-xs text-vault-muted">{sub}</p>
+                  </div>
+                </div>
+                <span className="shrink-0 text-sm font-semibold text-vault-text tabular-nums">
+                  {value}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {hasAnyFee && (
+            <div className="mt-4 flex items-center justify-between border-t border-vault-border pt-4">
+              <p className="text-sm font-semibold text-vault-text">Total estimated fees</p>
+              <p className="text-sm font-bold text-vault-accent tabular-nums">
+                {networkFee && platformFeeTotal
+                  ? `${platformFeeTotal} ${currency} + ${networkFee}`
+                  : platformFeeTotal
+                  ? `${platformFeeTotal} ${currency}`
+                  : networkFee ?? "—"}
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/app/VaultLiquidityWarning.jsx
+++ b/components/app/VaultLiquidityWarning.jsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { AlertTriangle, RefreshCw, Droplets } from "lucide-react";
+
+/**
+ * VaultLiquidityWarning — shown inline when liquidity data is missing or stale.
+ *
+ * Props:
+ *   missing   boolean  — true when no liquidity data was returned at all
+ *   stale     boolean  — true when data exists but hasn't refreshed recently
+ *   onRefresh function — callback to re-fetch liquidity data
+ *   loading   boolean  — true while a refresh is in flight
+ */
+export default function VaultLiquidityWarning({
+  missing = false,
+  stale = false,
+  onRefresh,
+  loading = false,
+}) {
+  if (!missing && !stale) return null;
+
+  const title = missing
+    ? "Liquidity data unavailable"
+    : "Liquidity data may be outdated";
+
+  const description = missing
+    ? "We couldn't retrieve current liquidity information for this vault. Other vault details are still visible below."
+    : "Liquidity figures were last updated a while ago and may not reflect the current state of the vault.";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-4 rounded-2xl border border-amber-500/20 bg-amber-500/5 px-5 py-4 backdrop-blur-md"
+    >
+      <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-amber-500/30 bg-amber-500/10 text-amber-400">
+        {missing ? (
+          <Droplets className="h-5 w-5" aria-hidden="true" />
+        ) : (
+          <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+        )}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-vault-text">{title}</p>
+        <p className="mt-1 text-sm text-vault-muted">{description}</p>
+      </div>
+
+      {onRefresh && (
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading}
+          aria-label="Refresh liquidity data"
+          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-sm font-medium text-amber-400 transition-colors hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+            aria-hidden="true"
+          />
+          {loading ? "Refreshing…" : "Refresh"}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #299

---

Closes #298

---

Closes #301

---

Closes #300

---

## Summary

- **`VaultLiquidityWarning`** (`components/app/VaultLiquidityWarning.jsx`): inline amber banner shown when `missing` or `stale` props are set; renders a context-appropriate icon, friendly copy explaining why the data is unavailable, and an optional refresh button with a spinning loader — surrounding page content is never blocked (#298)
- **`VaultFeeBreakdown`** (`components/app/VaultFeeBreakdown.jsx`): structured fee panel with a network fee row, a platform fee row (auto-computed from `platformFeePct × amount`), a total estimate footer, and an `unavailable` fallback state that reminds users their wallet will show final fees before signing (#299)
- **`VaultActivityExport`** (`components/app/VaultActivityExport.jsx`): client-side CSV/JSON export of any `activities` array; includes action type, date, and amount; triggers a browser download with no API call; shows a green success toast and a red error alert on failure (#300)
- **`VaultActionChecklist`** (`components/app/VaultActionChecklist.jsx`): pre-confirmation checklist modal with an action summary block, before/after balance impact grid, fee estimate row, and four acknowledgement checkboxes; the "Confirm & Submit" button stays disabled until all boxes are checked; supports a `loading` prop to show a submitting state (#301)

## Test plan

- [ ] Render `<VaultLiquidityWarning missing />` — verify amber banner with "Liquidity data unavailable" and a refresh button; confirm it returns `null` when neither `missing` nor `stale` is set
- [ ] Render `<VaultFeeBreakdown networkFee="~0.001 XLM" platformFeePct={0.5} amount={1000} />` — verify platform fee shows `5.0000 USDC` and total row appears; render with `unavailable` to see the fallback copy
- [ ] Render `<VaultActivityExport activities={DEMO_TRANSACTIONS} />`, select CSV, click Export — verify a `.csv` file is downloaded with the correct header row and activity data; try with an empty array to see the error state
- [ ] Render `<VaultActionChecklist action="Withdraw 500 USDC" balanceBefore="1 000 USDC" balanceAfter="500 USDC" feeEstimate="~0.001 XLM" />` — verify Confirm button is disabled until all four checkboxes are ticked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-confirmation checklist for major vault actions, including action details, balance impact, fee estimates, and a gated confirm flow.
  * Added local export options for vault activity in CSV or JSON format, with success/error feedback.
  * Added a structured fee breakdown view to show estimated network and platform fees.
  * Added liquidity status warnings for missing or stale data, with an optional refresh action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->