### PR TITLE
feat(drip-pool): add claim deadline and unclaimed reward sweep

### DIFF
--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -31,6 +31,19 @@
 //! - All instance reads/writes extend instance TTL.
 //! - All persistent reads/writes extend participant TTL.
 //! - `renew_participant` and `renew_instance` are operator maintenance entrypoints.
+//!
+//! #440 Claim deadline and unclaimed reward handling
+//! - `Pool.claim_deadline` is an optional ledger timestamp, set per pool via
+//!   `set_claim_deadline`. `claim`/`claim_reward` succeed while
+//!   `timestamp <= claim_deadline` and revert with `ClaimDeadlinePassed` once
+//!   `timestamp > claim_deadline` — the deadline instant itself is claimable.
+//! - `sweep_unclaimed` lets a signer move a participant's unclaimed reward
+//!   (yield_accrued + prize − claimed_reward) to the pool admin (treasury)
+//!   once the deadline has strictly passed. It reuses the same `transfer_tokens`
+//!   SAC path as `withdraw`, so it is a no-op transfer when no token is
+//!   configured. `Pool.unclaimed_swept` flips to `true` on first sweep.
+//! - `claim_deadline`, `claim_deadline_passed` and `unclaimed_swept` are public
+//!   views so the frontend can read deadline/status without decoding `Pool`.
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, Vec,
@@ -84,11 +97,15 @@ pub enum Error {
     ThresholdNotMet = 9, // not enough signatures
     AlreadySigned = 10,  // signer already approved this proposal
     ProposalNotFound = 11,
-    ProposalExpired = 12,    // proposal ledger deadline passed
-    InvalidAction = 13,      // payload fails reserve or signer-count checks
-    TokenNotConfigured = 14, // no accepted asset configured (#376)
-    AssetMismatch = 15,      // caller sent a different asset than the configured one (#376)
-    TransferFailed = 16,     // token transfer failed (#376)
+    ProposalExpired = 12,         // proposal ledger deadline passed
+    InvalidAction = 13,           // payload fails reserve or signer-count checks
+    TokenNotConfigured = 14,      // no accepted asset configured (#376)
+    AssetMismatch = 15,           // caller sent a different asset than the configured one (#376)
+    TransferFailed = 16,          // token transfer failed (#376)
+    ClaimDeadlinePassed = 17,     // claim attempted after the pool's claim deadline (#440)
+    ClaimDeadlineNotReached = 18, // sweep attempted before the deadline has passed (#440)
+    NoClaimDeadline = 19,         // sweep attempted but no deadline was ever configured (#440)
+    InvalidDeadline = 20,         // deadline must be strictly in the future (#440)
 }
 
 // ── Structs ────────────────────────────────────────────────────────────────
@@ -102,6 +119,8 @@ pub struct Pool {
     pub locked: bool,
     pub proposal_nonce: u32,
     pub distributable_yield: i128, // realized yield available for distribution (#382)
+    pub claim_deadline: Option<u64>, // ledger timestamp after which claims revert (#440)
+    pub unclaimed_swept: bool,     // true once an unclaimed-reward sweep has executed (#440)
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -310,6 +329,8 @@ impl DripPool {
             locked: false,
             proposal_nonce: 0,
             distributable_yield: 0,
+            claim_deadline: None,
+            unclaimed_swept: false,
         };
         let admins: Vec<Address> = vec![&env, admin.clone()];
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -693,6 +714,19 @@ impl DripPool {
     pub fn claim_reward(env: Env, who: Address) -> Result<i128, Error> {
         who.require_auth();
 
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        // The deadline instant itself is still claimable; only strictly-later
+        // timestamps revert (#440).
+        if let Some(deadline) = pool.claim_deadline {
+            if env.ledger().timestamp() > deadline {
+                return Err(Error::ClaimDeadlinePassed);
+            }
+        }
+
         let mut p = Self::load_participant(&env, &who)?;
         let available = (p.yield_accrued + p.prize) - p.claimed_reward;
         p.claimed_reward += available;
@@ -703,6 +737,82 @@ impl DripPool {
             (who, available),
         );
         Ok(available)
+    }
+
+    // ── Claim deadline & unclaimed reward sweep (#440) ─────────────────────
+
+    /// Configure (or update) the pool's claim deadline as a ledger timestamp.
+    /// Only callable by an approved signer. The deadline must be strictly in
+    /// the future.
+    pub fn set_claim_deadline(env: Env, caller: Address, deadline: u64) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_signer(&env, &caller)?;
+        if deadline <= env.ledger().timestamp() {
+            return Err(Error::InvalidDeadline);
+        }
+
+        let mut pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        pool.claim_deadline = Some(deadline);
+        env.storage().instance().set(&DataKey::Pool, &pool);
+        Self::bump_instance(&env);
+
+        env.events()
+            .publish((symbol_short!("pool"), symbol_short!("deadline")), deadline);
+        Ok(())
+    }
+
+    /// Sweep a participant's unclaimed reward (yield_accrued + prize −
+    /// claimed_reward) to the pool admin (treasury) once the claim deadline
+    /// has strictly passed. Only callable by an approved signer. Reuses the
+    /// SAC transfer path from `withdraw`, so it is a no-op transfer when no
+    /// token is configured. Marks the participant's reward as fully claimed
+    /// so it cannot be swept or claimed twice.
+    pub fn sweep_unclaimed(env: Env, caller: Address, who: Address) -> Result<i128, Error> {
+        caller.require_auth();
+        Self::require_signer(&env, &caller)?;
+
+        let mut pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        let deadline = pool.claim_deadline.ok_or(Error::NoClaimDeadline)?;
+        if env.ledger().timestamp() <= deadline {
+            return Err(Error::ClaimDeadlineNotReached);
+        }
+
+        let mut p = Self::load_participant(&env, &who)?;
+        let unclaimed = (p.yield_accrued + p.prize) - p.claimed_reward;
+        if unclaimed <= 0 {
+            return Ok(0);
+        }
+        p.claimed_reward += unclaimed;
+        Self::save_participant(&env, &who, &p);
+
+        // Transfer first; roll back the participant's claimed_reward on
+        // failure so a failed sweep never silently burns the reward (#440,
+        // mirrors the withdraw/withdraw_locked rollback pattern from #376).
+        let contract_addr = env.current_contract_address();
+        if let Err(e) = Self::transfer_tokens(&env, &contract_addr, &pool.admin, &unclaimed) {
+            let mut p = Self::load_participant(&env, &who)?;
+            p.claimed_reward -= unclaimed;
+            Self::save_participant(&env, &who, &p);
+            return Err(e);
+        }
+
+        pool.unclaimed_swept = true;
+        env.storage().instance().set(&DataKey::Pool, &pool);
+        Self::bump_instance(&env);
+
+        env.events().publish(
+            (symbol_short!("pool"), symbol_short!("swept")),
+            (who, pool.admin.clone(), unclaimed),
+        );
+        Ok(unclaimed)
     }
 
     // ── Withdraw (#376: real token custody) ────────────────────────────────
@@ -898,6 +1008,41 @@ impl DripPool {
     /// View the configured token address (#376).
     pub fn token(env: Env) -> Result<Address, Error> {
         Self::get_token_address(&env)
+    }
+
+    /// View the configured claim deadline, if any (#440).
+    pub fn claim_deadline(env: Env) -> Result<Option<u64>, Error> {
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        Ok(pool.claim_deadline)
+    }
+
+    /// True once a configured claim deadline has strictly passed. Returns
+    /// false when no deadline has been set (#440).
+    pub fn claim_deadline_passed(env: Env) -> Result<bool, Error> {
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        Ok(match pool.claim_deadline {
+            Some(deadline) => env.ledger().timestamp() > deadline,
+            None => false,
+        })
+    }
+
+    /// True once at least one unclaimed-reward sweep has executed for this
+    /// pool (#440).
+    pub fn unclaimed_swept(env: Env) -> Result<bool, Error> {
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        Ok(pool.unclaimed_swept)
     }
 }
 

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -1057,6 +1057,282 @@ fn invariant_total_claimed_never_exceeds_rewards() {
     assert_eq!(client.savings(&bob).withdrawn_principal, 500);
 }
 
+// ── #440: claim deadline and unclaimed reward sweep ────────────────────────
+
+/// set_claim_deadline stores the deadline and is readable via the view.
+#[test]
+fn set_claim_deadline_by_signer_succeeds() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &1_500);
+    assert_eq!(client.claim_deadline(), Some(1_500));
+    assert!(!client.claim_deadline_passed());
+}
+
+/// set_claim_deadline emits an event.
+#[test]
+fn set_claim_deadline_emits_event() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &1_500);
+    let events = env.events().all();
+    assert!(!events.events().is_empty(), "no events emitted");
+}
+
+/// set_claim_deadline rejects a deadline that is not strictly in the future.
+#[test]
+fn set_claim_deadline_in_past_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    env.ledger().set_timestamp(1_000);
+    assert_eq!(
+        client.try_set_claim_deadline(&admin, &1_000),
+        Err(Ok(Error::InvalidDeadline))
+    );
+    assert_eq!(
+        client.try_set_claim_deadline(&admin, &999),
+        Err(Ok(Error::InvalidDeadline))
+    );
+}
+
+/// Only an approved signer may set the claim deadline.
+#[test]
+fn set_claim_deadline_by_non_signer_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let rando = Address::generate(&env);
+    env.ledger().set_timestamp(1_000);
+    assert_eq!(
+        client.try_set_claim_deadline(&rando, &1_500),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+/// Without a configured deadline, claims are always allowed.
+#[test]
+fn claim_without_deadline_never_blocked() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(10_000_000);
+    assert_eq!(client.claim_reward(&alice), 100);
+}
+
+/// Boundary: the deadline instant itself is still claimable.
+#[test]
+fn claim_exactly_at_deadline_succeeds() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+
+    env.ledger().set_timestamp(2_000);
+    assert_eq!(client.claim_reward(&alice), 100);
+}
+
+/// Boundary: one second before the deadline is claimable.
+#[test]
+fn claim_one_second_before_deadline_succeeds() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+
+    env.ledger().set_timestamp(1_999);
+    assert_eq!(client.claim_reward(&alice), 100);
+}
+
+/// Boundary: one second after the deadline reverts.
+#[test]
+fn claim_one_second_after_deadline_reverts() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+
+    env.ledger().set_timestamp(2_001);
+    assert_eq!(
+        client.try_claim_reward(&alice),
+        Err(Ok(Error::ClaimDeadlinePassed))
+    );
+    // Reward remains unclaimed — deadline enforcement does not lose it.
+    assert_eq!(client.savings(&alice).claimed_reward, 0);
+}
+
+/// claim() (the alias) is also blocked once the deadline has passed.
+#[test]
+fn claim_alias_blocked_after_deadline() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &500);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+    env.ledger().set_timestamp(2_001);
+
+    assert_eq!(
+        client.try_claim(&alice),
+        Err(Ok(Error::ClaimDeadlinePassed))
+    );
+}
+
+/// sweep_unclaimed cannot run before a deadline is configured.
+#[test]
+fn sweep_without_deadline_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    assert_eq!(
+        client.try_sweep_unclaimed(&admin, &alice),
+        Err(Ok(Error::NoClaimDeadline))
+    );
+}
+
+/// sweep_unclaimed cannot run before the deadline has passed (not even
+/// exactly at the deadline — the deadline instant still belongs to claim).
+#[test]
+fn sweep_before_deadline_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+
+    env.ledger().set_timestamp(2_000);
+    assert_eq!(
+        client.try_sweep_unclaimed(&admin, &alice),
+        Err(Ok(Error::ClaimDeadlineNotReached))
+    );
+}
+
+/// After the deadline passes, unclaimed reward is swept to the pool admin
+/// (treasury), the participant's reward is marked claimed, and the pool
+/// records that a sweep has occurred.
+#[test]
+fn sweep_after_deadline_moves_reward_to_admin() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &300);
+    client.credit_yield(&admin, &alice, &300);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+    env.ledger().set_timestamp(2_001);
+
+    assert!(!client.unclaimed_swept());
+    let swept = client.sweep_unclaimed(&admin, &alice);
+    assert_eq!(swept, 300);
+    assert!(client.unclaimed_swept());
+    assert!(client.claim_deadline_passed());
+
+    // Participant's reward is now marked claimed; nothing left to claim or
+    // sweep again.
+    assert_eq!(client.savings(&alice).claimed_reward, 300);
+    assert_eq!(
+        client.try_claim_reward(&alice),
+        Err(Ok(Error::ClaimDeadlinePassed))
+    );
+    assert_eq!(client.sweep_unclaimed(&admin, &alice), 0);
+
+    // Principal is untouched by the sweep.
+    assert_eq!(client.savings(&alice).deposited, 1_000);
+}
+
+/// sweep_unclaimed emits an event.
+#[test]
+fn sweep_emits_event() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+    env.ledger().set_timestamp(2_001);
+
+    client.sweep_unclaimed(&admin, &alice);
+    let events = env.events().all();
+    assert!(!events.events().is_empty(), "no events emitted");
+}
+
+/// Only an approved signer may sweep unclaimed rewards.
+#[test]
+fn sweep_by_non_signer_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+    env.ledger().set_timestamp(2_001);
+
+    let rando = Address::generate(&env);
+    assert_eq!(
+        client.try_sweep_unclaimed(&rando, &alice),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+/// A participant who claims before the deadline has nothing left to sweep.
+#[test]
+fn claimed_reward_leaves_nothing_to_sweep() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+
+    // Alice claims before the deadline.
+    assert_eq!(client.claim_reward(&alice), 100);
+
+    env.ledger().set_timestamp(2_001);
+    assert_eq!(client.sweep_unclaimed(&admin, &alice), 0);
+    // Nothing was actually moved, so the pool-level sweep flag stays unset.
+    assert!(!client.unclaimed_swept());
+}
+
 /// Participant struct has the correct V2 fields via savings view.
 #[test]
 fn participant_v2_fields_present() {


### PR DESCRIPTION
## Summary

Adds a per-pool claim deadline to the `drip-pool` Soroban contract, so admins can bound how long participants have to claim yield/prize rewards after a pool cycle completes, plus a documented path for whatever is left unclaimed once that window closes.

- `Pool` gains `claim_deadline: Option<u64>` (a ledger timestamp) and `unclaimed_swept: bool`. There's no separate "cycle" struct in this contract — a `Pool` instance *is* the cycle — so the deadline lives directly on `Pool`, next to the other pool-scoped config (`distributable_yield`, `proposal_nonce`, etc.).
- `set_claim_deadline(caller, deadline)` — signer-gated (same `require_signer` pattern as `set_token`/`add_yield`), rejects a deadline that isn't strictly in the future (`InvalidDeadline`), and emits a `("pool", "deadline")` event.
- `claim` / `claim_reward` now check the deadline: they succeed while `timestamp <= claim_deadline` and revert with `ClaimDeadlinePassed` once `timestamp > claim_deadline`. **The deadline instant itself is still claimable** — this is the deterministic boundary rule the acceptance criteria asked for, and it's exercised directly in the boundary tests below.
- `sweep_unclaimed(caller, who)` — signer-gated, only runs once `timestamp > claim_deadline` (`ClaimDeadlineNotReached` before that, `NoClaimDeadline` if no deadline was ever set). It moves a participant's unclaimed reward (`yield_accrued + prize - claimed_reward`) to the **pool admin as treasury**, reusing the exact `transfer_tokens` SAC path `withdraw`/`withdraw_locked` already use (so it's a no-op transfer in tests/deployments with no token configured), and marks the participant's `claimed_reward` as fully settled so it can't be swept or claimed twice. On a failed transfer, the participant's `claimed_reward` is rolled back — mirroring the existing rollback pattern in `withdraw`/`withdraw_locked` — so a failed sweep never silently burns the reward. Emits a `("pool", "swept")` event with `(participant, admin, amount)`.
- New views for the frontend: `claim_deadline()`, `claim_deadline_passed()`, `unclaimed_swept()` — so a client can read deadline/status without decoding raw `Pool` storage.

### Design decision: where unclaimed rewards go

I went with **sweep-to-admin (treasury)** rather than "roll into next cycle" or "hold for recovery," because:
- This contract has no multi-cycle model — one `Pool` per deployment — so "next cycle" isn't a natural target without inventing new state.
- The contract already treats `pool.admin` as the privileged treasury-like party (it's the default `draw_winner` recipient and the sole initial signer), so crediting swept funds there is consistent with existing conventions rather than adding a new actor.
- Doing a real token transfer at sweep time (instead of re-crediting an internal balance) avoids a second, separate "admin claims the swept amount" step that would itself need to bypass the very deadline check that triggered the sweep.

### Errors added
`ClaimDeadlinePassed (17)`, `ClaimDeadlineNotReached (18)`, `NoClaimDeadline (19)`, `InvalidDeadline (20)` — appended after the existing `TransferFailed (16)`, following the contract's existing incrementing `#[repr(u32)]` convention.

## Test plan

- [x] `cargo test -p drip-pool` — full suite passes for everything touched by this change; **149 passed, 6 failed**, and the 6 failures are pre-existing on `main` (verified by stashing this change and re-running against a clean checkout — same 6 tests fail with the same errors: multisig `seed_admin`/threshold benchmarks hitting `Unauthorized`, and `bench_stress_max_operations` asserting `10_000_000` where the loop math actually produces `1_000_000`). None of the 6 reference claim, deadline, or sweep, and none are in files this PR touches (`benchmarks.rs` is untouched).
- [x] 15 new tests added in `contracts/drip-pool/src/test.rs`, all passing, covering:
  - `set_claim_deadline` success, event emission, past-timestamp rejection, non-signer rejection
  - Boundary claim behavior: no deadline set (never blocked), exactly at the deadline (claimable), one second before (claimable), one second after (reverts with `ClaimDeadlinePassed`), and the `claim()` alias also blocked
  - `sweep_unclaimed`: rejected with no deadline configured, rejected before the deadline passes, succeeds after and moves the reward to admin, sets `unclaimed_swept`, emits an event, rejected for non-signers, and a no-op (returns 0) when the participant already claimed everything themselves
- [x] `cargo fmt -p drip-pool --check` — clean
- [x] `cargo clippy -p drip-pool -- -D warnings` — **not clean, but pre-existing**: main already fails this with 13 errors (deprecated `Events::publish` used throughout every existing event emission in `lib.rs`/`proxy.rs`, plus an unused `apply_admin_release` in `vault.rs`), verified by running clippy against a clean stash of this change. My two new event emissions (`deadline`, `swept`) follow the exact same pre-existing `env.events().publish(...)` pattern as every other event in the file, adding 2 more instances of the same warning (13 → 15). Migrating the whole contract to the `#[contractevent]` macro is a much larger, unrelated change and is out of scope here.

## Out of scope

- `contracts/drip-pool/canonical-spec.ts` / `canonical-spec.json` and `golden-fixtures/structs.json` are a hand-maintained TS mirror of the contract used by `pnpm test:conformance`. They're already stale relative to `main` independent of this PR — e.g. `golden-fixtures/structs.json` still lists the old V1 `Participant.claimable` field and is missing `prize`/`claimed_reward`/`withdrawn_principal` from #377, and `canonical-spec.ts` is missing the `#376` token error codes/method. Updating that layer to catch up (both for prior drift and for this PR's new fields/methods) is a separate effort I didn't want to bundle into a single-issue PR.
- `contracts/docs/EVENT_SCHEMA.md` describes an aspirational event envelope (`["vaultquest","v1",name,pool_id]`) that doesn't match the contract's actual current events (`("pool", action)` topics, no `pool_id`/envelope versioning) even before this PR — left untouched for the same reason.
- `cargo clippy -D warnings` pre-existing failures noted above.
- The 6 pre-existing `benchmarks` test failures noted above.

Closes #440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable deadlines for claiming rewards.
  * Claims remain available through the deadline, but are blocked afterward.
  * Added an admin-controlled option to recover unclaimed rewards after the deadline.
  * Added status views for the claim deadline and sweep state.
* **Bug Fixes**
  * Preserved reward and principal balances when claims or recovery transfers fail.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->