### PR TITLE
feat: implement minimum threshold and emergency withdrawal semantics

### DIFF
--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -66,6 +66,8 @@ pub enum DataKey {
     ParticipantV1(Address),     // legacy V1 participant storage (migration source)
     Proposal(u32), // pending admin proposal
     Token,        // Address — accepted Stellar Asset Contract address (#376)
+    ActivationConfig,
+    EmergencyMode,
 }
 
 // ── Errors ─────────────────────────────────────────────────────────────────
@@ -89,9 +91,18 @@ pub enum Error {
     TokenNotConfigured = 14, // no accepted asset configured (#376)
     AssetMismatch = 15,      // caller sent a different asset than the configured one (#376)
     TransferFailed = 16,     // token transfer failed (#376)
+    NotActive = 17,
+    EmergencyModeActive = 18,
+    ThresholdNotMetForActivation = 19,
 }
 
 // ── Structs ────────────────────────────────────────────────────────────────
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct ActivationConfig {
+    pub start_time: u64,
+    pub min_participants: u32,
+}
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
 pub struct Pool {
@@ -145,6 +156,8 @@ pub enum ProposalAction {
     AddAdmin(Address),
     RemoveAdmin(Address),
     SetThreshold(u32), // change the approval threshold (#383)
+    SetActivationConfig(u64, u32), // start_time, min_participants
+    SetEmergencyMode(bool),
 }
 
 // ── Contract ───────────────────────────────────────────────────────────────
@@ -202,6 +215,34 @@ impl DripPool {
         env.storage()
             .persistent()
             .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    }
+
+    fn check_emergency_and_activation(env: &Env, pool: &Pool) -> Result<(), Error> {
+        if env.storage().instance().get(&DataKey::EmergencyMode).unwrap_or(false) {
+            return Err(Error::EmergencyModeActive);
+        }
+        if let Some(config) = env.storage().instance().get::<DataKey, ActivationConfig>(&DataKey::ActivationConfig) {
+            if env.ledger().timestamp() >= config.start_time {
+                if pool.total_drips < config.min_participants as u64 {
+                    return Err(Error::ThresholdNotMetForActivation);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn can_withdraw_early(env: &Env) -> bool {
+        if env.storage().instance().get(&DataKey::EmergencyMode).unwrap_or(false) {
+            return true;
+        }
+        if let Some(pool) = env.storage().instance().get::<DataKey, Pool>(&DataKey::Pool) {
+            if let Some(config) = env.storage().instance().get::<DataKey, ActivationConfig>(&DataKey::ActivationConfig) {
+                if env.ledger().timestamp() >= config.start_time && pool.total_drips < config.min_participants as u64 {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     // ── Participant migration helpers (#377) ─────────────────────────────
@@ -511,6 +552,16 @@ impl DripPool {
                 }
                 env.storage().instance().set(&DataKey::Threshold, &t);
             }
+            ProposalAction::SetActivationConfig(start_time, min_participants) => {
+                let config = ActivationConfig {
+                    start_time,
+                    min_participants,
+                };
+                env.storage().instance().set(&DataKey::ActivationConfig, &config);
+            }
+            ProposalAction::SetEmergencyMode(mode) => {
+                env.storage().instance().set(&DataKey::EmergencyMode, &mode);
+            }
         }
         Ok(())
     }
@@ -559,6 +610,8 @@ impl DripPool {
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
 
+        Self::check_emergency_and_activation(&env, &old_pool)?;
+
         // Transfer tokens from caller to this contract (#376)
         let contract_addr = env.current_contract_address();
         Self::transfer_tokens(&env, &who, &contract_addr, &amount)?;
@@ -604,9 +657,13 @@ impl DripPool {
         if amount <= 0 {
             return Err(Error::InvalidAmount);
         }
-        if !env.storage().instance().has(&DataKey::Pool) {
-            return Err(Error::NotInitialized);
-        }
+        let mut pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+            
+        Self::check_emergency_and_activation(&env, &pool)?;
 
         // Transfer tokens from caller to this contract (#376)
         let contract_addr = env.current_contract_address();
@@ -705,7 +762,7 @@ impl DripPool {
 
         let mut p = Self::load_participant(&env, &who)?;
 
-        if env.ledger().sequence() < p.locked_until {
+        if env.ledger().sequence() < p.locked_until && !Self::can_withdraw_early(&env) {
             return Err(Error::LockupActive);
         }
 

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -1072,3 +1072,73 @@ fn participant_v2_fields_present() {
     // V1 field that should NOT be present
     // The following would fail to compile: savings.claimable
 }
+
+// ── #439: Minimum participant threshold ────────────────────────────────────
+
+#[test]
+fn deposit_fails_if_activation_threshold_not_met() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+
+    // Set threshold: requires 5 participants after sequence 100
+    let start_time = env.ledger().timestamp() + 100;
+    let pid = client.propose(&admin, &ProposalAction::SetActivationConfig(start_time, 5));
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+    client.approve(&signer2, &pid);
+
+    env.ledger().set_timestamp(start_time + 10);
+    
+    assert_eq!(
+        client.try_deposit(&alice, &100),
+        Err(Ok(Error::ThresholdNotMetForActivation))
+    );
+}
+
+#[test]
+fn early_withdrawal_allowed_if_activation_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    // deposit before start time
+    client.deposit(&alice, &100);
+
+    let start_time = env.ledger().timestamp() + 100;
+    let pid = client.propose(&admin, &ProposalAction::SetActivationConfig(start_time, 5));
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+    client.approve(&signer2, &pid);
+
+    env.ledger().set_timestamp(start_time + 10);
+
+    // normally locked, but threshold failed, so withdraw succeeds!
+    assert_eq!(client.withdraw(&alice), 100);
+}
+
+// ── #442: Emergency withdrawal semantics ───────────────────────────────────
+
+#[test]
+fn emergency_withdrawal_allows_early_withdraw_and_blocks_deposit() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &500);
+
+    let pid = client.propose(&admin, &ProposalAction::SetEmergencyMode(true));
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+    client.approve(&signer2, &pid);
+
+    // deposit blocked
+    assert_eq!(
+        client.try_deposit(&alice, &100),
+        Err(Ok(Error::EmergencyModeActive))
+    );
+
+    // early withdraw allowed
+    assert_eq!(client.withdraw(&alice), 500);
+}

--- a/contracts/drip-pool/src/vault.rs
+++ b/contracts/drip-pool/src/vault.rs
@@ -61,7 +61,7 @@ pub(crate) fn apply_time_locked_deposit(
 pub(crate) fn apply_withdrawal(env: &Env, who: &Address) -> Result<i128, Error> {
     let p = super::DripPool::load_participant(env, who)?;
 
-    if env.ledger().sequence() < p.locked_until {
+    if env.ledger().sequence() < p.locked_until && !super::DripPool::can_withdraw_early(env) {
         return Err(Error::LockupActive);
     }
 


### PR DESCRIPTION
This PR resolves #439 and #442.

## Tasks and Fixes Made
- Added ActivationConfig and EmergencyMode as new DataKeys to avoid mutating the existing Pool struct signature.
- Introduced check_emergency_and_activation to block deposits when Emergency Mode is active or the minimum participant threshold is not met after the start time.
- Implemented can_withdraw_early to allow users to withdraw their principal bypassing the lockup period when Emergency Mode is active or the pool activation fails (threshold not met).
- Updated ault::apply_withdrawal and withdraw in lib.rs to support the early withdrawal.
- Appended robust unit tests to verify both failure states (deposits blocked) and success states (early withdrawal allowed) for emergency mode and failed threshold activations.

Closes #439
Closes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activation settings with configurable start times and minimum participant thresholds.
  * Added emergency mode controls through multisig governance.
  * Enabled early withdrawals during emergency mode or when activation requirements permit them.

* **Bug Fixes**
  * Deposits are now blocked when emergency or activation conditions are not satisfied.
  * Withdrawals remain available when activation fails, improving access to deposited funds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->