### PR TITLE
ci: implement automatic release drafting and asset compilation for v*tags

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -1,0 +1,86 @@
+name: Release on Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install smart contract build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev zip
+
+      - name: Build contract WASM binaries
+        working-directory: contracts
+        run: |
+          # Build Soroban artifacts
+          cargo build --target wasm32-unknown-unknown --release
+
+          # Standard cargo workspaces place 'target' at the repository root.
+          # We search from the root level to ensure we catch the compiled .wasm files safely.
+          mkdir -p ../release-artifacts/contracts
+          find ../target/wasm32-unknown-unknown/release -maxdepth 1 -type f -name "*.wasm" -print -exec cp {} ../release-artifacts/contracts/ \;
+
+      - name: Compile changelog from commits
+        id: changelog
+        shell: bash
+        run: |
+          TAG_REF="${GITHUB_REF_NAME}"
+          echo "Building changelog for tag: $TAG_REF"
+
+          PREV_TAG=$(git tag --list 'v*' | sort -V | tail -n 2 | head -n 1)
+          echo "Previous tag candidate: ${PREV_TAG}"
+
+          if [[ -z "${PREV_TAG}" || "${PREV_TAG}" == "${TAG_REF}" ]]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          if [[ "${RANGE}" == "HEAD" ]]; then
+            git log --pretty=format:'- %s' --no-merges --max-count=200 > changelog.md
+          else
+            git log ${RANGE} --pretty=format:'- %s' --no-merges --max-count=200 > changelog.md
+          fi
+
+          if [[ ! -s changelog.md ]]; then
+            echo "- (no notable commits)" > changelog.md
+          fi
+
+          echo "changelog<<'EOF'" >> $GITHUB_OUTPUT
+          cat changelog.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Zip contract binaries
+        run: |
+          cd ./release-artifacts
+          zip -r contracts-wasm.zip contracts
+
+      - name: Draft GitHub Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: true
+          prerelease: false
+          files: ./release-artifacts/contracts-wasm.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR resolves #295 by implementing an automated GitHub Actions workflow (`release-tagging.yml`) that triggers whenever a new semantic version tag matching `v*` is pushed to the repository.

The workflow automates the drafting of new releases, handles Rust smart contract compilation for the Soroban platform, and automatically attaches build artifacts to the release.

## Key Changes
* **Trigger Strategy:** Scoped strictly to target push events containing `v*` tags.
* **Smart Contract Compilation:** Sets up a stable Rust toolchain targeting `wasm32-unknown-unknown`, installs essential Linux build tools (`pkg-config`, `libssl-dev`, `zip`), compiles the Soroban contracts in `--release` mode, and bundles the `.wasm` binaries into a compressed ZIP file.
* **Automated Changelog Generation:** Uses a robust inline bash script to diff commits between the current tag and the previous semantic tag, ensuring a fallback gracefully covers repositories without prior tags.
* **Modern Release Action Integration:** Employs `softprops/action-gh-release@v2` (replacing deprecated, archived legacy community actions) to seamlessly handle simultaneous release drafting and asset uploads.

## Requirements Checklist
- [x] Workflow triggers seamlessly on `v*` tags.
- [x] Compiles changelogs automatically from recent commits.
- [x] Attaches compiled contract binaries (`contracts-wasm.zip`) to the release draft.

Closes #295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic release creation when a version tag is pushed.
  * Release artifacts now include packaged contract build files for easy download.
* **Chores**
  * Improved release automation by generating release notes from recent commit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->