### PR TITLE
feat: Add Email Service, WebSocket Chat, and Auth Unit Tests

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,7 @@ NODE_ENV=development
 # BACKUP_DIR=/var/backups/vaultquest
 # BACKUP_RETAIN_DAYS=7
 # BACKUP_SCHEDULE=0 2 * * *
+
+# SendGrid email notification service (issues #487, #488)
+# SENDGRID_API_KEY=your-sendgrid-api-key
+# EMAIL_FROM=noreply@yourdomain.com

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@fastify/rate-limit": "^11.1.0",
     "@prisma/client": "^5.22.0",
+    "@sendgrid/mail": "^8.1.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "fastify": "^4.28.1",
     "fastify-plugin": "^4.5.1",
@@ -31,6 +32,7 @@
     "pino": "^9.5.0",
     "pino-pretty": "^11.3.0",
     "prom-client": "^15.1.0",
+    "socket.io": "^4.8.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -25,6 +25,7 @@ import type { CacheService } from "./services/cacheService.js";
 import { walletAuthRoutes } from "./routes/walletAuth.js";
 import { WalletAuthService } from "./services/walletAuth.js";
 import { transactionMetricsRoutes } from "./routes/transactionMetrics.js";
+import { EmailService } from "./services/emailService.js";
 
 export type AppDeps = {
   prisma: PrismaClient;
@@ -33,6 +34,7 @@ export type AppDeps = {
   apiKey?: string;
   logger?: Logger;
   cacheService?: CacheService;
+  emailService?: EmailService;
 };
 
 export function buildApp(deps: AppDeps): FastifyInstance {

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -44,7 +44,9 @@ const schema = z.object({
    */
   BACKUP_DIR: z.string().min(1).optional(),
   BACKUP_RETAIN_DAYS: z.coerce.number().int().positive().default(7),
-  BACKUP_SCHEDULE: z.string().default("0 2 * * *")
+  BACKUP_SCHEDULE: z.string().default("0 2 * * *"),
+  SENDGRID_API_KEY: z.string().min(1).optional(),
+  EMAIL_FROM: z.string().email().optional()
 });
 
 export type Env = z.infer<typeof schema>;
@@ -78,7 +80,9 @@ export function getEnv(): Env {
       API_KEY: process.env.API_KEY || undefined,
       BACKUP_DIR: process.env.BACKUP_DIR || undefined,
       BACKUP_RETAIN_DAYS: Number(process.env.BACKUP_RETAIN_DAYS ?? 7),
-      BACKUP_SCHEDULE: process.env.BACKUP_SCHEDULE ?? "0 2 * * *"
+      BACKUP_SCHEDULE: process.env.BACKUP_SCHEDULE ?? "0 2 * * *",
+      SENDGRID_API_KEY: process.env.SENDGRID_API_KEY || undefined,
+      EMAIL_FROM: process.env.EMAIL_FROM || undefined
     } satisfies Env;
   }
   return parseEnv();

--- a/backend/src/services/chatService.ts
+++ b/backend/src/services/chatService.ts
@@ -1,0 +1,137 @@
+import { Server as HttpServer } from "node:http";
+import { Server, type Socket } from "socket.io";
+import type { Logger } from "pino";
+import type { PrismaClient } from "@prisma/client";
+
+export interface ChatMessage {
+  roomId: string;
+  senderId: string;
+  content: string;
+  timestamp: Date;
+}
+
+export interface ChatConfig {
+  prisma: PrismaClient;
+  logger?: Logger;
+  sessionTtlMs?: number;
+}
+
+export class ChatService {
+  private readonly io: Server;
+  private readonly prisma: PrismaClient;
+  private readonly logger?: Logger;
+  private readonly sessionTtlMs: number;
+
+  constructor(httpServer: HttpServer, config: ChatConfig) {
+    this.prisma = config.prisma;
+    this.logger = config.logger;
+    this.sessionTtlMs = config.sessionTtlMs || 24 * 60 * 60 * 1000;
+
+    this.io = new Server(httpServer, {
+      cors: {
+        origin: "*",
+        methods: ["GET", "POST"]
+      },
+      pingTimeout: 60000,
+      pingInterval: 25000
+    });
+
+    this.setupMiddleware();
+    this.setupEventHandlers();
+  }
+
+  private setupMiddleware(): void {
+    this.io.use(async (socket, next) => {
+      const token = socket.handshake.auth.token;
+      if (!token) {
+        return next(new Error("Authentication required"));
+      }
+
+      try {
+        const session = await this.prisma.walletSession.findUnique({
+          where: { token }
+        });
+
+        if (!session || session.revokedAt !== null || session.expiresAt.getTime() <= Date.now()) {
+          return next(new Error("Invalid or expired session"));
+        }
+
+        (socket as any).userId = session.walletAddress;
+        (socket as any).publicKey = session.publicKey;
+        (socket as any).network = session.network;
+        next();
+      } catch {
+        next(new Error("Authentication failed"));
+      }
+    });
+  }
+
+  private setupEventHandlers(): void {
+    this.io.on("connection", (socket: Socket) => {
+      const userId = (socket as any).userId as string;
+      this.logger?.info({ userId, socketId: socket.id }, "Client connected");
+
+      socket.on("join_room", async (roomId: string) => {
+        if (!roomId || typeof roomId !== "string") {
+          socket.emit("error", { message: "Invalid room ID" });
+          return;
+        }
+
+        socket.join(roomId);
+        this.logger?.info({ userId, roomId }, "User joined room");
+
+        socket.to(roomId).emit("user_joined", {
+          userId,
+          roomId,
+          timestamp: new Date()
+        });
+
+        socket.emit("room_joined", { roomId, timestamp: new Date() });
+      });
+
+      socket.on("send_message", async (data: { roomId: string; content: string }) => {
+        if (!data.roomId || !data.content || typeof data.content !== "string") {
+          socket.emit("error", { message: "Invalid message data" });
+          return;
+        }
+
+        if (data.content.length > 5000) {
+          socket.emit("error", { message: "Message too long" });
+          return;
+        }
+
+        const message: ChatMessage = {
+          roomId: data.roomId,
+          senderId: userId,
+          content: data.content.trim(),
+          timestamp: new Date()
+        };
+
+        this.io.to(data.roomId).emit("new_message", message);
+        this.logger?.debug({ userId, roomId: data.roomId }, "Message broadcast");
+      });
+
+      socket.on("leave_room", (roomId: string) => {
+        socket.leave(roomId);
+        socket.to(roomId).emit("user_left", {
+          userId,
+          roomId,
+          timestamp: new Date()
+        });
+        this.logger?.info({ userId, roomId }, "User left room");
+      });
+
+      socket.on("disconnect", (reason) => {
+        this.logger?.info({ userId, reason }, "Client disconnected");
+      });
+    });
+  }
+
+  getIo(): Server {
+    return this.io;
+  }
+
+  async close(): Promise<void> {
+    this.io.close();
+  }
+}

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,0 +1,114 @@
+import sgMail from "@sendgrid/mail";
+import type { Logger } from "pino";
+
+export interface EmailConfig {
+  apiKey?: string;
+  fromEmail?: string;
+  logger?: Logger;
+}
+
+export interface SendEmailInput {
+  to: string;
+  template: "welcome" | "password_reset";
+  data: Record<string, string>;
+}
+
+const templates: Record<string, { subject: string; html: string }> = {
+  welcome: {
+    subject: "Welcome to VaultQuest",
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h1 style="color: #4F46E5;">Welcome to VaultQuest!</h1>
+        <p>Thank you for joining VaultQuest. We're excited to have you on board.</p>
+        <p>With VaultQuest, you can:</p>
+        <ul>
+          <li>Create and manage savings vaults</li>
+          <li>Participate in quest challenges</li>
+          <li>Earn rewards through DeFi participation</li>
+        </ul>
+        <p>If you have any questions, feel free to reach out to our support team.</p>
+        <p style="color: #6B7280; font-size: 12px;">This email was sent to {{email}}.</p>
+      </div>
+    `
+  },
+  password_reset: {
+    subject: "Reset Your Password",
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h1 style="color: #4F46E5;">Password Reset Request</h1>
+        <p>We received a request to reset your password.</p>
+        <p>Click the link below to reset your password. This link will expire in 1 hour.</p>
+        <a href="{{resetUrl}}" style="display: inline-block; background-color: #4F46E5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 16px 0;">Reset Password</a>
+        <p>If you did not request a password reset, please ignore this email.</p>
+        <p style="color: #6B7280; font-size: 12px;">This email was sent to {{email}}.</p>
+      </div>
+    `
+  }
+};
+
+export class EmailService {
+  private readonly apiKey?: string;
+  private readonly fromEmail: string;
+  private readonly logger?: Logger;
+  private readonly initialized: boolean;
+
+  constructor(config: EmailConfig) {
+    this.apiKey = config.apiKey;
+    this.fromEmail = config.fromEmail || "noreply@vaultquest.io";
+    this.logger = config.logger;
+    this.initialized = !!config.apiKey;
+
+    if (this.initialized) {
+      sgMail.setApiKey(config.apiKey!);
+    }
+  }
+
+  async sendEmail(input: SendEmailInput): Promise<boolean> {
+    if (!this.initialized) {
+      this.logger?.warn("EmailService not configured, skipping send");
+      return false;
+    }
+
+    const template = templates[input.template];
+    if (!template) {
+      this.logger?.error({ template: input.template }, "Unknown email template");
+      return false;
+    }
+
+    let html = template.html;
+    for (const [key, value] of Object.entries(input.data)) {
+      html = html.replace(new RegExp(`\\{\\{${key}\\}\\}`, "g"), value);
+    }
+
+    try {
+      await sgMail.send({
+        to: input.to,
+        from: this.fromEmail,
+        subject: template.subject,
+        html
+      });
+      this.logger?.info({ to: input.to, template: input.template }, "Email sent successfully");
+      return true;
+    } catch (error) {
+      this.logger?.error({ err: error, to: input.to, template: input.template }, "Failed to send email");
+      return false;
+    }
+  }
+
+  async sendWelcomeEmail(email: string, walletAddress: string): Promise<boolean> {
+    return this.sendEmail({
+      to: email,
+      template: "welcome",
+      data: { email, walletAddress }
+    });
+  }
+
+  async sendPasswordResetEmail(email: string, resetToken: string): Promise<boolean> {
+    const resetUrl = `https://vaultquest.io/reset-password?token=${resetToken}`;
+    return this.sendEmail({
+      to: email,
+      template: "password_reset",
+      data: { email, resetUrl }
+    });
+  }
+}

--- a/backend/tests/chatService.spec.ts
+++ b/backend/tests/chatService.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChatService } from "../src/services/chatService";
+
+vi.mock("socket.io", () => {
+  const mockIo = {
+    on: vi.fn(),
+    use: vi.fn(),
+    to: vi.fn().mockReturnThis(),
+    emit: vi.fn(),
+    close: vi.fn()
+  };
+  return {
+    Server: vi.fn().mockImplementation(() => mockIo)
+  };
+});
+
+vi.mock("node:http", () => ({
+  Server: vi.fn()
+}));
+
+describe("ChatService", () => {
+  let svc: ChatService;
+  let mockPrisma: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = {
+      walletSession: {
+        findUnique: vi.fn()
+      }
+    };
+    svc = new ChatService({} as any, { prisma: mockPrisma });
+  });
+
+  it("creates ChatService instance", () => {
+    expect(svc).toBeDefined();
+  });
+
+  it("returns the io server instance", () => {
+    const io = svc.getIo();
+    expect(io).toBeDefined();
+  });
+
+  it("closes the server", async () => {
+    await svc.close();
+    const io = svc.getIo();
+    expect(io.close).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/emailService.spec.ts
+++ b/backend/tests/emailService.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EmailService } from "../src/services/emailService";
+
+vi.mock("@sendgrid/mail", () => ({
+  default: {
+    setApiKey: vi.fn(),
+    send: vi.fn().mockResolvedValue([])
+  }
+}));
+
+describe("EmailService", () => {
+  let svc: EmailService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new EmailService({
+      apiKey: "SG.test-api-key-12345678901234567890",
+      fromEmail: "test@vaultquest.io"
+    });
+  });
+
+  it("sends welcome email successfully", async () => {
+    const result = await svc.sendWelcomeEmail("user@example.com", "GABC123");
+    expect(result).toBe(true);
+  });
+
+  it("sends password reset email successfully", async () => {
+    const result = await svc.sendPasswordResetEmail("user@example.com", "reset-token-123");
+    expect(result).toBe(true);
+  });
+
+  it("returns false when not configured", async () => {
+    const unconfigured = new EmailService({});
+    const result = await unconfigured.sendWelcomeEmail("user@example.com", "GABC123");
+    expect(result).toBe(false);
+  });
+
+  it("returns false for unknown template", async () => {
+    const result = await svc.sendEmail({
+      to: "user@example.com",
+      template: "unknown" as any,
+      data: {}
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/backend/tests/walletAuth.unit.spec.ts
+++ b/backend/tests/walletAuth.unit.spec.ts
@@ -1,0 +1,482 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WalletAuthService } from "../src/services/walletAuth";
+
+function createMockPrisma() {
+  return {
+    walletChallenge: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn()
+    },
+    walletSession: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn()
+    }
+  };
+}
+
+describe("WalletAuthService", () => {
+  let svc: WalletAuthService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prisma = createMockPrisma();
+    svc = new WalletAuthService(prisma as any);
+  });
+
+  describe("createChallenge", () => {
+    it("creates a challenge with correct fields", async () => {
+      prisma.walletChallenge.create.mockResolvedValue({});
+
+      const result = await svc.createChallenge({
+        walletAddress: "GABC123",
+        publicKey: "GDEF456",
+        network: "TESTNET"
+      });
+
+      expect(result.challengeId).toBeDefined();
+      expect(result.nonce).toBeDefined();
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      expect(result.domain).toContain("vaultquest-auth");
+      expect(result.domain).toContain("TESTNET");
+      expect(prisma.walletChallenge.create).toHaveBeenCalledOnce();
+    });
+
+    it("includes contract in domain when provided", async () => {
+      prisma.walletChallenge.create.mockResolvedValue({});
+
+      const result = await svc.createChallenge({
+        walletAddress: "GABC123",
+        publicKey: "GDEF456",
+        network: "TESTNET",
+        contract: "contract123"
+      });
+
+      expect(result.domain).toContain("contract123");
+    });
+
+    it("includes action in domain when provided", async () => {
+      prisma.walletChallenge.create.mockResolvedValue({});
+
+      const result = await svc.createChallenge({
+        walletAddress: "GABC123",
+        publicKey: "GDEF456",
+        network: "TESTNET",
+        action: "deposit"
+      });
+
+      expect(result.domain).toContain("deposit");
+    });
+
+    it("includes idempotency key in domain when provided", async () => {
+      prisma.walletChallenge.create.mockResolvedValue({});
+
+      const result = await svc.createChallenge({
+        walletAddress: "GABC123",
+        publicKey: "GDEF456",
+        network: "TESTNET",
+        idempotencyKey: "idem-key-123"
+      });
+
+      expect(result.domain).toContain("idem-key-123");
+    });
+  });
+
+  describe("verifyChallenge", () => {
+    it("rejects when challenge does not exist", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue(null);
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "nonexistent",
+          payload: "{}",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when challenge is expired", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() - 1000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "{}",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when public key does not match", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY_OTHER",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "{}",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when network does not match", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "PUBLIC",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "{}",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when challenge is already consumed", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: new Date(),
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "{}",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when signature is empty", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "{}",
+          signature: "",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when payload is invalid JSON", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload: "not-json",
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when appName is wrong", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      const payload = JSON.stringify({
+        appName: "EvilApp",
+        network: "TESTNET",
+        purpose: "API_AUTHENTICATION",
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload,
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when purpose is wrong", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "nonce1"
+      });
+
+      const payload = JSON.stringify({
+        appName: "VaultQuest",
+        network: "TESTNET",
+        purpose: "WRONG_PURPOSE",
+        nonce: "nonce1"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload,
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when nonce does not match", async () => {
+      prisma.walletChallenge.findUnique.mockResolvedValue({
+        challengeId: "ch1",
+        expiresAt: new Date(Date.now() + 60000),
+        publicKey: "GKEY",
+        network: "TESTNET",
+        consumedAt: null,
+        nonce: "correct-nonce"
+      });
+
+      const payload = JSON.stringify({
+        appName: "VaultQuest",
+        network: "TESTNET",
+        purpose: "API_AUTHENTICATION",
+        nonce: "wrong-nonce"
+      });
+
+      await expect(
+        svc.verifyChallenge({
+          challengeId: "ch1",
+          payload,
+          signature: "sig",
+          publicKey: "GKEY",
+          network: "TESTNET"
+        })
+      ).rejects.toThrow("unauthorized");
+    });
+  });
+
+  describe("refreshSession", () => {
+    it("rejects when session does not exist", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue(null);
+
+      await expect(svc.refreshSession("nonexistent")).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when session is revoked", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        refreshToken: "refresh1",
+        revokedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60000)
+      });
+
+      await expect(svc.refreshSession("refresh1")).rejects.toThrow("unauthorized");
+    });
+
+    it("rejects when session is expired", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        refreshToken: "refresh1",
+        revokedAt: null,
+        expiresAt: new Date(Date.now() - 1000)
+      });
+
+      await expect(svc.refreshSession("refresh1")).rejects.toThrow("unauthorized");
+    });
+
+    it("creates new session on valid refresh", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        refreshToken: "refresh1",
+        walletAddress: "GABC",
+        publicKey: "GDEF",
+        network: "TESTNET",
+        revokedAt: null,
+        expiresAt: new Date(Date.now() + 60000)
+      });
+
+      prisma.walletSession.update.mockResolvedValue({
+        id: "session2",
+        token: "new-token",
+        refreshToken: "new-refresh",
+        expiresAt: new Date(Date.now() + 86400000),
+        walletAddress: "GABC",
+        publicKey: "GDEF",
+        network: "TESTNET"
+      });
+
+      const result = await svc.refreshSession("refresh1");
+
+      expect(result.token).toBe("new-token");
+      expect(result.refreshToken).toBe("new-refresh");
+      expect(prisma.walletSession.update).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("revokeSession", () => {
+    it("does nothing for nonexistent session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue(null);
+
+      await svc.revokeSession("nonexistent");
+
+      expect(prisma.walletSession.update).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for already revoked session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        revokedAt: new Date()
+      });
+
+      await svc.revokeSession("token1");
+
+      expect(prisma.walletSession.update).not.toHaveBeenCalled();
+    });
+
+    it("revokes an active session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        revokedAt: null
+      });
+      prisma.walletSession.update.mockResolvedValue({});
+
+      await svc.revokeSession("token1");
+
+      expect(prisma.walletSession.update).toHaveBeenCalledWith({
+        where: { id: "session1" },
+        data: { revokedAt: expect.any(Date) }
+      });
+    });
+  });
+
+  describe("validateSession", () => {
+    it("returns null for nonexistent session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue(null);
+
+      const result = await svc.validateSession("nonexistent");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null for revoked session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        revokedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60000)
+      });
+
+      const result = await svc.validateSession("token1");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null for expired session", async () => {
+      prisma.walletSession.findUnique.mockResolvedValue({
+        id: "session1",
+        revokedAt: null,
+        expiresAt: new Date(Date.now() - 1000)
+      });
+
+      const result = await svc.validateSession("token1");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns session for valid token", async () => {
+      const mockSession = {
+        id: "session1",
+        revokedAt: null,
+        expiresAt: new Date(Date.now() + 60000),
+        walletAddress: "GABC"
+      };
+      prisma.walletSession.findUnique.mockResolvedValue(mockSession);
+      prisma.walletSession.update.mockResolvedValue({});
+
+      const result = await svc.validateSession("token1");
+
+      expect(result).toEqual(mockSession);
+      expect(prisma.walletSession.update).toHaveBeenCalled();
+    });
+  });
+
+  describe("revokeAllSessions", () => {
+    it("revokes all active sessions for a wallet", async () => {
+      prisma.walletSession.updateMany.mockResolvedValue({ count: 3 });
+
+      const count = await svc.revokeAllSessions("GABC");
+
+      expect(count).toBe(3);
+      expect(prisma.walletSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          walletAddress: "GABC",
+          revokedAt: null
+        },
+        data: { revokedAt: expect.any(Date) }
+      });
+    });
+
+    it("returns 0 when no active sessions exist", async () => {
+      prisma.walletSession.updateMany.mockResolvedValue({ count: 0 });
+
+      const count = await svc.revokeAllSessions("GABC");
+
+      expect(count).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #487, Closes #488, Closes #489, Closes #490

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR implements three backend features: a SendGrid-based email notification service with HTML templates for Welcome and Password Reset emails, a WebSocket server using Socket.IO for real-time bidirectional chat with room-based messaging, and comprehensive unit tests for the existing WalletAuthService covering challenge creation, verification, session refresh/revocation, and validation.

## Motivation / Context

These changes address the need for transactional email capabilities (#487, #488), real-time support chat (#489), and improved test coverage for the authentication layer (#490). The email service is designed as a reusable internal module, the WebSocket server authenticates connections via existing wallet sessions, and the auth tests use mocked Prisma for isolated fast execution.

Closes #487, Closes #488, Closes #489, Closes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time chat with authenticated room joining, messaging, and participant notifications.
  * Added welcome and password-reset email notifications.
  * Added configuration options for email delivery and sender details.

* **Bug Fixes**
  * Improved validation for authentication sessions, including expired, revoked, or invalid sessions.

* **Tests**
  * Added coverage for chat, email notifications, and wallet authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->