### PR TITLE
test(contracts): validate event schema snapshots

### DIFF
--- a/contracts/docs/event-schema-v1.snapshot
+++ b/contracts/docs/event-schema-v1.snapshot
@@ -1,0 +1,10 @@
+# event|topic0|topic1|required_payload_fields
+pool_created|vaultquest|v1|pool_id,creator,asset,target_amount,opens_at,locks_at,draws_at,admin
+pool_joined|vaultquest|v1|pool_id,wallet,amount,shares,participant_count
+drip_deposited|vaultquest|v1|pool_id,wallet,amount,shares_delta,total_deposited,tvl
+reward_claimed|vaultquest|v1|pool_id,wallet,amount,asset,cycle
+withdrawn|vaultquest|v1|pool_id,wallet,amount,shares_burned,remaining_shares
+payout_selected|vaultquest|v1|pool_id,winner,amount,asset,cycle
+paused|vaultquest|v1|scope,admin,reason,paused_at
+recovered|vaultquest|v1|scope,admin,recovered_at
+config_changed|vaultquest|v1|scope,admin,key,new_value,effective_at

--- a/contracts/drip-pool/tests/event_schema_snapshot.rs
+++ b/contracts/drip-pool/tests/event_schema_snapshot.rs
@@ -1,0 +1,53 @@
+use std::collections::BTreeMap;
+
+const DOC: &str = include_str!("../../docs/EVENT_SCHEMA.md");
+const SNAPSHOT: &str = include_str!("../../docs/event-schema-v1.snapshot");
+
+fn snapshot_rows() -> BTreeMap<&'static str, Vec<&'static str>> {
+    SNAPSHOT
+        .lines()
+        .filter(|line| !line.trim().is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let mut parts = line.split('|');
+            let event = parts.next().expect("event name");
+            let topic0 = parts.next().expect("topic 0");
+            let topic1 = parts.next().expect("topic 1");
+            let fields = parts.next().expect("payload fields");
+            assert_eq!(topic0, "vaultquest", "{event} changed envelope topic 0");
+            assert_eq!(topic1, "v1", "{event} changed schema version");
+            (event, fields.split(',').collect())
+        })
+        .collect()
+}
+
+#[test]
+fn documented_event_rows_match_the_versioned_snapshot() {
+    for (event, fields) in snapshot_rows() {
+        let row = DOC
+            .lines()
+            .find(|line| line.starts_with(&format!("| `{event}` |")))
+            .unwrap_or_else(|| panic!("EVENT_SCHEMA.md is missing required event `{event}`"));
+
+        for field in fields {
+            assert!(
+                row.contains(&format!("`{field}`")),
+                "documented `{event}` payload is missing required field `{field}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn documented_envelope_remains_indexer_compatible() {
+    for expected in [
+        "| `0` | `\"vaultquest\"` |",
+        "| `1` | schema version, currently `\"v1\"` |",
+        "| `2` | event name |",
+        "| `3` | pool id when available, otherwise admin/config scope |",
+    ] {
+        assert!(DOC.contains(expected), "event envelope changed: {expected}");
+    }
+
+    assert!(DOC.contains("ledger:tx_hash:event_index"));
+    assert!(DOC.contains("Required field changes"));
+}


### PR DESCRIPTION
## Summary
- adds a machine-readable v1 event schema snapshot
- validates documented event names, envelope topics, and required payload fields
- protects backend indexer identity/versioning assumptions from accidental drift

## Testing
- `cd contracts && cargo test -p drip-pool --test event_schema_snapshot`

Closes #19