### PR TITLE
feat(ci): automate staging deployments via Vercel and Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID=CA_PLACEHOLDER_DRIP_POOL_CONTRACT_ID
 NEXT_PUBLIC_TRUSTLESS_WORK_ESCROW_CONTRACT_ID=
 TRUSTLESS_WORK_API_BASE_URL=https://dev.api.trustlesswork.com
 TRUSTLESS_WORK_API_KEY=
+
+# Staging deployment secrets (set in GitHub Actions → Settings → Secrets)
+# VERCEL_TOKEN=<your-vercel-token>
+# VERCEL_ORG_ID=<your-vercel-org-id>
+# VERCEL_PROJECT_ID=<your-vercel-project-id>
+# STAGING_HOST=<staging-server-ip>
+# STAGING_USER=deploy
+# STAGING_SSH_KEY=<private-key>
+# STAGING_DATABASE_URL=<separate-staging-postgres-url>

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,57 @@
+name: Staging Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-frontend:
+    name: Deploy frontend to Vercel staging
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy to Vercel (staging)
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+  deploy-backend:
+    name: Build and push backend Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ghcr.io/${{ github.repository }}/backend:staging
+
+      - name: Deploy to staging server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            docker pull ghcr.io/${{ github.repository }}/backend:staging
+            docker stop vaultquest-backend-staging || true
+            docker rm vaultquest-backend-staging || true
+            docker run -d \
+              --name vaultquest-backend-staging \
+              --env-file /etc/vaultquest/staging.env \
+              -p 3001:3000 \
+              ghcr.io/${{ github.repository }}/backend:staging


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/staging-deploy.yml` triggered on every push to `main`.
- `deploy-frontend` job: deploys to Vercel staging using `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` secrets.
- `deploy-backend` job: builds and pushes a `backend:staging` Docker image to GHCR, then SSH-deploys to the staging server — pulls the new image, swaps the container, loads env from `/etc/vaultquest/staging.env` (keeping staging DB isolated from production).
- Documents all 7 required GitHub Actions secrets in `.env.example`.

## Issues closed

Closes #296

## Test plan

- [ ] Push to `main` triggers both `deploy-frontend` and `deploy-backend` jobs
- [ ] Vercel preview URL resolves to the staging frontend
- [ ] Backend container starts on staging server with staging DB env
- [ ] Production DB is not affected (separate `STAGING_DATABASE_URL`)