### PR TITLE
test: harden wallet transaction state and modal flows

### DIFF
--- a/stellar-wallet-connect/src/vault/components/DepositModal.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/DepositModal.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { createMockVaultClient, SAMPLE_ADDRESS } from "../contract/mockClient";
+import { ContractInterfaceError, type PoolActionResult, type PoolSummary } from "../contract/types";
+import { DepositModal } from "./DepositModal";
+
+const pool: PoolSummary = {
+  id: "pool-1",
+  name: "Weekly USDC",
+  status: "open",
+  tvl: "1000000000",
+  asset: "USDC",
+  participantCount: 10,
+  expectedYield: "5.2% APY",
+  prize: "100 USDC",
+  opensAt: "2026-07-01T00:00:00Z",
+  locksAt: "2026-07-31T00:00:00Z",
+  drawsAt: "2026-08-01T00:00:00Z",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function enterReview(amount = "10") {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Amount"), amount);
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+  return user;
+}
+
+describe("DepositModal transaction states", () => {
+  it("shows a pending wallet state and then confirmed success", async () => {
+    const submission = deferred<PoolActionResult>();
+    const client = createMockVaultClient();
+    const submit = vi.spyOn(client, "submitAction").mockImplementation(() => submission.promise);
+    const onClose = vi.fn();
+
+    render(
+      <DepositModal
+        pool={pool}
+        walletBalance="100"
+        onClose={onClose}
+        onDeposit={async (amount) => {
+          await client.submitAction("drip", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview();
+    await user.click(screen.getByRole("button", { name: "Confirm deposit" }));
+
+    expect(await screen.findByText("Broadcasting deposit...")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for wallet confirmation")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    submission.resolve({ txHash: "tx-deposit", status: "submitted" });
+
+    expect(await screen.findByText("Deposit successful!")).toBeInTheDocument();
+    expect(screen.getByText(/10 USDC/)).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces wallet rejection and retries without a duplicate submission", async () => {
+    const client = createMockVaultClient();
+    const submit = vi
+      .spyOn(client, "submitAction")
+      .mockRejectedValueOnce(
+        new ContractInterfaceError("signature_rejected", "Request rejected in wallet. No funds were moved."),
+      )
+      .mockResolvedValueOnce({ txHash: "tx-deposit-retry", status: "submitted" });
+
+    render(
+      <DepositModal
+        pool={pool}
+        walletBalance="100"
+        onClose={vi.fn()}
+        onDeposit={async (amount) => {
+          await client.submitAction("drip", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("15");
+    await user.click(screen.getByRole("button", { name: "Confirm deposit" }));
+
+    expect(await screen.findByText("Request rejected in wallet. No funds were moved.")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    // The failed request returns to review with the same amount. One explicit
+    // retry creates exactly one additional wallet submission.
+    await user.click(screen.getByRole("button", { name: "Confirm deposit" }));
+
+    expect(await screen.findByText("Deposit successful!")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit).toHaveBeenLastCalledWith(
+      "drip",
+      expect.objectContaining({ amount: "15", poolId: pool.id }),
+    );
+  });
+
+  it.each([
+    ["rpc_failure", "Stellar RPC is unavailable."],
+    ["contract_error", "Transaction reverted by the contract."],
+    ["stale_data", "Confirmation timed out. Try again safely."],
+  ] as const)("renders %s failures clearly", async (kind, message) => {
+    const client = createMockVaultClient();
+    vi.spyOn(client, "submitAction").mockRejectedValue(new ContractInterfaceError(kind, message));
+
+    render(
+      <DepositModal
+        pool={pool}
+        walletBalance="100"
+        onClose={vi.fn()}
+        onDeposit={async (amount) => {
+          await client.submitAction("drip", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview();
+    await user.click(screen.getByRole("button", { name: "Confirm deposit" }));
+
+    await waitFor(() => expect(screen.getByText(message)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Confirm deposit" })).toBeEnabled();
+  });
+});

--- a/stellar-wallet-connect/src/vault/components/WithdrawalModal.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/WithdrawalModal.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { createMockVaultClient, SAMPLE_ADDRESS } from "../contract/mockClient";
+import {
+  ContractInterfaceError,
+  type PoolActionResult,
+  type PoolSummary,
+  type UserPosition,
+} from "../contract/types";
+import { WithdrawalModal } from "./WithdrawalModal";
+
+const pool: PoolSummary = {
+  id: "pool-1",
+  name: "Weekly USDC",
+  status: "open",
+  tvl: "1000000000",
+  asset: "USDC",
+  participantCount: 10,
+  expectedYield: "5.2% APY",
+  prize: "100 USDC",
+  opensAt: "2026-07-01T00:00:00Z",
+  locksAt: "2026-07-31T00:00:00Z",
+  drawsAt: "2026-08-01T00:00:00Z",
+};
+
+const position: UserPosition = {
+  walletAddress: SAMPLE_ADDRESS,
+  deposited: "80",
+  shares: "80",
+  joined: true,
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function enterReview(amount = "20") {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Amount"), amount);
+  await user.click(screen.getByRole("button", { name: "Continue" }));
+  return user;
+}
+
+describe("WithdrawalModal transaction states", () => {
+  it("shows pending confirmation and a confirmed withdrawal summary", async () => {
+    const submission = deferred<PoolActionResult>();
+    const client = createMockVaultClient();
+    const submit = vi.spyOn(client, "submitAction").mockImplementation(() => submission.promise);
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview();
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    expect(await screen.findByText("Broadcasting withdrawal...")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for wallet confirmation")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    submission.resolve({ txHash: "tx-withdraw", status: "submitted" });
+
+    expect(await screen.findByText("Withdrawal successful!")).toBeInTheDocument();
+    expect(screen.getByText("Confirmed")).toBeInTheDocument();
+    expect(screen.getByText(/60 USDC/)).toBeInTheDocument();
+  });
+
+  it("shows a reverted transaction and allows one safe retry", async () => {
+    const client = createMockVaultClient();
+    const submit = vi
+      .spyOn(client, "submitAction")
+      .mockRejectedValueOnce(
+        new ContractInterfaceError("contract_error", "Withdrawal reverted; your position is unchanged."),
+      )
+      .mockResolvedValueOnce({ txHash: "tx-withdraw-retry", status: "submitted" });
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("30");
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    expect(await screen.findByText("Withdrawal reverted; your position is unchanged.")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    expect(await screen.findByText("Withdrawal successful!")).toBeInTheDocument();
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit).toHaveBeenLastCalledWith(
+      "withdraw",
+      expect.objectContaining({ amount: "30", poolId: pool.id }),
+    );
+  });
+
+  it.each([
+    ["signature_rejected", "Withdrawal rejected in wallet."],
+    ["rpc_failure", "RPC submission failed."],
+    ["stale_data", "Withdrawal confirmation timed out."],
+  ] as const)("renders %s failures and preserves the entered amount", async (kind, message) => {
+    const client = createMockVaultClient();
+    vi.spyOn(client, "submitAction").mockRejectedValue(new ContractInterfaceError(kind, message));
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("12");
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    await waitFor(() => expect(screen.getByText(message)).toBeInTheDocument());
+    expect(screen.getByText(/12 USDC/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm withdrawal" })).toBeEnabled();
+  });
+});

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.test.tsx
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.test.tsx
@@ -1,0 +1,222 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createMockVaultClient, SAMPLE_ADDRESS } from "../contract/mockClient";
+import {
+  ContractInterfaceError,
+  type PoolActionInput,
+  type PoolActionResult,
+  type VaultContractClient,
+} from "../contract/types";
+import {
+  transitionTxState,
+  useTxFlow,
+  type TxFlowState,
+} from "./txStateMachine";
+
+const input: PoolActionInput = {
+  poolId: "pool-1",
+  walletAddress: SAMPLE_ADDRESS,
+  amount: "25",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function clientWithSubmit(
+  submitAction: VaultContractClient["submitAction"],
+): VaultContractClient {
+  return { ...createMockVaultClient(), submitAction };
+}
+
+describe("transitionTxState", () => {
+  it("accepts the complete ordered lifecycle", () => {
+    let state: TxFlowState = { stage: "idle" };
+    state = transitionTxState(state, { type: "START" });
+    expect(state).toEqual({ stage: "preparing" });
+
+    state = transitionTxState(state, { type: "AWAIT_SIGNATURE" });
+    expect(state).toEqual({ stage: "awaiting-signature" });
+
+    state = transitionTxState(state, { type: "SUBMITTED", txHash: "tx-1" });
+    expect(state).toEqual({ stage: "submitting", txHash: "tx-1" });
+
+    state = transitionTxState(state, { type: "CONFIRMING", txHash: "tx-1" });
+    expect(state).toEqual({ stage: "confirming", txHash: "tx-1" });
+
+    state = transitionTxState(state, { type: "INDEXING", txHash: "tx-1" });
+    expect(state).toEqual({ stage: "indexing", txHash: "tx-1" });
+
+    state = transitionTxState(state, { type: "SUCCEEDED", txHash: "tx-1" });
+    expect(state).toEqual({ stage: "success", txHash: "tx-1" });
+  });
+
+  it("ignores invalid and out-of-order transitions predictably", () => {
+    const idle: TxFlowState = { stage: "idle" };
+    expect(
+      transitionTxState(idle, { type: "SUBMITTED", txHash: "tx-skipped" }),
+    ).toBe(idle);
+
+    const preparing: TxFlowState = { stage: "preparing" };
+    expect(
+      transitionTxState(preparing, { type: "SUCCEEDED", txHash: "tx-skipped" }),
+    ).toBe(preparing);
+    expect(transitionTxState(preparing, { type: "RESET" })).toBe(preparing);
+  });
+
+  it("allows terminal states to start a retry and reset to idle", () => {
+    const failed: TxFlowState = {
+      stage: "failed",
+      failedAt: "submitting",
+      message: "RPC unavailable",
+    };
+
+    expect(transitionTxState(failed, { type: "START" })).toEqual({ stage: "preparing" });
+    expect(transitionTxState(failed, { type: "RESET" })).toEqual({ stage: "idle" });
+  });
+});
+
+describe("useTxFlow", () => {
+  it("moves through confirmation and success with a mocked client", async () => {
+    const client = createMockVaultClient({ txHashFactory: () => "tx-success" });
+    const onConfirmed = vi.fn();
+    const { result } = renderHook(() => useTxFlow());
+
+    await act(async () => {
+      await result.current.run(client, "drip", input, {
+        waitForConfirmation: async () => {},
+        onConfirmed,
+        indexingDelayMs: 0,
+      });
+    });
+
+    expect(result.current.state).toEqual({ stage: "success", txHash: "tx-success" });
+    expect(result.current.busy).toBe(false);
+    expect(onConfirmed).toHaveBeenCalledWith("tx-success");
+  });
+
+  it("keeps the flow pending while ledger confirmation is unresolved", async () => {
+    const confirmation = deferred<void>();
+    const client = createMockVaultClient({ txHashFactory: () => "tx-pending" });
+    const { result } = renderHook(() => useTxFlow());
+    let runPromise!: Promise<void>;
+
+    act(() => {
+      runPromise = result.current.run(client, "drip", input, {
+        waitForConfirmation: () => confirmation.promise,
+        confirmationTimeoutMs: 1_000,
+        indexingDelayMs: 0,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ stage: "confirming", txHash: "tx-pending" });
+    });
+    expect(result.current.busy).toBe(true);
+
+    await act(async () => {
+      confirmation.resolve();
+      await runPromise;
+    });
+
+    expect(result.current.state).toEqual({ stage: "success", txHash: "tx-pending" });
+  });
+
+  it("maps wallet rejection, RPC failure, revert, and stale indexing to their stages", async () => {
+    const cases = [
+      ["signature_rejected", "awaiting-signature"],
+      ["rpc_failure", "submitting"],
+      ["contract_error", "confirming"],
+      ["stale_data", "indexing"],
+    ] as const;
+
+    for (const [kind, failedAt] of cases) {
+      const client = createMockVaultClient({ failActions: { drip: kind } });
+      const { result, unmount } = renderHook(() => useTxFlow());
+
+      await act(async () => {
+        await result.current.run(client, "drip", input, { indexingDelayMs: 0 });
+      });
+
+      expect(result.current.state.stage).toBe("failed");
+      if (result.current.state.stage === "failed") {
+        expect(result.current.state.failedAt).toBe(failedAt);
+        expect(result.current.state.message).toContain(kind);
+      }
+      unmount();
+    }
+  });
+
+  it("fails at confirmation when the confirmation adapter times out", async () => {
+    const client = createMockVaultClient({ txHashFactory: () => "tx-timeout" });
+    const { result } = renderHook(() => useTxFlow());
+
+    await act(async () => {
+      await result.current.run(client, "withdraw", input, {
+        waitForConfirmation: () => new Promise<void>(() => {}),
+        confirmationTimeoutMs: 5,
+        indexingDelayMs: 0,
+      });
+    });
+
+    expect(result.current.state.stage).toBe("failed");
+    if (result.current.state.stage === "failed") {
+      expect(result.current.state.failedAt).toBe("confirming");
+      expect(result.current.state.message).toContain("timed out");
+    }
+  });
+
+  it("deduplicates concurrent submissions while one action is in flight", async () => {
+    const submission = deferred<PoolActionResult>();
+    const submitAction = vi.fn(() => submission.promise);
+    const client = clientWithSubmit(submitAction);
+    const { result } = renderHook(() => useTxFlow());
+    let first!: Promise<void>;
+    let duplicate!: Promise<void>;
+
+    act(() => {
+      first = result.current.run(client, "drip", input, { indexingDelayMs: 0 });
+      duplicate = result.current.run(client, "drip", input, { indexingDelayMs: 0 });
+    });
+
+    expect(submitAction).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      submission.resolve({ txHash: "tx-deduped", status: "submitted" });
+      await Promise.all([first, duplicate]);
+    });
+
+    expect(submitAction).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toEqual({ stage: "success", txHash: "tx-deduped" });
+  });
+
+  it("retries a recoverable failure once without duplicating the retry", async () => {
+    const submitAction = vi
+      .fn<VaultContractClient["submitAction"]>()
+      .mockRejectedValueOnce(new ContractInterfaceError("rpc_failure", "RPC temporarily unavailable"))
+      .mockResolvedValueOnce({ txHash: "tx-retry", status: "submitted" });
+    const client = clientWithSubmit(submitAction);
+    const { result } = renderHook(() => useTxFlow());
+
+    await act(async () => {
+      await result.current.run(client, "withdraw", input, { indexingDelayMs: 0 });
+    });
+    expect(result.current.state.stage).toBe("failed");
+
+    await act(async () => {
+      await Promise.all([
+        result.current.run(client, "withdraw", input, { indexingDelayMs: 0 }),
+        result.current.run(client, "withdraw", input, { indexingDelayMs: 0 }),
+      ]);
+    });
+
+    expect(submitAction).toHaveBeenCalledTimes(2);
+    expect(result.current.state).toEqual({ stage: "success", txHash: "tx-retry" });
+  });
+});

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
@@ -2,16 +2,15 @@
  * Shared transaction state machine for wallet-driven actions (#94).
  *
  * All wallet flows (join, drip, claim, withdraw, create) pass through the same
- * lifecycle. This hook owns that lifecycle so each flow gets consistent state
- * labels, transitions, and recovery options without duplicating logic.
- *
- * The `stage` value is intentionally typed as `TimelineStage` so callers can
- * pass it straight to `<TransactionTimeline>` with no mapping.
+ * lifecycle. The pure transition function below is intentionally exported so
+ * invalid transitions can be regression-tested without mounting React.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { TimelineStage } from "../../components/TransactionTimeline";
 import type { PoolActionInput, PoolActionType, VaultContractClient } from "../contract/types";
+
+export type ActiveTxStage = Exclude<TimelineStage, "success" | "failed">;
 
 export type TxFlowState =
   | { stage: "idle" }
@@ -21,7 +20,17 @@ export type TxFlowState =
   | { stage: "confirming"; txHash: string }
   | { stage: "indexing"; txHash: string }
   | { stage: "success"; txHash: string }
-  | { stage: "failed"; failedAt: Exclude<TimelineStage, "success" | "failed">; message: string };
+  | { stage: "failed"; failedAt: ActiveTxStage; message: string };
+
+export type TxFlowEvent =
+  | { type: "START" }
+  | { type: "AWAIT_SIGNATURE" }
+  | { type: "SUBMITTED"; txHash: string }
+  | { type: "CONFIRMING"; txHash: string }
+  | { type: "INDEXING"; txHash: string }
+  | { type: "SUCCEEDED"; txHash: string }
+  | { type: "FAILED"; failedAt: ActiveTxStage; message: string }
+  | { type: "RESET" };
 
 export interface TxFlowResult {
   /** Current flow state — pass `state.stage` directly to `<TransactionTimeline stage={...}>`. */
@@ -35,58 +44,152 @@ export interface TxFlowResult {
     input: PoolActionInput,
     options?: TxFlowOptions,
   ) => Promise<void>;
-  /** Reset back to idle so the same hook can run another action. */
+  /** Reset back to idle. Resets are ignored while an action is in flight. */
   reset: () => void;
 }
 
 export interface TxFlowOptions {
-  /**
-   * Called when the transaction reaches the indexing stage with a confirmed
-   * tx hash. Use this to trigger a data refetch in the parent.
-   */
+  /** Called after ledger confirmation and before the indexing stage. */
   onConfirmed?: (txHash: string) => void;
   /**
-   * Milliseconds to wait in the `indexing` stage before advancing to
-   * `success`. Defaults to 2 000 ms — enough for the backend reconciler to
-   * pick up the event in most environments.
+   * Optional confirmation adapter. Production callers can poll Horizon/Soroban;
+   * tests can inject pending, reverted, and timeout behavior deterministically.
    */
+  waitForConfirmation?: (txHash: string) => Promise<void>;
+  /** Maximum wait for `waitForConfirmation`. Defaults to 45 seconds. */
+  confirmationTimeoutMs?: number;
+  /** Delay before advancing from indexing to success. Defaults to 2 seconds. */
   indexingDelayMs?: number;
 }
 
-const STAGE_ORDER: Record<TimelineStage, number> = {
-  preparing: 0,
-  "awaiting-signature": 1,
-  submitting: 2,
-  confirming: 3,
-  indexing: 4,
-  success: 5,
-  failed: -1,
-};
+const INITIAL_STATE: TxFlowState = { stage: "idle" };
 
-function isTerminal(stage: TimelineStage): boolean {
-  return stage === "success" || stage === "failed";
+function isTerminalState(state: TxFlowState): boolean {
+  return state.stage === "success" || state.stage === "failed";
 }
 
-function mapError(err: unknown): { failedAt: Exclude<TimelineStage, "success" | "failed">; message: string } {
+function isActiveState(state: TxFlowState): state is Exclude<TxFlowState, { stage: "idle" | "success" | "failed" }> {
+  return state.stage !== "idle" && !isTerminalState(state);
+}
+
+/**
+ * Apply one legal state-machine event. Invalid or out-of-order events are
+ * ignored by returning the exact same state object.
+ */
+export function transitionTxState(state: TxFlowState, event: TxFlowEvent): TxFlowState {
+  switch (event.type) {
+    case "START":
+      return state.stage === "idle" || isTerminalState(state)
+        ? { stage: "preparing" }
+        : state;
+    case "AWAIT_SIGNATURE":
+      return state.stage === "preparing" ? { stage: "awaiting-signature" } : state;
+    case "SUBMITTED":
+      return state.stage === "awaiting-signature"
+        ? { stage: "submitting", txHash: event.txHash }
+        : state;
+    case "CONFIRMING":
+      return state.stage === "submitting"
+        ? { stage: "confirming", txHash: event.txHash }
+        : state;
+    case "INDEXING":
+      return state.stage === "confirming"
+        ? { stage: "indexing", txHash: event.txHash }
+        : state;
+    case "SUCCEEDED":
+      return state.stage === "indexing"
+        ? { stage: "success", txHash: event.txHash }
+        : state;
+    case "FAILED":
+      return isActiveState(state)
+        ? { stage: "failed", failedAt: event.failedAt, message: event.message }
+        : state;
+    case "RESET":
+      return state.stage === "idle" || isTerminalState(state) ? INITIAL_STATE : state;
+  }
+}
+
+export class TxConfirmationTimeoutError extends Error {
+  readonly kind = "confirmation_timeout";
+
+  constructor(timeoutMs: number) {
+    super(`Transaction confirmation timed out after ${timeoutMs}ms.`);
+    this.name = "TxConfirmationTimeoutError";
+  }
+}
+
+export function mapTxError(
+  err: unknown,
+  fallbackStage: ActiveTxStage,
+): { failedAt: ActiveTxStage; message: string } {
   const message = err instanceof Error ? err.message : String(err);
-  // Map known ContractInterfaceError kinds to the stage where they occur.
   const kind = (err as { kind?: string }).kind ?? "";
+
   if (kind === "wallet_disconnected" || kind === "signature_rejected") {
     return { failedAt: "awaiting-signature", message };
   }
-  if (kind === "rpc_failure" || kind === "contract_error") {
+  if (kind === "rpc_failure") {
     return { failedAt: "submitting", message };
   }
-  return { failedAt: "confirming", message };
+  if (kind === "contract_error" || kind === "confirmation_timeout") {
+    return { failedAt: "confirming", message };
+  }
+  if (kind === "stale_data") {
+    return { failedAt: "indexing", message };
+  }
+  return { failedAt: fallbackStage, message };
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function withTimeout(
+  confirmation: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  if (timeoutMs <= 0) return confirmation;
+
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new TxConfirmationTimeoutError(timeoutMs)), timeoutMs);
+    confirmation.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function stateFailureFallback(state: TxFlowState): ActiveTxStage {
+  if (isActiveState(state)) return state.stage;
+  return "confirming";
 }
 
 export function useTxFlow(): TxFlowResult {
-  const [state, setState] = useState<TxFlowState>({ stage: "idle" });
+  const [state, setState] = useState<TxFlowState>(INITIAL_STATE);
+  const stateRef = useRef<TxFlowState>(INITIAL_STATE);
+  const inFlightRef = useRef(false);
 
-  const busy =
-    state.stage !== "idle" && !isTerminal(state.stage as TimelineStage);
+  const transition = useCallback((event: TxFlowEvent): TxFlowState => {
+    const next = transitionTxState(stateRef.current, event);
+    if (next !== stateRef.current) {
+      stateRef.current = next;
+      setState(next);
+    }
+    return next;
+  }, []);
 
-  const reset = useCallback(() => setState({ stage: "idle" }), []);
+  const busy = isActiveState(state);
+
+  const reset = useCallback(() => {
+    transition({ type: "RESET" });
+  }, [transition]);
 
   const run = useCallback(
     async (
@@ -95,35 +198,44 @@ export function useTxFlow(): TxFlowResult {
       input: PoolActionInput,
       options: TxFlowOptions = {},
     ) => {
-      const { onConfirmed, indexingDelayMs = 2_000 } = options;
+      // A synchronous ref guard prevents two clicks/render cycles from creating
+      // duplicate local action records or wallet submissions.
+      if (inFlightRef.current) return;
 
-      // Prevent double-submission.
-      setState((prev) => {
-        if (prev.stage !== "idle" && !isTerminal(STAGE_ORDER[prev.stage as TimelineStage] >= 0 ? prev.stage as TimelineStage : "failed")) {
-          return prev;
-        }
-        return { stage: "preparing" };
-      });
+      const started = transition({ type: "START" });
+      if (started.stage !== "preparing") return;
+      inFlightRef.current = true;
+
+      const {
+        onConfirmed,
+        waitForConfirmation,
+        confirmationTimeoutMs = 45_000,
+        indexingDelayMs = 2_000,
+      } = options;
 
       try {
-        setState({ stage: "awaiting-signature" });
+        transition({ type: "AWAIT_SIGNATURE" });
         const result = await client.submitAction(type, input);
 
-        setState({ stage: "submitting", txHash: result.txHash });
+        transition({ type: "SUBMITTED", txHash: result.txHash });
+        transition({ type: "CONFIRMING", txHash: result.txHash });
 
-        setState({ stage: "confirming", txHash: result.txHash });
+        if (waitForConfirmation) {
+          await withTimeout(waitForConfirmation(result.txHash), confirmationTimeoutMs);
+        }
+
         onConfirmed?.(result.txHash);
-
-        setState({ stage: "indexing", txHash: result.txHash });
-        await new Promise<void>((resolve) => setTimeout(resolve, indexingDelayMs));
-
-        setState({ stage: "success", txHash: result.txHash });
+        transition({ type: "INDEXING", txHash: result.txHash });
+        await delay(indexingDelayMs);
+        transition({ type: "SUCCEEDED", txHash: result.txHash });
       } catch (err) {
-        const { failedAt, message } = mapError(err);
-        setState({ stage: "failed", failedAt, message });
+        const { failedAt, message } = mapTxError(err, stateFailureFallback(stateRef.current));
+        transition({ type: "FAILED", failedAt, message });
+      } finally {
+        inFlightRef.current = false;
       }
     },
-    [],
+    [transition],
   );
 
   return { state, busy, run, reset };


### PR DESCRIPTION
## What changed
- extracted a pure, ordered transaction transition function with predictable invalid-transition handling
- added an in-flight ref guard so concurrent clicks cannot create duplicate wallet submissions or local action records
- added injectable confirmation polling, confirmation timeout handling, and error-to-stage mapping for rejection, RPC failure, revert, timeout, and stale indexing
- added Vitest coverage for success, pending confirmation, failure stages, timeout, retry, and concurrent deduplication
- added deposit and withdrawal modal tests using mocked contract clients for pending, confirmed, rejected, reverted, RPC, timeout, and retry UI states

## Impact
Wallet flows now have deterministic transitions and a safe retry path. A second submission while the first is active is ignored synchronously, while a terminal failure can be retried exactly once per user action.

## Validation
Tests were added under the wallet package's existing Vitest configuration. Local dependency execution was not available in this environment; repository CI should run `npm test` from `stellar-wallet-connect`.

Closes #363