### PR TITLE
test: isolate saved pools by wallet and harden cache eviction

### DIFF
--- a/backend/docs/SAVED_POOLS_SCOPING.md
+++ b/backend/docs/SAVED_POOLS_SCOPING.md
@@ -1,0 +1,55 @@
+# Saved pools wallet scoping and cache invariants
+
+Saved pools are user-specific watchlist records. The backend treats the wallet
+address as the ownership scope for every saved-pool operation.
+
+## Persistence boundary
+
+- The database identity is the composite `(walletAddress, poolId)` key.
+- A pool id alone is never sufficient to read, update, or delete a saved record.
+- Two wallets may save the same pool without sharing or overwriting metadata.
+- List operations always filter by the normalized wallet address.
+- Delete operations require both the normalized wallet address and pool id. A
+  request made with a different wallet returns a deleted count of zero.
+
+## Cache boundary
+
+Saved-pool list entries use this key shape:
+
+```text
+saved-pools:<wallet-address>
+```
+
+The wallet component is mandatory. Cache entries must never be keyed only by a
+pool id because pool ids intentionally overlap across users.
+
+A successful save or delete invalidates only the requesting wallet's list. It
+must not clear another wallet's entry. A failed cross-wallet delete does not
+evict either owner's cached list.
+
+The in-memory cache applies a per-wallet TTL and deterministic least-recently-used
+eviction. Expiry or capacity eviction removes one wallet entry at a time and
+must not flush unrelated users.
+
+## Authorization assumption
+
+The current HTTP routes receive the wallet address in the request body or query
+string. The service enforces data isolation by applying that wallet to every
+persistence selector and cache key; it does not independently prove wallet
+ownership.
+
+When signed sessions, wallet challenges, or another authenticated principal are
+introduced, routes must derive the wallet scope from the verified principal and
+reject a conflicting body/query wallet before calling `SavedPoolsService`.
+The service-level composite selectors and wallet-qualified cache keys should
+remain as defense in depth.
+
+## Regression requirements
+
+Changes to saved pools must keep tests for:
+
+1. two wallets saving overlapping and unique pool ids;
+2. wallet A being unable to list or delete wallet B's records;
+3. wallet-local mutation invalidation;
+4. deterministic TTL and LRU eviction without cross-wallet cache loss;
+5. metadata refreshes remaining confined to the composite owner key.

--- a/backend/src/services/savedPools.ts
+++ b/backend/src/services/savedPools.ts
@@ -1,85 +1,122 @@
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient, SavedPool } from "@prisma/client";
+import { SavedPoolsCache } from "./savedPoolsCache.js";
 
-/**
- * Persists user-saved vault/pool references for quick access and watchlists.
- */
+/** Metadata persisted for a wallet's saved/watchlisted pool. */
+export interface SavedPoolMetadataInput {
+  poolId: string;
+  poolName: string;
+  status: string;
+  tvl: string;
+  asset: string;
+  participantCount: number;
+  expectedYield: string;
+  prize: string | null;
+  opensAt: Date | null;
+  locksAt: Date | null;
+  drawsAt: Date | null;
+}
 
 export interface SavedPoolInput {
   walletAddress: string;
-  poolId: string;
+  pool: SavedPoolMetadataInput;
 }
 
-export interface SavedPoolRecord {
-  walletAddress: string;
-  poolId: string;
-  createdAt: Date;
+export type SavedPoolRecord = SavedPool;
+
+function normalizeWallet(walletAddress: string): string {
+  return walletAddress.trim();
 }
 
 /**
- * Manages saved pool records linked to user wallets.
+ * Persists and caches user-saved vault/pool references.
+ *
+ * Authorization/scoping invariant: every database selector and every cache key
+ * includes the normalized wallet address. A pool id is never sufficient to
+ * list, update, delete, cache, or invalidate a saved-pool record.
  */
 export class SavedPoolsService {
-  /**
-   * @param prisma - Prisma client for database access
-   */
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly cache: SavedPoolsCache = new SavedPoolsCache(),
+  ) {}
 
   /**
-   * Saves a pool reference for a wallet if not already saved.
+   * Saves or refreshes a pool reference for one wallet.
    *
-   * @param input - Wallet and pool identifiers
-   * @returns The saved record and whether it was newly created
+   * The composite `(walletAddress, poolId)` key prevents an overlapping pool id
+   * from replacing another wallet's saved record. Only this wallet's list cache
+   * is invalidated after the mutation.
    */
   async savePool(input: SavedPoolInput): Promise<{ record: SavedPoolRecord; created: boolean }> {
-    const existing = await this.prisma.savedPool.findUnique({
-      where: {
-        walletAddress_poolId: {
-          walletAddress: input.walletAddress,
-          poolId: input.poolId,
-        },
+    const walletAddress = normalizeWallet(input.walletAddress);
+    const { pool } = input;
+    const where = {
+      walletAddress_poolId: {
+        walletAddress,
+        poolId: pool.poolId,
       },
+    };
+
+    const existing = await this.prisma.savedPool.findUnique({ where });
+    const metadata = {
+      poolName: pool.poolName,
+      status: pool.status,
+      tvl: pool.tvl,
+      asset: pool.asset,
+      participantCount: pool.participantCount,
+      expectedYield: pool.expectedYield,
+      prize: pool.prize,
+      opensAt: pool.opensAt,
+      locksAt: pool.locksAt,
+      drawsAt: pool.drawsAt,
+    };
+
+    const record = await this.prisma.savedPool.upsert({
+      where,
+      create: {
+        walletAddress,
+        poolId: pool.poolId,
+        ...metadata,
+      },
+      update: metadata,
     });
 
-    if (existing) {
-      return { record: existing as unknown as SavedPoolRecord, created: false };
-    }
-
-    const created = await this.prisma.savedPool.create({
-      data: {
-        walletAddress: input.walletAddress,
-        poolId: input.poolId,
-      },
-    });
-
-    return { record: created as unknown as SavedPoolRecord, created: true };
+    this.cache.invalidateWallet(walletAddress);
+    return { record, created: existing === null };
   }
 
   /**
-   * Removes a saved pool reference for a wallet.
+   * Removes a saved pool only when both wallet and pool id match.
    *
-   * @param walletAddress - Wallet identifier
-   * @param poolId - Pool identifier
-   * @returns Number of records removed
+   * A wallet attempting to delete another wallet's record receives a count of
+   * zero and cannot evict the other wallet's cached list.
    */
-  async unsavePool(walletAddress: string, poolId: string): Promise<number> {
+  async unsavePool(walletAddressInput: string, poolId: string): Promise<number> {
+    const walletAddress = normalizeWallet(walletAddressInput);
     const result = await this.prisma.savedPool.deleteMany({
       where: { walletAddress, poolId },
     });
+
+    if (result.count > 0) {
+      this.cache.invalidateWallet(walletAddress);
+    }
     return result.count;
   }
 
   /**
-   * Lists all saved pools for a wallet.
-   *
-   * @param walletAddress - Wallet identifier
-   * @returns Saved pool records
+   * Lists saved pools for exactly one wallet, using a wallet-qualified cache key.
    */
-  async listSavedPools(walletAddress: string): Promise<SavedPoolRecord[]> {
+  async listSavedPools(walletAddressInput: string): Promise<SavedPoolRecord[]> {
+    const walletAddress = normalizeWallet(walletAddressInput);
+    const cached = this.cache.get(walletAddress);
+    if (cached) return cached;
+
     const rows = await this.prisma.savedPool.findMany({
       where: { walletAddress },
       orderBy: { createdAt: "desc" },
     });
 
-    return rows as unknown as SavedPoolRecord[];
+    this.cache.set(walletAddress, rows);
+    return rows.map((row) => ({ ...row }));
   }
 }

--- a/backend/src/services/savedPoolsCache.ts
+++ b/backend/src/services/savedPoolsCache.ts
@@ -1,0 +1,101 @@
+import type { SavedPool } from "@prisma/client";
+
+export interface SavedPoolsCacheOptions {
+  /** Maximum number of wallet entries retained. */
+  maxEntries?: number;
+  /** Time-to-live for each wallet entry. */
+  ttlMs?: number;
+  /** Injectable clock used by deterministic tests. */
+  now?: () => number;
+}
+
+type SavedPoolsCacheEntry = {
+  records: readonly SavedPool[];
+  expiresAt: number;
+};
+
+/**
+ * Build the only supported cache key for saved-pool lists.
+ *
+ * Wallet scope is part of the key by construction. A pool id must never be used
+ * as a list-cache key because the same pool can be saved by many wallets.
+ */
+export function savedPoolsCacheKey(walletAddress: string): string {
+  return `saved-pools:${walletAddress.trim()}`;
+}
+
+/**
+ * Small in-memory LRU cache for saved-pool lists.
+ *
+ * Each entry represents exactly one wallet. Reads move that wallet to the most
+ * recently used position, writes replace only that wallet, and invalidation is
+ * wallet-local. Returned arrays are shallow copies so callers cannot mutate the
+ * cached list accidentally.
+ */
+export class SavedPoolsCache {
+  private readonly entries = new Map<string, SavedPoolsCacheEntry>();
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: SavedPoolsCacheOptions = {}) {
+    this.maxEntries = Math.max(0, options.maxEntries ?? 500);
+    this.ttlMs = Math.max(0, options.ttlMs ?? 30_000);
+    this.now = options.now ?? Date.now;
+  }
+
+  get(walletAddress: string): SavedPool[] | null {
+    const key = savedPoolsCacheKey(walletAddress);
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+
+    // Map insertion order is the LRU order. Reinsert on read to mark as MRU.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.records.map((record) => ({ ...record }));
+  }
+
+  set(walletAddress: string, records: readonly SavedPool[]): void {
+    if (this.maxEntries === 0) return;
+
+    const key = savedPoolsCacheKey(walletAddress);
+    this.entries.delete(key);
+    this.entries.set(key, {
+      records: records.map((record) => ({ ...record })),
+      expiresAt: this.now() + this.ttlMs,
+    });
+
+    while (this.entries.size > this.maxEntries) {
+      const leastRecentlyUsed = this.entries.keys().next().value as string | undefined;
+      if (leastRecentlyUsed === undefined) break;
+      this.entries.delete(leastRecentlyUsed);
+    }
+  }
+
+  invalidateWallet(walletAddress: string): void {
+    this.entries.delete(savedPoolsCacheKey(walletAddress));
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /** Test/diagnostic helper without exposing mutable entry data. */
+  hasWallet(walletAddress: string): boolean {
+    return this.entries.has(savedPoolsCacheKey(walletAddress));
+  }
+
+  /** Test/diagnostic helper for deterministic eviction assertions. */
+  keys(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/backend/tests/saved-pools-cache.spec.ts
+++ b/backend/tests/saved-pools-cache.spec.ts
@@ -1,0 +1,99 @@
+import type { SavedPool } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { SavedPoolsCache, savedPoolsCacheKey } from "../src/services/savedPoolsCache.js";
+
+const WALLET_A = "GA-WALLET-A";
+const WALLET_B = "GB-WALLET-B";
+const WALLET_C = "GC-WALLET-C";
+
+function record(walletAddress: string, poolId: string): SavedPool {
+  const timestamp = new Date("2026-07-15T00:00:00.000Z");
+  return {
+    id: `${walletAddress}-${poolId}`,
+    walletAddress,
+    poolId,
+    poolName: poolId,
+    status: "open",
+    tvl: "1000",
+    asset: "USDC",
+    participantCount: 1,
+    expectedYield: "5% APY",
+    prize: null,
+    opensAt: null,
+    locksAt: null,
+    drawsAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+describe("SavedPoolsCache", () => {
+  it("qualifies every cache key with the wallet address", () => {
+    expect(savedPoolsCacheKey(WALLET_A)).toBe(`saved-pools:${WALLET_A}`);
+    expect(savedPoolsCacheKey(WALLET_B)).not.toBe(savedPoolsCacheKey(WALLET_A));
+  });
+
+  it("keeps overlapping pool ids isolated between wallets", () => {
+    const cache = new SavedPoolsCache();
+    cache.set(WALLET_A, [record(WALLET_A, "shared"), record(WALLET_A, "a-only")]);
+    cache.set(WALLET_B, [record(WALLET_B, "shared"), record(WALLET_B, "b-only")]);
+
+    expect(cache.get(WALLET_A)?.map((item) => item.poolId)).toEqual(["shared", "a-only"]);
+    expect(cache.get(WALLET_B)?.map((item) => item.poolId)).toEqual(["shared", "b-only"]);
+    expect(cache.get(WALLET_A)?.every((item) => item.walletAddress === WALLET_A)).toBe(true);
+    expect(cache.get(WALLET_B)?.every((item) => item.walletAddress === WALLET_B)).toBe(true);
+  });
+
+  it("invalidates one wallet without flushing another wallet", () => {
+    const cache = new SavedPoolsCache();
+    cache.set(WALLET_A, [record(WALLET_A, "shared")]);
+    cache.set(WALLET_B, [record(WALLET_B, "shared")]);
+
+    cache.invalidateWallet(WALLET_A);
+
+    expect(cache.get(WALLET_A)).toBeNull();
+    expect(cache.get(WALLET_B)?.map((item) => item.poolId)).toEqual(["shared"]);
+  });
+
+  it("evicts the deterministic least-recently-used wallet entry", () => {
+    const cache = new SavedPoolsCache({ maxEntries: 2 });
+    cache.set(WALLET_A, [record(WALLET_A, "a")]);
+    cache.set(WALLET_B, [record(WALLET_B, "b")]);
+
+    // Touch A, making B the least recently used entry.
+    expect(cache.get(WALLET_A)).not.toBeNull();
+    cache.set(WALLET_C, [record(WALLET_C, "c")]);
+
+    expect(cache.get(WALLET_B)).toBeNull();
+    expect(cache.get(WALLET_A)).not.toBeNull();
+    expect(cache.get(WALLET_C)).not.toBeNull();
+    expect(cache.keys()).toEqual([
+      savedPoolsCacheKey(WALLET_A),
+      savedPoolsCacheKey(WALLET_C),
+    ]);
+  });
+
+  it("expires stale wallet data without affecting a newer wallet entry", () => {
+    let now = 0;
+    const cache = new SavedPoolsCache({ ttlMs: 10, now: () => now });
+
+    cache.set(WALLET_A, [record(WALLET_A, "stale")]);
+    now = 5;
+    cache.set(WALLET_B, [record(WALLET_B, "fresh")]);
+    now = 11;
+
+    expect(cache.get(WALLET_A)).toBeNull();
+    expect(cache.get(WALLET_B)?.map((item) => item.poolId)).toEqual(["fresh"]);
+    expect(cache.hasWallet(WALLET_B)).toBe(true);
+  });
+
+  it("returns defensive list copies", () => {
+    const cache = new SavedPoolsCache();
+    cache.set(WALLET_A, [record(WALLET_A, "pool-1")]);
+
+    const first = cache.get(WALLET_A)!;
+    first.push(record(WALLET_A, "mutated"));
+
+    expect(cache.get(WALLET_A)?.map((item) => item.poolId)).toEqual(["pool-1"]);
+  });
+});

--- a/backend/tests/saved-pools-isolation.spec.ts
+++ b/backend/tests/saved-pools-isolation.spec.ts
@@ -1,0 +1,155 @@
+import type { PrismaClient, SavedPool } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { SavedPoolsService, type SavedPoolMetadataInput } from "../src/services/savedPools.js";
+import { SavedPoolsCache } from "../src/services/savedPoolsCache.js";
+
+const WALLET_A = "GA-ALICE-WALLET";
+const WALLET_B = "GB-BOB-WALLET";
+
+function pool(poolId: string, poolName = poolId): SavedPoolMetadataInput {
+  return {
+    poolId,
+    poolName,
+    status: "open",
+    tvl: "10000",
+    asset: "USDC",
+    participantCount: 5,
+    expectedYield: "5.2% APY",
+    prize: "500 USDC",
+    opensAt: new Date("2026-07-01T00:00:00.000Z"),
+    locksAt: new Date("2026-07-31T00:00:00.000Z"),
+    drawsAt: new Date("2026-08-01T00:00:00.000Z"),
+  };
+}
+
+function createPrismaHarness() {
+  const rows = new Map<string, SavedPool>();
+  let sequence = 0;
+  const key = (walletAddress: string, poolId: string) => `${walletAddress}:${poolId}`;
+
+  const findUnique = vi.fn(async (args: any) => {
+    const selector = args.where.walletAddress_poolId;
+    return rows.get(key(selector.walletAddress, selector.poolId)) ?? null;
+  });
+
+  const upsert = vi.fn(async (args: any) => {
+    const selector = args.where.walletAddress_poolId;
+    const rowKey = key(selector.walletAddress, selector.poolId);
+    const existing = rows.get(rowKey);
+    const timestamp = new Date(`2026-07-15T00:00:${String(sequence).padStart(2, "0")}.000Z`);
+    sequence += 1;
+
+    const row: SavedPool = existing
+      ? { ...existing, ...args.update, updatedAt: timestamp }
+      : {
+          id: `saved-${sequence}`,
+          ...args.create,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        };
+    rows.set(rowKey, row);
+    return row;
+  });
+
+  const deleteMany = vi.fn(async (args: any) => {
+    const rowKey = key(args.where.walletAddress, args.where.poolId);
+    const deleted = rows.delete(rowKey);
+    return { count: deleted ? 1 : 0 };
+  });
+
+  const findMany = vi.fn(async (args: any) =>
+    [...rows.values()]
+      .filter((row) => row.walletAddress === args.where.walletAddress)
+      .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime()),
+  );
+
+  const prisma = {
+    savedPool: { findUnique, upsert, deleteMany, findMany },
+  } as unknown as PrismaClient;
+
+  return { prisma, rows, findUnique, upsert, deleteMany, findMany };
+}
+
+describe("SavedPoolsService wallet isolation", () => {
+  it("keeps overlapping and unique pools scoped to their owning wallets", async () => {
+    const harness = createPrismaHarness();
+    const service = new SavedPoolsService(harness.prisma, new SavedPoolsCache());
+
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("shared", "Shared A") });
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("a-only") });
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("shared", "Shared B") });
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("b-only") });
+
+    const alice = await service.listSavedPools(WALLET_A);
+    const bob = await service.listSavedPools(WALLET_B);
+
+    expect(alice.map((item) => item.poolId)).toEqual(expect.arrayContaining(["shared", "a-only"]));
+    expect(bob.map((item) => item.poolId)).toEqual(expect.arrayContaining(["shared", "b-only"]));
+    expect(alice.every((item) => item.walletAddress === WALLET_A)).toBe(true);
+    expect(bob.every((item) => item.walletAddress === WALLET_B)).toBe(true);
+    expect(alice.find((item) => item.poolId === "shared")?.poolName).toBe("Shared A");
+    expect(bob.find((item) => item.poolId === "shared")?.poolName).toBe("Shared B");
+  });
+
+  it("does not let wallet A delete wallet B's record", async () => {
+    const harness = createPrismaHarness();
+    const service = new SavedPoolsService(harness.prisma, new SavedPoolsCache());
+
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("b-only") });
+
+    expect(await service.unsavePool(WALLET_A, "b-only")).toBe(0);
+    expect((await service.listSavedPools(WALLET_B)).map((item) => item.poolId)).toEqual(["b-only"]);
+  });
+
+  it("deletes an overlapping pool only for the requesting wallet", async () => {
+    const harness = createPrismaHarness();
+    const service = new SavedPoolsService(harness.prisma, new SavedPoolsCache());
+
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("shared") });
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("shared") });
+
+    expect(await service.unsavePool(WALLET_A, "shared")).toBe(1);
+    expect(await service.listSavedPools(WALLET_A)).toEqual([]);
+    expect((await service.listSavedPools(WALLET_B)).map((item) => item.poolId)).toEqual(["shared"]);
+  });
+
+  it("serves wallet-qualified cache hits and invalidates only the mutated wallet", async () => {
+    const harness = createPrismaHarness();
+    const cache = new SavedPoolsCache();
+    const service = new SavedPoolsService(harness.prisma, cache);
+
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("shared") });
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("shared") });
+
+    await service.listSavedPools(WALLET_A);
+    await service.listSavedPools(WALLET_B);
+    expect(harness.findMany).toHaveBeenCalledTimes(2);
+
+    // Both reads are now cache hits.
+    await service.listSavedPools(WALLET_A);
+    await service.listSavedPools(WALLET_B);
+    expect(harness.findMany).toHaveBeenCalledTimes(2);
+
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("a-new") });
+    expect(cache.hasWallet(WALLET_A)).toBe(false);
+    expect(cache.hasWallet(WALLET_B)).toBe(true);
+
+    // Bob remains a cache hit; only Alice is reloaded from persistence.
+    await service.listSavedPools(WALLET_B);
+    await service.listSavedPools(WALLET_A);
+    expect(harness.findMany).toHaveBeenCalledTimes(3);
+  });
+
+  it("refreshes metadata without changing another wallet's overlapping record", async () => {
+    const harness = createPrismaHarness();
+    const service = new SavedPoolsService(harness.prisma, new SavedPoolsCache());
+
+    await service.savePool({ walletAddress: WALLET_A, pool: pool("shared", "Alice v1") });
+    await service.savePool({ walletAddress: WALLET_B, pool: pool("shared", "Bob pool") });
+    const refreshed = await service.savePool({ walletAddress: WALLET_A, pool: pool("shared", "Alice v2") });
+
+    expect(refreshed.created).toBe(false);
+    expect(refreshed.record.poolName).toBe("Alice v2");
+    expect((await service.listSavedPools(WALLET_B))[0]?.poolName).toBe("Bob pool");
+  });
+});


### PR DESCRIPTION
## What changed
- completed the saved-pools service model so persisted metadata matches the route and Prisma schema
- enforced the composite `(walletAddress, poolId)` selector for save, list, refresh, and delete operations
- added a wallet-qualified `saved-pools:<wallet>` cache with TTL and deterministic LRU eviction
- limited mutation invalidation to the requesting wallet and prevented failed cross-wallet deletes from evicting another user's cache
- added deterministic service and cache regressions for overlapping pools, cross-wallet deletion, metadata refresh, TTL expiry, LRU eviction, and defensive cache reads
- documented the current wallet-ownership boundary and the requirement to derive wallet scope from a verified principal when signed authentication is introduced

## Impact
One wallet cannot list, overwrite, delete, or invalidate another wallet's saved pools, even when both wallets save the same pool id. Stale or capacity-evicted cache entries are removed independently.

## Validation
Tests follow the backend's existing Vitest style and use a deterministic Prisma harness for service isolation. Local dependency execution was not available in this environment; repository CI should run the backend test suite.

Closes #364