### PR TITLE
feat(protocol): add loss circuit breaker and pro-rata emergency exit (#512)

### DIFF
--- a/backend/src/services/reconciler.ts
+++ b/backend/src/services/reconciler.ts
@@ -43,7 +43,8 @@ export type DriftType =
   | "contradiction"
   | "orphaned_settlement"
   | "missing_settlement"
-  | "stale_pending_event";
+  | "stale_pending_event"
+  | "insolvency_drift";
 
 export interface DriftRecord {
   type: DriftType;

--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -106,6 +106,9 @@ pub enum Error {
     ClaimDeadlineNotReached = 18, // sweep attempted before the deadline has passed (#440)
     NoClaimDeadline = 19,         // sweep attempted but no deadline was ever configured (#440)
     InvalidDeadline = 20,         // deadline must be strictly in the future (#440)
+    InEmergency = 21,             // action blocked while in emergency mode (#512)
+    NotInEmergency = 22,          // emergency exit blocked while not in emergency mode (#512)
+    Insolvent = 23,               // principal coverage below policy (#512)
 }
 
 // ── Structs ────────────────────────────────────────────────────────────────
@@ -121,6 +124,8 @@ pub struct Pool {
     pub distributable_yield: i128, // realized yield available for distribution (#382)
     pub claim_deadline: Option<u64>, // ledger timestamp after which claims revert (#440)
     pub unclaimed_swept: bool,     // true once an unclaimed-reward sweep has executed (#440)
+    pub is_emergency: bool,        // true when loss circuit breaker triggered (#512)
+    pub emergency_assets: i128,    // available assets recorded for pro-rata exit (#512)
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -164,6 +169,9 @@ pub enum ProposalAction {
     AddAdmin(Address),
     RemoveAdmin(Address),
     SetThreshold(u32), // change the approval threshold (#383)
+    TriggerEmergency(i128), // enter emergency mode with available asset amount (#512)
+    Recapitalize(i128),     // inject capital into emergency pool (#512)
+    ResumeNormal,           // return to normal operations (#512)
 }
 
 // ── Contract ───────────────────────────────────────────────────────────────
@@ -331,6 +339,8 @@ impl DripPool {
             distributable_yield: 0,
             claim_deadline: None,
             unclaimed_swept: false,
+            is_emergency: false,
+            emergency_assets: 0,
         };
         let admins: Vec<Address> = vec![&env, admin.clone()];
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -400,6 +410,21 @@ impl DripPool {
                 let admins = Self::get_admins(&env);
                 if *t == 0 || *t > admins.len() {
                     return Err(Error::InvalidAction);
+                }
+            }
+            ProposalAction::TriggerEmergency(assets) => {
+                if *assets < 0 {
+                    return Err(Error::InvalidAmount);
+                }
+            }
+            ProposalAction::Recapitalize(amount) => {
+                if *amount <= 0 {
+                    return Err(Error::InvalidAmount);
+                }
+            }
+            ProposalAction::ResumeNormal => {
+                if pool.emergency_assets < pool.total_deposited {
+                    return Err(Error::Insolvent);
                 }
             }
             _ => {}
@@ -538,6 +563,52 @@ impl DripPool {
                 }
                 env.storage().instance().set(&DataKey::Threshold, &t);
             }
+            ProposalAction::TriggerEmergency(assets) => {
+                let mut pool: Pool = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Pool)
+                    .ok_or(Error::NotInitialized)?;
+                pool.is_emergency = true;
+                pool.emergency_assets = assets;
+                env.storage().instance().set(&DataKey::Pool, &pool);
+                env.events().publish(
+                    (symbol_short!("emergency"), symbol_short!("triggered")),
+                    assets,
+                );
+            }
+            ProposalAction::Recapitalize(amount) => {
+                if amount <= 0 {
+                    return Err(Error::InvalidAmount);
+                }
+                let mut pool: Pool = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Pool)
+                    .ok_or(Error::NotInitialized)?;
+                pool.emergency_assets = pool.emergency_assets.saturating_add(amount);
+                env.storage().instance().set(&DataKey::Pool, &pool);
+                env.events().publish(
+                    (symbol_short!("emergency"), symbol_short!("recap")),
+                    amount,
+                );
+            }
+            ProposalAction::ResumeNormal => {
+                let mut pool: Pool = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Pool)
+                    .ok_or(Error::NotInitialized)?;
+                if pool.emergency_assets < pool.total_deposited {
+                    return Err(Error::Insolvent);
+                }
+                pool.is_emergency = false;
+                env.storage().instance().set(&DataKey::Pool, &pool);
+                env.events().publish(
+                    (symbol_short!("emergency"), symbol_short!("resumed")),
+                    pool.total_deposited,
+                );
+            }
         }
         Ok(())
     }
@@ -545,6 +616,14 @@ impl DripPool {
     // ── Join ───────────────────────────────────────────────────────────────
     pub fn join(env: Env, who: Address) -> Result<(), Error> {
         who.require_auth();
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        if pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
         if Self::has_participant(&env, &who) {
             return Err(Error::AlreadyJoined);
         }
@@ -576,15 +655,19 @@ impl DripPool {
             return Err(Error::InvalidAmount);
         }
 
-        let old_participant: Option<Participant> = {
-            let key = DataKey::Participant(who.clone());
-            env.storage().persistent().get(&key)
-        };
         let old_pool: Pool = env
             .storage()
             .instance()
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
+        if old_pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
+
+        let old_participant: Option<Participant> = {
+            let key = DataKey::Participant(who.clone());
+            env.storage().persistent().get(&key)
+        };
 
         // Transfer tokens from caller to this contract (#376)
         let contract_addr = env.current_contract_address();
@@ -884,6 +967,9 @@ impl DripPool {
             .instance()
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
+        if pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
         pool.distributable_yield += amount;
         env.storage().instance().set(&DataKey::Pool, &pool);
         Self::bump_instance(&env);
@@ -908,6 +994,9 @@ impl DripPool {
             .instance()
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
+        if pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
         if amount > pool.distributable_yield {
             return Err(Error::InvalidAction);
         }
@@ -956,6 +1045,10 @@ impl DripPool {
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
 
+        if pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
+
         let winner = pool.admin.clone();
 
         // Auto-join the winner if they aren't yet a participant
@@ -983,6 +1076,70 @@ impl DripPool {
             (winner.clone(), prize),
         );
         Ok(winner)
+    }
+
+    // ── Emergency Pro-rata Exit (#512) ────────────────────────────────────
+    pub fn emergency_withdraw(env: Env, who: Address) -> Result<i128, Error> {
+        who.require_auth();
+
+        let mut pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+
+        if !pool.is_emergency {
+            return Err(Error::NotInEmergency);
+        }
+
+        let mut p = Self::load_participant(&env, &who)?;
+        let unwithdrawn = p.deposited - p.withdrawn_principal;
+        if unwithdrawn <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let payout = if pool.total_deposited > 0 && pool.emergency_assets > 0 {
+            (unwithdrawn.saturating_mul(pool.emergency_assets)) / pool.total_deposited
+        } else {
+            0
+        };
+
+        pool.total_deposited = pool.total_deposited.saturating_sub(unwithdrawn);
+        pool.emergency_assets = pool.emergency_assets.saturating_sub(payout);
+        env.storage().instance().set(&DataKey::Pool, &pool);
+
+        p.withdrawn_principal += unwithdrawn;
+        Self::save_participant(&env, &who, &p);
+
+        let contract_addr = env.current_contract_address();
+        if payout > 0 {
+            let _ = Self::transfer_tokens(&env, &contract_addr, &who, &payout);
+        }
+
+        env.events().publish(
+            (symbol_short!("emergency"), symbol_short!("withdraw")),
+            (who, unwithdrawn, payout),
+        );
+
+        Ok(payout)
+    }
+
+    pub fn is_emergency(env: Env) -> Result<bool, Error> {
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        Ok(pool.is_emergency)
+    }
+
+    pub fn emergency_assets(env: Env) -> Result<i128, Error> {
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        Ok(pool.emergency_assets)
     }
 
     // ── Views ──────────────────────────────────────────────────────────────

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -1348,3 +1348,122 @@ fn participant_v2_fields_present() {
     // V1 field that should NOT be present
     // The following would fail to compile: savings.claimable
 }
+
+// ── #512: Loss Circuit Breaker & Emergency Exit ────────────────────────────
+
+/// draw_winner and deposit are blocked while in emergency mode.
+#[test]
+fn draw_winner_blocked_in_emergency() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2); // 2 signers for threshold
+
+    // Trigger emergency mode with 500 available assets
+    let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(500));
+    client.approve(&signer2, &pid);
+
+    assert!(client.is_emergency());
+    assert_eq!(client.emergency_assets(), 500);
+
+    // draw_winner fails with InEmergency
+    assert_eq!(
+        client.try_draw_winner(&admin, &100),
+        Err(Ok(Error::InEmergency))
+    );
+
+    // join and deposit fail with InEmergency
+    let alice = Address::generate(&env);
+    assert_eq!(client.try_join(&alice), Err(Ok(Error::InEmergency)));
+}
+
+/// Emergency withdraw distributes available assets pro-rata on partial loss.
+#[test]
+fn emergency_withdraw_pro_rata_partial_loss() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.join(&alice);
+    client.join(&bob);
+
+    client.deposit(&alice, &600);
+    client.deposit(&bob, &400);
+    assert_eq!(client.pool().total_deposited, 1_000);
+
+    // Trigger emergency with 500 assets (50% loss)
+    let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(500));
+    client.approve(&signer2, &pid);
+
+    assert!(client.is_emergency());
+
+    // Alice has 600/1000 = 60%, gets 600 * 500 / 1000 = 300
+    let alice_payout = client.emergency_withdraw(&alice);
+    assert_eq!(alice_payout, 300);
+
+    // Bob has 400 remaining out of 400 total_deposited, 200 emergency_assets, gets 200
+    let bob_payout = client.emergency_withdraw(&bob);
+    assert_eq!(bob_payout, 200);
+
+    assert_eq!(client.pool().total_deposited, 0);
+    assert_eq!(client.emergency_assets(), 0);
+}
+
+/// Emergency withdraw returns 0 on total strategy failure (0 emergency assets).
+#[test]
+fn emergency_withdraw_total_strategy_failure() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+
+    // Trigger emergency with 0 assets
+    let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(0));
+    client.approve(&signer2, &pid);
+
+    let payout = client.emergency_withdraw(&alice);
+    assert_eq!(payout, 0);
+    assert_eq!(client.pool().total_deposited, 0);
+}
+
+/// Recapitalization and return to normal mode via governance.
+#[test]
+fn recapitalization_and_resume_normal() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    client.deposit(&alice, &1_000);
+
+    // Trigger emergency with 400 assets
+    let pid1 = client.propose(&admin, &ProposalAction::TriggerEmergency(400));
+    client.approve(&signer2, &pid1);
+
+    // Try ResumeNormal before recapitalization -> fails with Insolvent at propose time
+    assert_eq!(
+        client.try_propose(&admin, &ProposalAction::ResumeNormal),
+        Err(Ok(Error::Insolvent))
+    );
+
+    // Recapitalize by 600
+    let pid2 = client.propose(&admin, &ProposalAction::Recapitalize(600));
+    client.approve(&signer2, &pid2);
+
+    assert_eq!(client.emergency_assets(), 1_000);
+
+    // Resume normal mode
+    let pid3 = client.propose(&admin, &ProposalAction::ResumeNormal);
+    client.approve(&signer2, &pid3);
+
+    assert!(!client.is_emergency());
+}


### PR DESCRIPTION
Adds governed loss-recovery state transitions and pro-rata emergency redemption handling for vault participants when strategy impairment is detected. Includes fee/prize freezing guards and test coverage for partial loss, total failure, recapitalization, and concurrent exits.

Closes #512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an emergency mode for the pool to pause deposits, joins, and yield or prize operations.
  - Added pro-rata emergency withdrawals based on available pool assets.
  - Added governance actions to trigger emergencies, recapitalize the pool, and resume normal operations.
  - Added views for checking emergency status and available emergency assets.
- **Bug Fixes**
  - Prevented normal operations from resuming while the pool remains insolvent.
- **Tests**
  - Added coverage for emergency activation, blocked operations, withdrawals, and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->