### PR TITLE
feat(contracts): add maximum deposit limit per user (#260)

### DIFF
--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -24,6 +24,9 @@ use soroban_sdk::{
 
 // ── Lockup duration (ledgers, ~7 days at 5 s/ledger) ──────────────────────
 const LOCKUP_LEDGERS: u32 = 120_960;
+// ── Maximum cumulative deposit per user (#260) ────────────────────────────
+// Caps how much a single address can deposit across all deposits.
+const MAX_DEPOSIT: i128 = 1_000_000_000_000; // 100,000 units at 7 decimals
 // ── Multi-sig threshold: 2-of-N ───────────────────────────────────────────
 const SIG_THRESHOLD: u32 = 2;
 
@@ -56,6 +59,7 @@ pub enum Error {
     ThresholdNotMet    = 9,   // not enough signatures
     AlreadySigned      = 10,  // signer already approved this proposal
     ProposalNotFound   = 11,
+    DepositLimitExceeded = 12, // #260: deposit would exceed MAX_DEPOSIT per user
 }
 
 // ── Structs ────────────────────────────────────────────────────────────────
@@ -334,6 +338,11 @@ impl DripPool {
                 locked_until: env.ledger().sequence() + LOCKUP_LEDGERS,
                 lockup_multiplier: 100,
             });
+
+        // #260: Enforce the per-user maximum deposit cap.
+        if p.deposited + amount > MAX_DEPOSIT {
+            return Err(Error::DepositLimitExceeded);
+        }
 
         p.deposited += amount;
         p.claimable += amount;

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -281,6 +281,45 @@ fn negative_deposit_rejected() {
     );
 }
 
+/// #260: A deposit exceeding the per-user MAX_DEPOSIT cap is rejected.
+#[test]
+fn deposit_over_max_limit_rejected() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    assert_eq!(
+        client.try_deposit(&alice, &(MAX_DEPOSIT + 1)),
+        Err(Ok(Error::DepositLimitExceeded))
+    );
+}
+
+/// #260: Cumulative deposits crossing the cap are rejected even when each
+/// individual deposit is within bounds.
+#[test]
+fn cumulative_deposit_over_max_limit_rejected() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &MAX_DEPOSIT);
+    assert_eq!(
+        client.try_deposit(&alice, &1),
+        Err(Ok(Error::DepositLimitExceeded))
+    );
+}
+
+/// #260: A deposit exactly at the cap is accepted.
+#[test]
+fn deposit_at_max_limit_accepted() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &MAX_DEPOSIT);
+    assert_eq!(client.savings(&alice).deposited, MAX_DEPOSIT);
+}
+
 // ── #255: event emission ───────────────────────────────────────────────────
 
 /// Deposit emits a `pool / deposit` event with (who, amount, total_deposited).


### PR DESCRIPTION
  Closes #260

  Description

  Implements a cap on how much a single address can cumulatively deposit into the DripPool (Soroban) contract. Once a user's total deposited balance would
  exceed the cap, further deposits are rejected with a dedicated error.

  Changes

  contracts/drip-pool/src/lib.rs
  - Added a MAX_DEPOSIT constant (1_000_000_000_000 — 100,000 units at 7 decimals) defining the per-user cumulative deposit cap.
  - Added a new DepositLimitExceeded = 12 variant to the Error enum for a specific, descriptive revert reason.
  - Added a balance check in deposit that validates existing_balance + amount against MAX_DEPOSIT before any state mutation, reverting if the limit would
  be exceeded. Placed right after the existing amount <= 0 validation.

  contracts/drip-pool/src/test.rs
  - deposit_over_max_limit_rejected — a single deposit above the cap reverts.
  - cumulative_deposit_over_max_limit_rejected — deposits that individually fit but together cross the cap revert.
  - deposit_at_max_limit_accepted — a deposit exactly at the cap succeeds (boundary case).

  Requirements checklist

  - [x] Define a MAX_DEPOSIT constant
  - [x] Check user balance before accepting deposits
  - [x] Revert with a specific error if the limit is exceeded

  Notes

  - The cap is enforced on the cumulative per-user balance (p.deposited + amount), not per-transaction, so users cannot bypass it by splitting deposits.
  - The check runs before state changes, so a rejected deposit leaves participant and pool accounting untouched.
  - Rust/cargo was not available in my working environment, so I could not run cargo test locally. Please confirm with cargo test -p drip-pool in CI / a
  toolchain-enabled environment. The code mirrors existing patterns (error enum style, try_deposit/savings client usage, and the p.deposited + amount
  accounting already used in the function).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a per-user deposit cap to prevent cumulative deposits from exceeding the allowed maximum.
  * Deposits that would go over the limit now fail with a clear error, while deposits at the exact limit still succeed.

* **Tests**
  * Added coverage for over-limit deposits, cumulative limit checks, and exact-limit acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->