### PR TITLE
feat(backend): health check endpoint, Zod validation middleware, and structured logging

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,8 +9,8 @@ import { savedPoolsRoutes } from "./routes/savedPools.js";
 import { internalRoutes } from "./routes/internal.js";
 import { metricsRoutes } from "./routes/metrics.js";
 import { prometheusRoutes } from "./routes/prometheus.js";
+import { healthRoutes } from "./routes/health.js";
 import { MetricsService } from "./services/metricsService.js";
-import { ok } from "./responses.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { rateLimiter } from "./middleware/rateLimiter.js";
 import { createLogger } from "./logger.js";
@@ -76,12 +76,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
   const savedPoolsSvc = new SavedPoolsService(deps.prisma);
   const metricsSvc = new MetricsService(deps.prisma);
 
-  app.get("/health", async () => ok({ ok: true }));
-  app.get("/health/indexer", async () => {
-    const health = await svc.getIndexerHealth();
-    return ok(health);
-  });
-
+  app.register(healthRoutes(svc));
   app.register(actionsRoutes(svc));
   app.register(savedPoolsRoutes(savedPoolsSvc));
   app.register(internalRoutes(svc, deps.internalSecret));

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,40 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { ZodSchema } from "zod";
+
+export function validateBody<T>(schema: ZodSchema<T>) {
+  return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      req.log.debug(
+        { event: "body_validation_failed", url: req.url, issues: result.error.issues },
+        "request body validation failed"
+      );
+      return reply.status(400).send({
+        error: {
+          code: "INVALID_PAYLOAD",
+          message: "Request body validation failed",
+          issues: result.error.issues
+        }
+      });
+    }
+  };
+}
+
+export function validateQuery<T>(schema: ZodSchema<T>) {
+  return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const result = schema.safeParse(req.query);
+    if (!result.success) {
+      req.log.debug(
+        { event: "query_validation_failed", url: req.url, issues: result.error.issues },
+        "query parameter validation failed"
+      );
+      return reply.status(400).send({
+        error: {
+          code: "INVALID_PAYLOAD",
+          message: "Query parameter validation failed",
+          issues: result.error.issues
+        }
+      });
+    }
+  };
+}

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,25 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { LedgerService } from "../services/ledger.js";
+import { ok } from "../responses.js";
+
+export const healthRoutes = (svc: LedgerService): FastifyPluginAsync =>
+  async (app) => {
+    app.get("/health", async (req) => {
+      req.log.debug({ event: "health_check" }, "health check requested");
+      return ok({
+        status: "ok",
+        uptime: Math.floor(process.uptime()),
+        timestamp: new Date().toISOString(),
+        service: "vaultquest-backend"
+      });
+    });
+
+    app.get("/health/indexer", async (req) => {
+      const health = await svc.getIndexerHealth();
+      req.log.debug(
+        { event: "health_indexer_check", status: health.status },
+        "indexer health checked"
+      );
+      return ok(health);
+    });
+  };

--- a/backend/src/routes/internal.ts
+++ b/backend/src/routes/internal.ts
@@ -2,14 +2,18 @@ import type { FastifyPluginAsync } from "fastify";
 import type { LedgerService } from "../services/ledger.js";
 import { reconcileBody, checkpointBody } from "../schemas/actions.js";
 import { requireServiceAuth } from "../middleware/service-auth.js";
+import { validateBody } from "../middleware/validate.js";
 import { ok } from "../responses.js";
+import type { z } from "zod";
 
 export const internalRoutes = (svc: LedgerService, secret: string): FastifyPluginAsync =>
   async (app) => {
     const guard = requireServiceAuth(secret);
-    
-    app.post("/internal/reconcile", { preHandler: guard }, async (req, reply) => {
-      const body = reconcileBody.parse(req.body);
+
+    app.post("/internal/reconcile", {
+      preHandler: [guard, validateBody(reconcileBody)]
+    }, async (req, reply) => {
+      const body = req.body as z.infer<typeof reconcileBody>;
       const result = await svc.reconcileEvent({
         txHash: body.tx_hash,
         sorobanEventId: body.soroban_event_id,
@@ -23,8 +27,10 @@ export const internalRoutes = (svc: LedgerService, secret: string): FastifyPlugi
       return ok({ matched: true });
     });
 
-    app.post("/internal/checkpoint", { preHandler: guard }, async (req, reply) => {
-      const body = checkpointBody.parse(req.body);
+    app.post("/internal/checkpoint", {
+      preHandler: [guard, validateBody(checkpointBody)]
+    }, async (req) => {
+      const body = req.body as z.infer<typeof checkpointBody>;
       await svc.updateIndexerCheckpoint({
         latestLedger: body.latest_ledger,
         lastError: body.last_error,


### PR DESCRIPTION
## Summary

- **#269** — Added a dedicated `/health` route plugin ([backend/src/routes/health.ts](backend/src/routes/health.ts)) that returns `status`, `uptime` (seconds), `timestamp`, and `service` name for monitoring service uptime. Also moved `/health/indexer` into the same plugin for colocation.
- **#267** — Introduced `validateBody` and `validateQuery` middleware factories ([backend/src/middleware/validate.ts](backend/src/middleware/validate.ts)) that accept any Zod schema and return a Fastify `preHandler` hook. Validation errors surface as structured `400 INVALID_PAYLOAD` responses. Applied to `/internal/reconcile` and `/internal/checkpoint` as `preHandler: [guard, validateBody(schema)]`.
- **#268** — Extended Pino structured logging into the new middleware: validation failures emit `debug`-level events with `url` and `issues` fields; health endpoints emit `debug`-level `health_check` / `health_indexer_check` events. All `console.log` paths in `src/` remain replaced by the Pino logger.

## Test plan

- [ ] `GET /health` returns `{ data: { status: "ok", uptime: <number>, timestamp: <iso>, service: "vaultquest-backend" } }`
- [ ] `GET /health/indexer` continues to return indexer sync status (existing tests pass)
- [ ] `POST /internal/reconcile` with invalid body returns `400 INVALID_PAYLOAD` with Zod issue details
- [ ] `POST /internal/checkpoint` with valid body + correct secret returns `200`
- [ ] `POST /internal/checkpoint` without secret returns `401` (auth guard runs before validation)
- [ ] Run `pnpm test` in `backend/` — middleware, logger, and health tests pass; pre-existing cache failures are unrelated

Closes #267
Closes #268
Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer health-check responses, including service uptime and a timestamp, plus a separate indexer health endpoint.
  * Added more consistent request validation for incoming body and query data.

* **Bug Fixes**
  * Invalid requests now return structured 400 errors with validation details, making failures easier to understand.
  * Internal endpoints now use shared validation before processing, improving request handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->