### PR TITLE
Feature/refresh controls 412

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           node-version: '20'
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          run_install: false
       - name: Run pnpm audit
         run: pnpm audit

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
 
       - name: Get pnpm store directory

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@fastify/rate-limit": "^11.0.0",
     "@prisma/client": "^5.22.0",
+    "@stellar/stellar-sdk": "^12.0.0",
     "fastify": "^4.28.1",
     "fastify-plugin": "^4.5.1",
     "ioredis": "^5.11.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "build": "prisma generate && tsc -p tsconfig.json",
     "start": "node dist/server.js",
     "db:backup": "tsx src/scripts/backup.ts",
+    "indexer:backfill": "tsx src/scripts/backfill.ts",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/backend/src/routes/walletAuth.ts
+++ b/backend/src/routes/walletAuth.ts
@@ -13,6 +13,7 @@ const challengeBody = z.object({
 
 const verifyBody = z.object({
   challenge_id: z.string().uuid(),
+  payload: z.string().min(1),
   signature: z.string().min(1),
   public_key: z.string().min(1).max(120),
   network: z.string().min(1).max(64)
@@ -45,6 +46,7 @@ export const walletAuthRoutes = (svc: WalletAuthService): FastifyPluginAsync =>
       const body = verifyBody.parse(req.body);
       const session = await svc.verifyChallenge({
         challengeId: body.challenge_id,
+        payload: body.payload,
         signature: body.signature,
         publicKey: body.public_key,
         network: body.network

--- a/backend/src/scripts/backfill.ts
+++ b/backend/src/scripts/backfill.ts
@@ -1,0 +1,132 @@
+/**
+ * Standalone ledger-range backfill script (issue #435).
+ *
+ * Reprocesses a bounded range of Stellar ledgers for missing events.
+ * Reuses the idempotent LedgerService.reconcileEvent.
+ *
+ * Usage:
+ *   tsx src/scripts/backfill.ts --start 1000 --end 2000 [--dry-run]
+ *
+ * Exit codes:
+ *   0 - backfill succeeded
+ *   1 - backfill failed
+ */
+
+import { getEnv } from "../env.js";
+import { createLogger } from "../logger.js";
+import { PrismaClient } from "@prisma/client";
+import { LedgerService } from "../services/ledger.js";
+import { SorobanRpcEventSource, defaultXdrDecoder } from "../services/stellarIndexer.js";
+
+const env = getEnv();
+const logger = createLogger(env.LOG_LEVEL);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let startLedger: number | undefined;
+  let endLedger: number | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--start") {
+      startLedger = parseInt(args[++i], 10);
+    } else if (arg === "--end") {
+      endLedger = parseInt(args[++i], 10);
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    }
+  }
+
+  if (startLedger === undefined || endLedger === undefined || isNaN(startLedger) || isNaN(endLedger)) {
+    console.error("Usage: tsx src/scripts/backfill.ts --start <ledger> --end <ledger> [--dry-run]");
+    process.exit(1);
+  }
+
+  if (endLedger < startLedger) {
+    console.error("Error: --end ledger must be >= --start ledger");
+    process.exit(1);
+  }
+
+  return { startLedger, endLedger, dryRun };
+}
+
+async function run() {
+  const { startLedger, endLedger, dryRun } = parseArgs();
+
+  const prisma = new PrismaClient({
+    datasources: { db: { url: env.DATABASE_URL } }
+  });
+
+  const ledgerService = new LedgerService(prisma);
+  const source = new SorobanRpcEventSource({ rpcUrl: env.SOROBAN_RPC_URL });
+
+  logger.info({ startLedger, endLedger, dryRun }, "Starting ledger range backfill");
+  console.log(`Starting backfill from ledger ${startLedger} to ${endLedger}${dryRun ? ' (DRY RUN)' : ''}...`);
+
+  let processed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    // In a real implementation we would paginate through the ledgers.
+    // For now we assume a single fetchEvents call covers the range.
+    const rawEvents = await source.fetchEvents({ startLedger, endLedger, limit: 10000 });
+
+    for (const raw of rawEvents) {
+      const payload = defaultXdrDecoder.decode(raw);
+      const statusHint = raw.successful ? "confirmed" : "reverted";
+
+      if (dryRun) {
+        // In dry-run, we perform no mutations, but we can check if it exists
+        // to categorize it as skipped vs processed.
+        const existingAction = await prisma.actionLedger.findFirst({ where: { txHash: raw.txHash } });
+        const existingPending = await prisma.pendingEvent.findFirst({ where: { txHash: raw.txHash } });
+        
+        if (existingAction || existingPending) {
+          skipped += 1;
+        } else {
+          processed += 1;
+        }
+      } else {
+        try {
+          await ledgerService.reconcileEvent({
+            txHash: raw.txHash,
+            sorobanEventId: raw.id,
+            eventPayload: payload,
+            statusHint
+          });
+          processed += 1;
+        } catch (err: unknown) {
+          const isDuplicate =
+            err instanceof Error &&
+            (err.message.includes("Unique constraint") ||
+              err.message.includes("P2002") ||
+              (err as any).code === "P2002");
+
+          if (isDuplicate) {
+            skipped += 1;
+          } else {
+            logger.warn({ err, txHash: raw.txHash }, "backfill: failed to process event");
+            failed += 1;
+          }
+        }
+      }
+    }
+
+    console.log("Backfill completed.");
+    console.log(`Processed: ${processed}`);
+    console.log(`Skipped (duplicates): ${skipped}`);
+    console.log(`Failed: ${failed}`);
+    logger.info({ processed, skipped, failed }, "Backfill completed");
+
+  } catch (err) {
+    logger.error({ err }, "Backfill encountered a fatal error");
+    console.error("Backfill encountered a fatal error:", err);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+run();

--- a/backend/src/services/stellarIndexer.ts
+++ b/backend/src/services/stellarIndexer.ts
@@ -46,7 +46,7 @@ export interface IndexResult {
 }
 
 export interface HorizonEventSource {
-  fetchEvents(opts: { cursor: string | null; limit: number }): Promise<RawHorizonEvent[]>;
+  fetchEvents(opts: { cursor?: string | null; startLedger?: number; endLedger?: number; limit?: number }): Promise<RawHorizonEvent[]>;
 }
 
 export interface XdrDecoder {
@@ -226,7 +226,7 @@ export class StellarIndexer {
 export class SorobanRpcEventSource implements HorizonEventSource {
   constructor(private options: SorobanRpcEventSourceOptions) {}
 
-  async fetchEvents(opts: { cursor: string | null; limit: number }): Promise<RawHorizonEvent[]> {
+  async fetchEvents(opts: { cursor?: string | null; startLedger?: number; endLedger?: number; limit?: number }): Promise<RawHorizonEvent[]> {
     // TODO: replace with real Soroban RPC call via @stellar/stellar-sdk
     // e.g. await server.getEvents({ startLedger, filters, limit })
     return [];

--- a/backend/src/services/walletAuth.ts
+++ b/backend/src/services/walletAuth.ts
@@ -16,6 +16,8 @@ import type { PrismaClient } from "@prisma/client";
 import { AppError } from "../errors.js";
 import { ERROR_CODES } from "../constants.js";
 
+import { Keypair } from "@stellar/stellar-sdk";
+
 export interface ChallengeInput {
   walletAddress: string;
   publicKey: string;
@@ -34,6 +36,7 @@ export interface Challenge {
 
 export interface VerifyInput {
   challengeId: string;
+  payload: string;
   signature: string;
   publicKey: string;
   network: string;
@@ -105,9 +108,44 @@ export class WalletAuthService {
       throw AppError.unauthorized();
     }
 
-    // In a real implementation, verify the Stellar signature here.
-    // For now, we accept any non-empty signature in development.
-    if (!input.signature || input.signature.length === 0) {
+    if (!input.signature || input.signature.length === 0 || !input.payload) {
+      throw AppError.unauthorized();
+    }
+
+    let parsedPayload: any;
+    try {
+      parsedPayload = JSON.parse(input.payload);
+    } catch {
+      throw AppError.unauthorized();
+    }
+
+    // Verify every domain field server-side
+    if (
+      parsedPayload.appName !== "VaultQuest" ||
+      parsedPayload.network !== input.network ||
+      parsedPayload.purpose !== "API_AUTHENTICATION" ||
+      parsedPayload.nonce !== challenge.nonce
+    ) {
+      throw AppError.unauthorized();
+    }
+    
+    // Check payload expiry if provided
+    if (parsedPayload.expiresAt) {
+      const payloadExpiry = new Date(parsedPayload.expiresAt);
+      if (isNaN(payloadExpiry.getTime()) || payloadExpiry.getTime() <= Date.now()) {
+        throw AppError.unauthorized();
+      }
+    }
+
+    // Cryptographic verification
+    try {
+      const kp = Keypair.fromPublicKey(input.publicKey);
+      const dataBuffer = Buffer.from(input.payload);
+      const sigBuffer = Buffer.from(input.signature, "base64");
+      if (!kp.verify(dataBuffer, sigBuffer)) {
+        throw AppError.unauthorized();
+      }
+    } catch (err) {
       throw AppError.unauthorized();
     }
 

--- a/backend/tests/walletAuth.spec.ts
+++ b/backend/tests/walletAuth.spec.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { WalletAuthService } from "../src/services/walletAuth";
+import { PrismaClient } from "@prisma/client";
+import { Keypair } from "@stellar/stellar-sdk";
+
+const prisma = new PrismaClient();
+
+describe("WalletAuthService", () => {
+  let svc: WalletAuthService;
+  let kp: Keypair;
+
+  beforeEach(async () => {
+    svc = new WalletAuthService(prisma);
+    kp = Keypair.random();
+    await prisma.walletSession.deleteMany();
+    await prisma.walletChallenge.deleteMany();
+  });
+
+  afterEach(async () => {
+    await prisma.walletSession.deleteMany();
+    await prisma.walletChallenge.deleteMany();
+  });
+
+  it("verifies a valid signed payload with correct domain fields", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    const session = await svc.verifyChallenge({
+      challengeId: challenge.challengeId,
+      payload,
+      signature,
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    expect(session.token).toBeDefined();
+    expect(session.publicKey).toBe(kp.publicKey());
+  });
+
+  it("rejects when appName is wrong", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const payload = JSON.stringify({
+      appName: "EvilApp",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects when network is mismatched", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    // Sign for PUBLIC but send to TESTNET challenge
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "PUBLIC",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects when nonce does not match challenge", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: "some-other-nonce",
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects when signature does not match payload", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+    });
+
+    // Tamper with payload after signing
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+    const tamperedPayload = payload.replace("TESTNET", "PUBLIC");
+
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload: tamperedPayload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects when payload is expired", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const expiredDate = new Date(Date.now() - 1000).toISOString();
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+      expiresAt: expiredDate,
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("rejects replayed signatures", async () => {
+    const challenge = await svc.createChallenge({
+      walletAddress: kp.publicKey(),
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    const payload = JSON.stringify({
+      appName: "VaultQuest",
+      network: "TESTNET",
+      purpose: "API_AUTHENTICATION",
+      nonce: challenge.nonce,
+    });
+
+    const signature = kp.sign(Buffer.from(payload)).toString("base64");
+
+    // First attempt succeeds
+    await svc.verifyChallenge({
+      challengeId: challenge.challengeId,
+      payload,
+      signature,
+      publicKey: kp.publicKey(),
+      network: "TESTNET",
+    });
+
+    // Replay fails
+    await expect(
+      svc.verifyChallenge({
+        challengeId: challenge.challengeId,
+        payload,
+        signature,
+        publicKey: kp.publicKey(),
+        network: "TESTNET",
+      })
+    ).rejects.toThrow("Unauthorized");
+  });
+});

--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -62,10 +62,10 @@ pub enum DataKey {
     Admins,    // Vec<Address> — approved signers
     Threshold, // u32 — current multisig threshold
     Pool,
-    Participant(Address),       // V2 participant storage (#377)
-    ParticipantV1(Address),     // legacy V1 participant storage (migration source)
-    Proposal(u32), // pending admin proposal
-    Token,        // Address — accepted Stellar Asset Contract address (#376)
+    Participant(Address),   // V2 participant storage (#377)
+    ParticipantV1(Address), // legacy V1 participant storage (migration source)
+    Proposal(u32),          // pending admin proposal
+    Token,                  // Address — accepted Stellar Asset Contract address (#376)
 }
 
 // ── Errors ─────────────────────────────────────────────────────────────────
@@ -84,8 +84,8 @@ pub enum Error {
     ThresholdNotMet = 9, // not enough signatures
     AlreadySigned = 10,  // signer already approved this proposal
     ProposalNotFound = 11,
-    ProposalExpired = 12, // proposal ledger deadline passed
-    InvalidAction = 13,   // payload fails reserve or signer-count checks
+    ProposalExpired = 12,    // proposal ledger deadline passed
+    InvalidAction = 13,      // payload fails reserve or signer-count checks
     TokenNotConfigured = 14, // no accepted asset configured (#376)
     AssetMismatch = 15,      // caller sent a different asset than the configured one (#376)
     TransferFailed = 16,     // token transfer failed (#376)
@@ -119,13 +119,13 @@ pub struct ParticipantV1 {
 #[contracttype]
 pub struct Participant {
     pub joined_at: u64,
-    pub deposited: i128,             // total principal deposited
+    pub deposited: i128, // total principal deposited
     pub locked_until: u32,
-    pub lockup_multiplier: u32,      // reward weight in bps — not a principal multiplier
-    pub yield_accrued: i128,         // realized yield credited by admin (#382)
-    pub prize: i128,                 // prize winnings from draw_winner (#377)
-    pub claimed_reward: i128,        // cumulative rewards already claimed (#377)
-    pub withdrawn_principal: i128,   // cumulative principal already withdrawn (#377)
+    pub lockup_multiplier: u32, // reward weight in bps — not a principal multiplier
+    pub yield_accrued: i128,    // realized yield credited by admin (#382)
+    pub prize: i128,            // prize winnings from draw_winner (#377)
+    pub claimed_reward: i128,   // cumulative rewards already claimed (#377)
+    pub withdrawn_principal: i128, // cumulative principal already withdrawn (#377)
 }
 
 /// A pending admin action that requires multi-sig approval.
@@ -214,7 +214,11 @@ impl DripPool {
             return Ok(p);
         }
         let v1_key = DataKey::ParticipantV1(who.clone());
-        if let Some(old) = env.storage().persistent().get::<DataKey, ParticipantV1>(&v1_key) {
+        if let Some(old) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, ParticipantV1>(&v1_key)
+        {
             let new_p = Participant {
                 joined_at: old.joined_at,
                 deposited: old.deposited,
@@ -237,7 +241,9 @@ impl DripPool {
     fn save_participant(env: &Env, who: &Address, p: &Participant) {
         let key = DataKey::Participant(who.clone());
         env.storage().persistent().set(&key, p);
-        env.storage().persistent().remove(&DataKey::ParticipantV1(who.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ParticipantV1(who.clone()));
         Self::bump_participant(env, &key);
     }
 
@@ -247,7 +253,9 @@ impl DripPool {
         if env.storage().persistent().has(&key) {
             return true;
         }
-        env.storage().persistent().has(&DataKey::ParticipantV1(who.clone()))
+        env.storage()
+            .persistent()
+            .has(&DataKey::ParticipantV1(who.clone()))
     }
 
     // ── Token helpers (#376) ──────────────────────────────────────────────
@@ -323,10 +331,8 @@ impl DripPool {
         Self::require_signer(&env, &caller)?;
         env.storage().instance().set(&DataKey::Token, &token);
         Self::bump_instance(&env);
-        env.events().publish(
-            (symbol_short!("pool"), symbol_short!("token_set")),
-            token,
-        );
+        env.events()
+            .publish((symbol_short!("pool"), symbol_short!("token_set")), token);
         Ok(())
     }
 

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -947,7 +947,7 @@ fn claim_and_withdraw_total_limited() {
     // Total = deposited + rewards = 1500, which is >= total paid = 1500 ✓
     let pool = client.pool();
     assert_eq!(pool.total_deposited, 1_000 + 0); // alice deposited 1000, admin 0
-    // pool.total_deposited is not reduced by claims/prizes (they are not escrow releases)
+                                                 // pool.total_deposited is not reduced by claims/prizes (they are not escrow releases)
 }
 
 /// Double-spend protection: deposit cannot be claimed twice.

--- a/package.json
+++ b/package.json
@@ -54,5 +54,11 @@
     "tailwindcss": "^3.4.17",
     "vitest": "^2.1.8"
   },
+  "pnpm": {
+    "overrides": {
+      "undici": "^6.0.0",
+      "fast-uri": "^3.0.0"
+    }
+  },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
+      '@stellar/stellar-sdk':
+        specifier: ^12.0.0
+        version: 12.3.0(bare-url@2.4.3)
       fastify:
         specifier: ^4.28.1
         version: 4.29.1
@@ -2196,9 +2199,16 @@ packages:
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
 
+  '@stellar/stellar-base@12.1.1':
+    resolution: {integrity: sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
+
   '@stellar/stellar-base@14.0.1':
     resolution: {integrity: sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==}
     engines: {node: '>=20.0.0'}
+
+  '@stellar/stellar-sdk@12.3.0':
+    resolution: {integrity: sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==}
 
   '@stellar/stellar-sdk@14.2.0':
     resolution: {integrity: sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==}
@@ -3202,6 +3212,14 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bare-addon-resolve@1.10.1:
+    resolution: {integrity: sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
   bare-events@2.8.3:
     resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
     peerDependencies:
@@ -3219,12 +3237,23 @@ packages:
       bare-buffer:
         optional: true
 
+  bare-module-resolve@1.12.4:
+    resolution: {integrity: sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
   bare-os@3.9.1:
     resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
     engines: {bare: '>=1.14.0'}
 
   bare-path@3.0.0:
     resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
 
   bare-stream@2.13.1:
     resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
@@ -5856,6 +5885,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6096,6 +6129,9 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sodium-native@4.3.3:
+    resolution: {integrity: sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==}
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -9937,6 +9973,19 @@ snapshots:
 
   '@stellar/js-xdr@3.1.2': {}
 
+  '@stellar/stellar-base@12.1.1(bare-url@2.4.3)':
+    dependencies:
+      '@stellar/js-xdr': 3.1.2
+      base32.js: 0.1.0
+      bignumber.js: 9.3.1
+      buffer: 6.0.3
+      sha.js: 2.4.12
+      tweetnacl: 1.0.3
+    optionalDependencies:
+      sodium-native: 4.3.3(bare-url@2.4.3)
+    transitivePeerDependencies:
+      - bare-url
+
   '@stellar/stellar-base@14.0.1':
     dependencies:
       '@noble/curves': 1.9.7
@@ -9945,6 +9994,20 @@ snapshots:
       bignumber.js: 9.3.1
       buffer: 6.0.3
       sha.js: 2.4.12
+
+  '@stellar/stellar-sdk@12.3.0(bare-url@2.4.3)':
+    dependencies:
+      '@stellar/stellar-base': 12.1.1(bare-url@2.4.3)
+      axios: 1.16.1
+      bignumber.js: 9.3.1
+      eventsource: 2.0.2
+      randombytes: 2.1.0
+      toml: 3.0.0
+      urijs: 1.19.11
+    transitivePeerDependencies:
+      - bare-url
+      - debug
+      - supports-color
 
   '@stellar/stellar-sdk@14.2.0':
     dependencies:
@@ -10650,6 +10713,14 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.41)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.41)(lightningcss@1.32.0)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))':
     dependencies:
@@ -12008,6 +12079,14 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bare-addon-resolve@1.10.1(bare-url@2.4.3):
+    dependencies:
+      bare-module-resolve: 1.12.4(bare-url@2.4.3)
+      bare-semver: 1.1.0
+    optionalDependencies:
+      bare-url: 2.4.3
+    optional: true
+
   bare-events@2.8.3: {}
 
   bare-fs@4.7.1:
@@ -12021,11 +12100,21 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  bare-module-resolve@1.12.4(bare-url@2.4.3):
+    dependencies:
+      bare-semver: 1.1.0
+    optionalDependencies:
+      bare-url: 2.4.3
+    optional: true
+
   bare-os@3.9.1: {}
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.9.1
+
+  bare-semver@1.1.0:
+    optional: true
 
   bare-stream@2.13.1(bare-events@2.8.3):
     dependencies:
@@ -12933,8 +13022,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -12953,7 +13042,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12964,22 +13053,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12990,7 +13079,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -15087,6 +15176,13 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-addon@1.2.0(bare-url@2.4.3):
+    dependencies:
+      bare-addon-resolve: 1.10.1(bare-url@2.4.3)
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -15388,6 +15484,13 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+
+  sodium-native@4.3.3(bare-url@2.4.3):
+    dependencies:
+      require-addon: 1.2.0(bare-url@2.4.3)
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
 
   sonic-boom@2.8.0:
     dependencies:
@@ -16202,7 +16305,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.19.41)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.41)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^6.0.0
+  fast-uri: ^3.0.0
+
 importers:
 
   .:
@@ -669,10 +673,6 @@ packages:
 
   '@fastify/ajv-compiler@3.6.0':
     resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@fastify/error@3.4.1':
     resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
@@ -4193,9 +4193,6 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@2.4.0:
-    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -6498,9 +6495,9 @@ packages:
   undici-types@7.26.0:
     resolution: {integrity: sha512-OY7qWYg4TsPpqg/kL2FfNnGA8cmAhPpLt45XQ2jd8p9UobYQ7Q09LeiCq5QwZhlKNLBj0iTUlBNhs4M2AVFmxA==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -7507,9 +7504,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
-      fast-uri: 2.4.0
-
-  '@fastify/busboy@2.1.1': {}
+      fast-uri: 3.1.2
 
   '@fastify/error@3.4.1': {}
 
@@ -13224,7 +13219,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-deep-equal: 3.1.3
-      fast-uri: 2.4.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 1.0.1
       rfdc: 1.4.1
 
@@ -13239,8 +13234,6 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-stable-stringify@1.0.0: {}
-
-  fast-uri@2.4.0: {}
 
   fast-uri@3.1.2: {}
 
@@ -15696,7 +15689,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.5
-      undici: 5.29.0
+      undici: 6.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -15897,9 +15890,7 @@ snapshots:
 
   undici-types@7.26.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.28.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:

--- a/stellar-wallet-connect/src/components/DataRefreshControl.test.tsx
+++ b/stellar-wallet-connect/src/components/DataRefreshControl.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DataRefreshControl } from "./DataRefreshControl";
+
+describe("DataRefreshControl", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the timestamp correctly", () => {
+    const now = Date.now();
+    const { rerender } = render(
+      <DataRefreshControl updatedAt={now} stale={false} fetching={false} partialError={null} onRefresh={() => {}} />
+    );
+    expect(screen.getByText("Updated: Just now")).toBeDefined();
+
+    // Advance 30 seconds
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    
+    // The component updates its text every 10s
+    expect(screen.getByText("Updated: 30s ago")).toBeDefined();
+  });
+
+  it("shows stale indicator when stale is true", () => {
+    render(<DataRefreshControl updatedAt={Date.now()} stale={true} fetching={false} partialError={null} onRefresh={() => {}} />);
+    expect(screen.getByText("Stale")).toBeDefined();
+  });
+
+  it("shows fetching indicator and disables button when fetching is true", () => {
+    render(<DataRefreshControl updatedAt={Date.now()} stale={false} fetching={true} partialError={null} onRefresh={() => {}} />);
+    expect(screen.getByText("Refreshing…")).toBeDefined();
+    expect(screen.queryByText(/Updated:/)).toBeNull(); // Should hide timestamp
+    const button = screen.getByRole("button", { name: "Refresh data" });
+    expect(button).toHaveProperty("disabled", true);
+  });
+
+  it("shows partialError when present", () => {
+    render(
+      <DataRefreshControl
+        updatedAt={Date.now()}
+        stale={false}
+        fetching={false}
+        partialError={new Error("Network fail")}
+        onRefresh={() => {}}
+      />
+    );
+    expect(screen.getByText("Update failed")).toBeDefined();
+    // The timestamp should be hidden because error takes precedence
+    expect(screen.queryByText(/Updated:/)).toBeNull();
+  });
+
+  it("calls onRefresh when clicked", () => {
+    const onRefresh = vi.fn();
+    render(<DataRefreshControl updatedAt={Date.now()} stale={false} fetching={false} partialError={null} onRefresh={onRefresh} />);
+    
+    const button = screen.getByRole("button", { name: "Refresh data" });
+    fireEvent.click(button);
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+});

--- a/stellar-wallet-connect/src/components/DataRefreshControl.tsx
+++ b/stellar-wallet-connect/src/components/DataRefreshControl.tsx
@@ -1,0 +1,91 @@
+import { FC, useEffect, useState } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { StaleIndicator } from "./FallbackStates";
+
+export interface DataRefreshControlProps {
+  updatedAt: number | null;
+  stale: boolean;
+  fetching: boolean;
+  partialError: Error | null;
+  onRefresh: () => void;
+  className?: string;
+}
+
+function useRelativeTime(timestamp: number | null): string {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    if (!timestamp) {
+      setText("");
+      return;
+    }
+
+    const update = () => {
+      const ms = Date.now() - timestamp;
+      const seconds = Math.floor(ms / 1000);
+      const minutes = Math.floor(seconds / 60);
+      const hours = Math.floor(minutes / 60);
+
+      if (seconds < 10) setText("Just now");
+      else if (seconds < 60) setText(`${seconds}s ago`);
+      else if (minutes < 60) setText(`${minutes}m ago`);
+      else if (hours < 24) setText(`${hours}h ago`);
+      else setText("Over 1d ago");
+    };
+
+    update();
+    const interval = setInterval(update, 10000);
+    return () => clearInterval(interval);
+  }, [timestamp]);
+
+  return text;
+}
+
+/**
+ * Inline control displaying the age of data, alongside a manual refresh button.
+ * Handles stale indicators and non-fatal refresh errors.
+ */
+export const DataRefreshControl: FC<DataRefreshControlProps> = ({
+  updatedAt,
+  stale,
+  fetching,
+  partialError,
+  onRefresh,
+  className = "",
+}) => {
+  const timeText = useRelativeTime(updatedAt);
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      {stale && !fetching && !partialError && <StaleIndicator label="Stale" />}
+      {fetching && <StaleIndicator label="Refreshing…" />}
+      
+      {partialError && (
+        <span
+          role="alert"
+          title={partialError.message}
+          className="inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-2.5 py-1 text-xs font-medium text-red-400"
+        >
+          <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+          Update failed
+        </span>
+      )}
+
+      {updatedAt && !fetching && !partialError && !stale && (
+        <span className="text-xs text-gray-400">
+          Updated: {timeText}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={fetching}
+        aria-label="Refresh data"
+        className="inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-red-900/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <RefreshCw className={`h-4 w-4 ${fetching ? "animate-spin" : ""}`} aria-hidden="true" />
+      </button>
+    </div>
+  );
+};

--- a/stellar-wallet-connect/src/core/walletService.test.ts
+++ b/stellar-wallet-connect/src/core/walletService.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setConnection, disconnect } from "./walletService.js";
+import { vaultQueryClient } from "../vault/data/queryClient.js";
+
+// Mock dependencies
+vi.mock("../vault/data/queryClient.js", () => {
+  return {
+    vaultQueryClient: {
+      clear: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./kit.js", () => ({
+  kit: {
+    getNetwork: vi.fn().mockResolvedValue({ network: "TESTNET" }),
+  }
+}));
+
+describe("walletService - Account Switching (#409)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    disconnect();
+  });
+
+  it("should reset user-scoped state when switching accounts rapidly", () => {
+    // Set some dummy data in localStorage for pending tx state
+    localStorage.setItem("vaultquest_pending_tx_state", JSON.stringify({ pending: true }));
+
+    // Connect wallet A
+    setConnection("G_WALLET_A", "freighter");
+
+    // Initially, clear shouldn't be called for a fresh connection
+    expect(vaultQueryClient.clear).not.toHaveBeenCalled();
+    expect(localStorage.getItem("vaultquest_pending_tx_state")).toBeTruthy();
+
+    // Switch to wallet B
+    setConnection("G_WALLET_B", "freighter");
+
+    // Clear MUST be called to abort in-flight requests and drop stale caches
+    expect(vaultQueryClient.clear).toHaveBeenCalledTimes(1);
+    
+    // Pending tx state for the old wallet MUST be removed
+    expect(localStorage.getItem("vaultquest_pending_tx_state")).toBeNull();
+    
+    // Ensure the new connection is stored properly
+    expect(localStorage.getItem("publicKey")).toBe("G_WALLET_B");
+  });
+});

--- a/stellar-wallet-connect/src/core/walletService.ts
+++ b/stellar-wallet-connect/src/core/walletService.ts
@@ -99,10 +99,7 @@ function setConnection(publicKey: string, provider: string): void {
   connectionState.provider = appProvider;
 
   if (previousPublicKey && previousPublicKey !== publicKey) {
-    vaultQueryClient.clear();
-    if (typeof localStorage !== "undefined") {
-      localStorage.removeItem("vaultquest_pending_tx_state");
-    }
+    resetUserScopedState();
   }
 
   if (typeof localStorage !== "undefined") {
@@ -131,6 +128,8 @@ function disconnect(): void {
     localStorage.removeItem("walletProvider");
   }
 
+  resetUserScopedState();
+
   connectedPublicKey.set("");
   connectedNetwork.set(null);
   isNetworkMismatch.set(false);
@@ -139,6 +138,13 @@ function disconnect(): void {
 export async function checkAndNotifyFunding(): Promise<void> {
   // The product flow no longer opens the wallet funding modal automatically.
   return;
+}
+
+function resetUserScopedState(): void {
+  vaultQueryClient.clear();
+  if (typeof localStorage !== "undefined") {
+    localStorage.removeItem("vaultquest_pending_tx_state");
+  }
 }
 
 async function getWalletAvailability(provider: WalletType): Promise<{

--- a/stellar-wallet-connect/src/core/walletService.ts
+++ b/stellar-wallet-connect/src/core/walletService.ts
@@ -11,6 +11,7 @@ import {
   normalizeStellarNetwork,
 } from "../lib/wallets.js";
 import { HorizonPool } from "./horizonPool.js";
+import { vaultQueryClient } from "../vault/data/queryClient.js";
 
 export interface WalletConnectionResult {
   address: string;
@@ -92,8 +93,17 @@ function setConnection(publicKey: string, provider: string): void {
     throw new Error(`Unsupported Stellar wallet provider: ${provider}`);
   }
 
+  const previousPublicKey = connectionState.publicKey;
+
   connectionState.publicKey = publicKey;
   connectionState.provider = appProvider;
+
+  if (previousPublicKey && previousPublicKey !== publicKey) {
+    vaultQueryClient.clear();
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem("vaultquest_pending_tx_state");
+    }
+  }
 
   if (typeof localStorage !== "undefined") {
     localStorage.setItem("publicKey", publicKey);

--- a/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
@@ -4,9 +4,9 @@ import { Bookmark, Coins, Trophy, Users } from "lucide-react";
 import {
   ErrorState,
   LoadingState,
-  StaleIndicator,
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
+import { DataRefreshControl } from "../../components/DataRefreshControl";
 import type { PoolActionType, PoolStatus, PoolSummary, UserPosition } from "../contract/types";
 import { formatAmount, formatDate, truncateAddress } from "../lib/format";
 import { OnboardingChecklist } from "./OnboardingChecklist";
@@ -41,6 +41,10 @@ export interface PoolDetailProps {
   showOnboarding?: boolean;
   /** When provided, renders an inline transaction timeline below the action buttons. */
   txFlow?: TxFlowResult;
+  updatedAt?: number | null;
+  fetching?: boolean;
+  partialError?: Error | null;
+  refetch?: () => void;
 }
 
 const Stat: FC<{ icon: ReactNode; label: string; value: string }> = ({ icon, label, value }) => (
@@ -92,6 +96,10 @@ export const PoolDetail: FC<PoolDetailProps> = ({
   savingSavedState = false,
   showOnboarding = true,
   txFlow,
+  updatedAt = null,
+  fetching = false,
+  partialError = null,
+  refetch = () => {},
 }) => {
   const mismatch = useStore(isNetworkMismatch);
 
@@ -130,7 +138,13 @@ export const PoolDetail: FC<PoolDetailProps> = ({
               {savingSavedState ? "Saving…" : saved ? "Unsave pool" : "Save pool"}
             </button>
           )}
-          {stale && <StaleIndicator />}
+          <DataRefreshControl
+            updatedAt={updatedAt}
+            stale={stale}
+            fetching={fetching}
+            partialError={partialError}
+            onRefresh={refetch}
+          />
         </div>
       </header>
 

--- a/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
+++ b/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
@@ -4,9 +4,9 @@ import {
   EmptyState,
   ErrorState,
   LoadingState,
-  StaleIndicator,
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
+import { DataRefreshControl } from "../../components/DataRefreshControl";
 import type { RewardHistoryEntry, RewardOutcome } from "../contract/types";
 import { explorerTxUrl, formatAmount, formatDate, truncateAddress, type StellarNetwork } from "../lib/format";
 import { TransactionTimeline } from "../../components/TransactionTimeline";
@@ -33,6 +33,10 @@ export interface RewardHistoryProps {
   /** When provided, renders an inline claim transaction timeline and wires claim buttons. */
   claimFlow?: TxFlowResult;
   onClaim?: (entry: RewardHistoryEntry) => void;
+  updatedAt?: number | null;
+  fetching?: boolean;
+  partialError?: Error | null;
+  refetch?: () => void;
 }
 
 const OUTCOME_BADGE: Record<RewardOutcome, { label: string; className: string }> = {
@@ -80,6 +84,10 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
   onConnect,
   claimFlow,
   onClaim,
+  updatedAt = null,
+  fetching = false,
+  partialError = null,
+  refetch = () => {},
 }) => {
   if (!walletConnected) {
     return <WalletDisconnectedState onConnect={onConnect} />;
@@ -107,7 +115,13 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
           <Trophy className="h-5 w-5 text-red-400" aria-hidden="true" />
           Reward history
         </h2>
-        {stale && <StaleIndicator />}
+        <DataRefreshControl
+          updatedAt={updatedAt}
+          stale={stale}
+          fetching={fetching}
+          partialError={partialError}
+          onRefresh={refetch}
+        />
       </header>
 
       {/* Desktop: table */}

--- a/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.tsx
+++ b/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.tsx
@@ -4,9 +4,9 @@ import {
   EmptyState,
   ErrorState,
   LoadingState,
-  StaleIndicator,
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
+import { DataRefreshControl } from "../../components/DataRefreshControl";
 import type { SavedPoolEntry, PoolStatus } from "../contract/types";
 import { formatAmount, formatDate } from "../lib/format";
 import PoolStatusBadge from "./PoolStatusBadge";
@@ -31,6 +31,10 @@ export interface SavedPoolsWatchlistProps {
   onOpenPool?: (poolId: string) => void;
   onUnsave?: (entry: SavedPoolEntry) => void;
   savingPoolId?: string | null;
+  updatedAt?: number | null;
+  fetching?: boolean;
+  partialError?: Error | null;
+  refetch?: () => void;
 }
 
 const HeaderIcon: FC<{ children: ReactNode }> = ({ children }) => (
@@ -50,6 +54,10 @@ export const SavedPoolsWatchlist: FC<SavedPoolsWatchlistProps> = ({
   onOpenPool,
   onUnsave,
   savingPoolId = null,
+  updatedAt = null,
+  fetching = false,
+  partialError = null,
+  refetch = () => {},
 }) => {
   if (!walletConnected) {
     return <WalletDisconnectedState onConnect={onConnect} />;
@@ -82,7 +90,13 @@ export const SavedPoolsWatchlist: FC<SavedPoolsWatchlistProps> = ({
             <p className="text-sm text-gray-400">Pools you bookmarked for later.</p>
           </div>
         </div>
-        {stale && <StaleIndicator />}
+        <DataRefreshControl
+          updatedAt={updatedAt}
+          stale={stale}
+          fetching={fetching}
+          partialError={partialError}
+          onRefresh={refetch}
+        />
       </header>
 
       <div className="hidden overflow-hidden rounded-2xl border border-red-900/30 bg-[#1A0505]/60 lg:block">

--- a/stellar-wallet-connect/src/vault/data/apiClient.ts
+++ b/stellar-wallet-connect/src/vault/data/apiClient.ts
@@ -134,67 +134,68 @@ export class VaultApiClient {
     return `${this.baseUrl}${path}${query}`;
   }
 
-  async listPools(): Promise<PoolSummary[]> {
+  async listPools(options?: { signal?: AbortSignal }): Promise<PoolSummary[]> {
     const body = await parseJsonResponse<ApiEnvelope<PoolSummary[]>>(
-      await fetch(this.url("/pools")),
+      await fetch(this.url("/pools"), { signal: options?.signal }),
       "Pool discovery request failed",
     );
     return body.data;
   }
 
-  async listPrizeViews(walletAddress?: string | null): Promise<RewardHistoryEntry[]> {
+  async listPrizeViews(walletAddress?: string | null, options?: { signal?: AbortSignal }): Promise<RewardHistoryEntry[]> {
     const params = walletAddress ? new URLSearchParams({ wallet: walletAddress }) : undefined;
     const body = await parseJsonResponse<ApiEnvelope<RewardHistoryEntry[]>>(
-      await fetch(this.url("/prizes", params)),
+      await fetch(this.url("/prizes", params), { signal: options?.signal }),
       "Prize views request failed",
     );
     return body.data;
   }
 
-  async getTransactionStatus(actionId: string): Promise<TransactionStatusView> {
+  async getTransactionStatus(actionId: string, options?: { signal?: AbortSignal }): Promise<TransactionStatusView> {
     const body = await parseJsonResponse<ApiEnvelope<ActionApiRecord>>(
-      await fetch(this.url(`/actions/${encodeURIComponent(actionId)}`)),
+      await fetch(this.url(`/actions/${encodeURIComponent(actionId)}`), { signal: options?.signal }),
       "Transaction status request failed",
     );
     return toTransactionStatus(body.data);
   }
 
-  async listSavedPools(walletAddress: string): Promise<SavedPoolEntry[]> {
+  async listSavedPools(walletAddress: string, options?: { signal?: AbortSignal }): Promise<SavedPoolEntry[]> {
     const params = new URLSearchParams({ wallet: walletAddress });
     const body = await parseJsonResponse<ApiEnvelope<SavedPoolApiRecord[]>>(
-      await fetch(this.url("/saved-pools", params)),
+      await fetch(this.url("/saved-pools", params), { signal: options?.signal }),
       "Saved pools request failed",
     );
     return body.data.map(toSavedPoolEntry);
   }
 
-  async savePool(walletAddress: string, pool: PoolSummary): Promise<SavedPoolEntry> {
+  async savePool(walletAddress: string, pool: PoolSummary, options?: { signal?: AbortSignal }): Promise<SavedPoolEntry> {
     const body = await parseJsonResponse<ApiEnvelope<{ saved: SavedPoolApiRecord }>>(
       await fetch(this.url("/saved-pools"), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ wallet_address: walletAddress, pool: poolToPayload(pool) }),
+        signal: options?.signal,
       }),
       "Saving pool failed",
     );
     return toSavedPoolEntry(body.data.saved);
   }
 
-  async unsavePool(walletAddress: string, poolId: string): Promise<number> {
+  async unsavePool(walletAddress: string, poolId: string, options?: { signal?: AbortSignal }): Promise<number> {
     const params = new URLSearchParams({ wallet: walletAddress });
     const body = await parseJsonResponse<ApiEnvelope<{ deleted: number }>>(
-      await fetch(this.url(`/saved-pools/${encodeURIComponent(poolId)}`, params), { method: "DELETE" }),
+      await fetch(this.url(`/saved-pools/${encodeURIComponent(poolId)}`, params), { method: "DELETE", signal: options?.signal }),
       "Removing saved pool failed",
     );
     return body.data.deleted;
   }
 
-  async exportActivity(options: { wallet: string; format: "json" | "csv"; from?: string; to?: string }): Promise<Blob> {
+  async exportActivity(options: { wallet: string; format: "json" | "csv"; from?: string; to?: string; signal?: AbortSignal }): Promise<Blob> {
     const params = new URLSearchParams({ wallet: options.wallet, format: options.format });
     if (options.from) params.set("from", options.from);
     if (options.to) params.set("to", options.to);
 
-    const res = await fetch(this.url("/actions/export", params));
+    const res = await fetch(this.url("/actions/export", params), { signal: options.signal });
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
       throw new Error(body.error?.message ?? `Export failed (${res.status})`);

--- a/stellar-wallet-connect/src/vault/data/queryClient.ts
+++ b/stellar-wallet-connect/src/vault/data/queryClient.ts
@@ -76,7 +76,11 @@ export class VaultQueryClient {
   }
 
   notify(key: readonly unknown[]): void {
-    this.getEntry(key).listeners.forEach((listener) => listener());
+    const id = serializeQueryKey(key);
+    const entry = this.entries.get(id);
+    if (entry) {
+      entry.listeners.forEach((listener) => listener());
+    }
   }
 
   isStale(key: readonly unknown[], staleTimeMs: number): boolean {

--- a/stellar-wallet-connect/src/vault/data/queryClient.ts
+++ b/stellar-wallet-connect/src/vault/data/queryClient.ts
@@ -21,7 +21,7 @@ export interface VaultQueryOptions<T> {
   enabled?: boolean;
   staleTimeMs?: number;
   refetchIntervalMs?: number;
-  fetcher: () => Promise<T>;
+  fetcher: (opts: { signal: AbortSignal }) => Promise<T>;
 }
 
 type Listener = () => void;
@@ -35,6 +35,7 @@ interface CacheEntry<T> {
   promise: Promise<T> | null;
   invalidated: boolean;
   listeners: Set<Listener>;
+  abortController?: AbortController;
 }
 
 function toError(err: unknown): Error {
@@ -58,6 +59,7 @@ export class VaultQueryClient {
       promise: null,
       invalidated: false,
       listeners: new Set(),
+      abortController: undefined,
     };
     this.entries.set(id, created as CacheEntry<unknown>);
     return created;
@@ -83,15 +85,18 @@ export class VaultQueryClient {
     return Date.now() - entry.updatedAt > staleTimeMs;
   }
 
-  fetchQuery<T>(key: readonly unknown[], fetcher: () => Promise<T>): Promise<T> {
+  fetchQuery<T>(key: readonly unknown[], fetcher: (opts: { signal: AbortSignal }) => Promise<T>): Promise<T> {
     const entry = this.getEntry<T>(key);
     if (entry.promise) return entry.promise;
+
+    const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+    entry.abortController = controller;
 
     entry.error = null;
     entry.partialError = null;
     this.notify(key);
 
-    entry.promise = fetcher()
+    entry.promise = fetcher({ signal: controller?.signal as AbortSignal })
       .then((data) => {
         entry.data = data;
         entry.error = null;
@@ -138,6 +143,7 @@ export class VaultQueryClient {
   }
 
   clear(): void {
+    this.entries.forEach((entry) => entry.abortController?.abort());
     this.entries.clear();
   }
 }

--- a/stellar-wallet-connect/src/vault/hooks.ts
+++ b/stellar-wallet-connect/src/vault/hooks.ts
@@ -125,10 +125,10 @@ export function usePoolDiscovery(
   const query = useVaultQuery({
     key: vaultQueryKeys.pools(backendReads ? "backend-first" : "contract-only"),
     staleTimeMs: 30_000,
-    fetcher: async () => {
+    fetcher: async (opts) => {
       if (backendReads) {
         try {
-          return await api.listPools();
+          return await api.listPools({ signal: opts.signal });
         } catch (err) {
           if (!contractFallbackReads || !client.listPools) throw err;
         }
@@ -158,10 +158,10 @@ export function usePrizeViews(
   const query = useVaultQuery({
     key: vaultQueryKeys.prizes(options.walletAddress),
     staleTimeMs: 60_000,
-    fetcher: async () => {
+    fetcher: async (opts) => {
       if (backendReads) {
         try {
-          return await api.listPrizeViews(options.walletAddress);
+          return await api.listPrizeViews(options.walletAddress, { signal: opts.signal });
         } catch (err) {
           if (!contractFallbackReads) throw err;
         }
@@ -197,10 +197,10 @@ export function useAccountView(
     key: vaultQueryKeys.account(walletAddress),
     enabled: Boolean(walletAddress),
     staleTimeMs: 30_000,
-    fetcher: async () => {
+    fetcher: async (opts) => {
       if (!walletAddress) throw new Error("Connect a wallet to load account data.");
       const [savedPools, rewards, positions] = await Promise.all([
-        api.listSavedPools(walletAddress),
+        api.listSavedPools(walletAddress, { signal: opts.signal }),
         client.listRewardHistory(walletAddress),
         Promise.all(poolIds.map((poolId) => client.getUserPosition(poolId, walletAddress))),
       ]);
@@ -235,7 +235,7 @@ export function useSavedPools(
     key: vaultQueryKeys.savedPools(walletAddress),
     enabled: Boolean(walletAddress),
     staleTimeMs: 30_000,
-    fetcher: async () => (walletAddress ? api.listSavedPools(walletAddress) : []),
+    fetcher: async (opts) => (walletAddress ? api.listSavedPools(walletAddress, { signal: opts.signal }) : []),
   });
 
   const invalidateSavedPools = useCallback(() => {
@@ -303,9 +303,9 @@ export function useTransactionStatus(
     enabled: Boolean(actionId),
     staleTimeMs: polling ? 0 : 15_000,
     refetchIntervalMs: polling ? (options.pollMs ?? 5_000) : undefined,
-    fetcher: async () => {
+    fetcher: async (opts) => {
       if (!actionId) throw new Error("Transaction id is required.");
-      const status = await api.getTransactionStatus(actionId);
+      const status = await api.getTransactionStatus(actionId, { signal: opts.signal });
       if (isTerminalTransaction(status.status)) {
         if (status.poolId) {
           vaultQueryClient.invalidateQueries(vaultQueryKeys.pool(status.poolId));

--- a/stellar-wallet-connect/src/vault/hooks.ts
+++ b/stellar-wallet-connect/src/vault/hooks.ts
@@ -130,6 +130,7 @@ export function usePoolDiscovery(
         try {
           return await api.listPools({ signal: opts.signal });
         } catch (err) {
+          if (opts.signal?.aborted) throw err;
           if (!contractFallbackReads || !client.listPools) throw err;
         }
       }
@@ -163,6 +164,7 @@ export function usePrizeViews(
         try {
           return await api.listPrizeViews(options.walletAddress, { signal: opts.signal });
         } catch (err) {
+          if (opts.signal?.aborted) throw err;
           if (!contractFallbackReads) throw err;
         }
       }


### PR DESCRIPTION
Closes #412

New Features & Enhancements:

Manual Refresh Controls: Added a unified DataRefreshControl component across the frontend (PoolDetail, RewardHistory, SavedPoolsWatchlist) that allows users to manually re-fetch data.
Stale-Data Timestamps: The DataRefreshControl automatically computes and updates a relative timestamp (e.g., "Updated: Just now", "Updated: 2m ago") based on the updatedAt property exposed by the useVaultQuery hook.
Safe UX Constraints:
The manual refresh button becomes disabled when a request is actively fetching, preventing redundant API calls.
If a background or manual refresh fails, existing data is preserved and a non-intrusive Update failed warning badge appears instead of a full-screen ErrorState.
Testing: Added DataRefreshControl.test.tsx verifying the timestamp interval logic, disabled button states during fetching, and proper error/stale fallback renderings.