### PR TITLE
fix(contracts): governance timelock, proxy multisig upgrades, liquidi…

### DIFF
--- a/contracts/docs/EVENT_SCHEMA.md
+++ b/contracts/docs/EVENT_SCHEMA.md
@@ -36,6 +36,12 @@ ledger when available.
 | `paused` | backend operations, frontend disabled states | `scope`, `admin`, `reason`, `paused_at` |
 | `recovered` | backend operations, frontend disabled states | `scope`, `admin`, `recovered_at` |
 | `config_changed` | backend indexing, frontend config refresh | `scope`, `admin`, `key`, `old_value?`, `new_value`, `effective_at` |
+| `withdrawal_queued` | backend indexing, frontend queue-position display | `pool_id`, `wallet`, `amount`, `request_id` |
+| `withdrawal_fulfilled` | backend indexing, frontend queue/balance refresh | `pool_id`, `queue_head`, `amount_paid` |
+| `withdrawal_cancelled` | backend indexing, frontend queue refresh | `pool_id`, `request_id`, `amount_refunded` |
+| `governance_epoch_changed` | backend operations, frontend proposal invalidation | `pool_id`, `admin`, `epoch` |
+| `proxy_upgrade_proposed` | backend operations, frontend upgrade tracker | `pool_id`, `upgrade_id`, `new_logic`, `breaking`, `ready_at`, `expires_at` |
+| `proxy_upgrade_executed` | backend operations, frontend upgrade tracker | `pool_id`, `upgrade_id`, `new_logic`, `executed_at` |
 
 ## Normalized indexer examples
 

--- a/contracts/drip-pool/src/benchmarks.rs
+++ b/contracts/drip-pool/src/benchmarks.rs
@@ -43,6 +43,12 @@ fn skip_lockup(env: &Env) {
     env.ledger().set_sequence_number(current + 120_961);
 }
 
+/// Advance ledger sequence past the high-risk governance timelock (#533).
+fn skip_high_risk_delay(env: &Env) {
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + HIGH_RISK_DELAY_LEDGERS + 1);
+}
+
 fn create_participants(env: &Env, client: &DripPoolClient, count: u32) -> Vec<Address> {
     let mut participants = Vec::new(env);
     for _ in 0..count {
@@ -479,7 +485,9 @@ fn bench_propose_and_approve_2_of_2() {
         &ProposalAction::ReleaseEscrow(recipient.clone(), 5_000),
     );
     let executed = client.approve(&signer2, &pid);
-    assert!(executed);
+    assert!(!executed, "high-risk action must not execute before its delay");
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid);
 
     let pool = client.pool();
     assert_eq!(pool.total_deposited, 5_000);
@@ -498,9 +506,11 @@ fn bench_propose_and_approve_3_of_5() {
     client.seed_admin(&admin, &signer2);
     client.seed_admin(&admin, &signer3);
 
-    // Lower threshold to 3 via proposal
+    // Lower threshold to 3 via proposal (high-risk: needs its own delay).
     let threshold_pid = client.propose(&admin, &ProposalAction::SetThreshold(3));
     let _ = client.approve(&signer2, &threshold_pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &threshold_pid);
 
     client.deposit(&admin, &10_000);
 
@@ -511,7 +521,9 @@ fn bench_propose_and_approve_3_of_5() {
     );
     let _ = client.approve(&signer2, &pid);
     let executed = client.approve(&signer3, &pid);
-    assert!(executed);
+    assert!(!executed, "high-risk action must not execute before its delay");
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer3, &pid);
 
     let pool = client.pool();
     assert_eq!(pool.total_deposited, 5_000);
@@ -956,7 +968,9 @@ fn bench_proposal_with_5_admins() {
     let _ = client.approve(&signer2, &pid);
     let _ = client.approve(&signer3, &pid);
     let executed = client.approve(&signer4, &pid);
-    assert!(executed);
+    assert!(!executed, "high-risk action must not execute before its delay");
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer4, &pid);
 
     let pool = client.pool();
     assert_eq!(pool.total_deposited, 5_000);

--- a/contracts/drip-pool/src/lib.rs
+++ b/contracts/drip-pool/src/lib.rs
@@ -78,6 +78,11 @@ const PERSISTENT_TTL_EXTEND: u32 = 500_000;
 // ── Proposal expiry (~30 days at 5 s/ledger) ──────────────────────────────
 const PROPOSAL_EXPIRY_LEDGERS: u32 = 17_280 * 30;
 
+// ── Timelock delay for high-risk governance actions (~24h at 5 s/ledger,
+// #533). Applies to fund release, emergency transitions, signer removal,
+// threshold changes, and strategy rotation — see `is_high_risk`.
+pub(crate) const HIGH_RISK_DELAY_LEDGERS: u32 = 17_280;
+
 // ── Default multi-sig threshold ────────────────────────────────────────────
 const DEFAULT_THRESHOLD: u32 = 2;
 
@@ -100,6 +105,13 @@ pub enum DataKey {
     StrategyExposureCap,    // i128 — maximum allowable deposit for active strategy (#532)
     ProposedExposureCap,    // i128 — exposure cap for candidate strategy (#532)
     StrategyRotationPhase,  // StrategyRotationPhase — phase of current rotation (#532)
+    StrategyRotationReadyAt, // u32 — ledger sequence when the pending rotation may activate (#533)
+    GovernanceEpoch,        // u32 — bumped on every Admins/Threshold change (#533)
+    MinIdleReserve,         // i128 — minimum idle principal governance must leave undeployed (#529)
+    WithdrawalQueueHead,    // u32 — next withdrawal request id to fulfill (#529)
+    WithdrawalQueueTail,    // u32 — next withdrawal request id to assign (#529)
+    WithdrawalRequest(u32), // queued withdrawal request, by id (#529)
+    ParticipantQueue(Address), // Address -> pending request id, prevents duplicate queuing (#529)
 }
 
 // ── Errors ─────────────────────────────────────────────────────────────────
@@ -131,6 +143,8 @@ pub enum Error {
     NotInEmergency = 22,          // emergency exit blocked while not in emergency mode (#512)
     Insolvent = 23,               // principal coverage below policy (#512)
     IncompatibleConfig = 24,      // configuration schema version mismatch (#441)
+    GovernanceEpochChanged = 25, // admin/threshold set changed since proposal creation (#533)
+    TimelockNotElapsed = 26,     // high-risk proposal executed before its delay (#533)
     StrategyNotSet = 51,
     StrategyVersionUnsupported = 52,
     StrategyPaused = 53,
@@ -141,6 +155,12 @@ pub enum Error {
     StrategyUnreconciledPrincipal = 58,
     ExposureCapExceeded = 59,
     StrategyAssetMismatch = 60,
+    StrategyRotationDelayNotElapsed = 61, // activate_strategy before timelock elapses (#533)
+    InsufficientIdleReserve = 62,  // deploy_to_strategy would breach the idle buffer (#529)
+    WithdrawalAlreadyQueued = 64,  // participant already has a pending queued withdrawal (#529)
+    WithdrawalRequestNotFound = 65,
+    WithdrawalRequestNotOwned = 66,
+    WithdrawalRequestNotPending = 67,
 }
 
 // ── Structs ────────────────────────────────────────────────────────────────
@@ -194,6 +214,35 @@ pub struct Proposal {
     pub approvals: Vec<Address>,
     pub expires_at: u32, // ledger sequence; approvals rejected after this (#383)
     pub approver_snapshot: Vec<Address>, // admin set frozen at proposal creation (#384)
+    pub threshold_snapshot: u32, // approvals required, frozen at creation — a later
+    // SetThreshold can never raise or lower what THIS proposal needs (#533)
+    pub epoch_snapshot: u32, // governance epoch at creation; a later Admins/Threshold
+    // change bumps the epoch and makes this proposal stale (#533)
+    pub ready_at: u32, // ledger sequence at/after which this proposal may execute;
+                        // `created_at + HIGH_RISK_DELAY_LEDGERS` for high-risk actions,
+                        // `created_at` (immediate) otherwise (#533)
+}
+
+/// Lifecycle status of a queued withdrawal request (#529).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[contracttype]
+pub enum WithdrawalRequestStatus {
+    Pending,
+    Fulfilled,
+    Cancelled,
+    Expired,
+}
+
+/// A FIFO withdrawal request created when idle liquidity cannot cover an
+/// immediate withdrawal because principal is deployed to a strategy (#529).
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct WithdrawalRequest {
+    pub who: Address,
+    pub amount: i128, // remaining amount still owed via this request
+    pub requested_at: u32,
+    pub expires_at: u32,
+    pub status: WithdrawalRequestStatus,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -269,6 +318,37 @@ impl DripPool {
             return Err(Error::IncompatibleConfig);
         }
         Ok(())
+    }
+
+    // ── Governance epoch & timelock helpers (#533) ────────────────────────
+
+    fn get_epoch(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::GovernanceEpoch)
+            .unwrap_or(0)
+    }
+
+    /// Bump the governance epoch. Called whenever the admin set or threshold
+    /// changes, so proposals snapshotted under the old rules become stale
+    /// (#533) instead of being silently approved/executed under new ones.
+    fn bump_epoch(env: &Env) {
+        let epoch = Self::get_epoch(env) + 1;
+        env.storage().instance().set(&DataKey::GovernanceEpoch, &epoch);
+    }
+
+    /// High-risk actions get a ledger-based execution delay after the
+    /// approval threshold is met, so they can never execute immediately even
+    /// when fully approved (#533).
+    fn is_high_risk(action: &ProposalAction) -> bool {
+        matches!(
+            action,
+            ProposalAction::ReleaseEscrow(_, _)
+                | ProposalAction::RemoveAdmin(_)
+                | ProposalAction::SetThreshold(_)
+                | ProposalAction::TriggerEmergency(_)
+                | ProposalAction::ResumeNormal
+        )
     }
 
     fn bump_participant(env: &Env, key: &DataKey) {
@@ -379,6 +459,51 @@ impl DripPool {
         accounting_update()
     }
 
+    // ── Withdrawal queue helpers (#529) ────────────────────────────────────
+
+    /// Real spendable custody: the contract's own SAC balance. When no token
+    /// is configured, transfers are no-ops, so liquidity is never the
+    /// constraint (mirrors `transfer_tokens`'s backward-compatible no-op).
+    fn idle_liquidity(env: &Env) -> i128 {
+        if !Self::has_token_configured(env) {
+            return i128::MAX;
+        }
+        let token_addr = match Self::get_token_address(env) {
+            Ok(a) => a,
+            Err(_) => return i128::MAX,
+        };
+        let contract_addr = env.current_contract_address();
+        soroban_sdk::token::TokenClient::new(env, &token_addr).balance(&contract_addr)
+    }
+
+    /// Push a new FIFO withdrawal request. Bounded and ordered by assignment
+    /// order — the queue can only be processed head-first (#529).
+    fn enqueue_withdrawal(env: &Env, who: &Address, amount: i128) -> u32 {
+        let tail: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawalQueueTail)
+            .unwrap_or(0);
+        let request = WithdrawalRequest {
+            who: who.clone(),
+            amount,
+            requested_at: env.ledger().sequence(),
+            expires_at: env.ledger().sequence() + PROPOSAL_EXPIRY_LEDGERS,
+            status: WithdrawalRequestStatus::Pending,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawalRequest(tail), &request);
+        env.storage()
+            .instance()
+            .set(&DataKey::ParticipantQueue(who.clone()), &tail);
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawalQueueTail, &(tail + 1));
+        Self::bump_instance(env);
+        tail
+    }
+
     // ── Initialise ─────────────────────────────────────────────────────────
     pub fn create(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
@@ -472,6 +597,7 @@ impl DripPool {
         if !admins.contains(&new_admin) {
             admins.push_back(new_admin);
             env.storage().instance().set(&DataKey::Admins, &admins);
+            Self::bump_epoch(&env);
         }
         Self::bump_instance(&env);
         Ok(())
@@ -527,15 +653,28 @@ impl DripPool {
         pool.proposal_nonce += 1;
         env.storage().instance().set(&DataKey::Pool, &pool);
 
-        // Snapshot the current admin set; only these addresses may approve (#384)
+        // Snapshot the current admin set, threshold and governance epoch;
+        // only this snapshot governs whether/when this proposal can execute,
+        // regardless of later Admins/Threshold changes (#384, #533).
         let snapshot = Self::get_admins(&env);
-        let expires_at = env.ledger().sequence() + PROPOSAL_EXPIRY_LEDGERS;
+        let threshold_snapshot = Self::get_threshold(&env);
+        let epoch_snapshot = Self::get_epoch(&env);
+        let now = env.ledger().sequence();
+        let ready_at = if Self::is_high_risk(&action) {
+            now + HIGH_RISK_DELAY_LEDGERS
+        } else {
+            now
+        };
+        let expires_at = now + PROPOSAL_EXPIRY_LEDGERS;
 
         let proposal = Proposal {
             action,
             approvals: vec![&env, signer],
             expires_at,
             approver_snapshot: snapshot,
+            threshold_snapshot,
+            epoch_snapshot,
+            ready_at,
         };
         env.storage()
             .instance()
@@ -544,7 +683,10 @@ impl DripPool {
         Ok(nonce)
     }
 
-    /// Approve an existing proposal. Executes automatically when threshold met.
+    /// Approve an existing proposal. Executes automatically once the
+    /// proposal's own snapshotted threshold is met AND (for high-risk
+    /// actions) its timelock delay has elapsed — never before (#533).
+    /// Returns whether the action executed as part of this call.
     pub fn approve(env: Env, signer: Address, proposal_id: u32) -> Result<bool, Error> {
         signer.require_auth();
         Self::require_signer(&env, &signer)?;
@@ -564,6 +706,15 @@ impl DripPool {
             return Err(Error::ProposalExpired);
         }
 
+        // A later Admins/Threshold change invalidates proposals snapshotted
+        // under the old epoch — they cannot be revived, only re-proposed (#533).
+        if proposal.epoch_snapshot != Self::get_epoch(&env) {
+            env.storage()
+                .instance()
+                .remove(&DataKey::Proposal(proposal_id));
+            return Err(Error::GovernanceEpochChanged);
+        }
+
         // Approvers must be in the snapshot from proposal creation (#384)
         if !proposal.approver_snapshot.contains(&signer) {
             return Err(Error::Unauthorized);
@@ -574,26 +725,31 @@ impl DripPool {
         }
         proposal.approvals.push_back(signer);
 
-        let threshold = Self::get_threshold(&env);
-        let threshold_met = proposal.approvals.len() >= threshold;
-        if threshold_met {
-            Self::execute_proposal(&env, &proposal)?;
+        // Threshold is always evaluated against the snapshot taken at
+        // creation, never the live value (#533).
+        let threshold_met = proposal.approvals.len() >= proposal.threshold_snapshot;
+        let executed = if threshold_met && env.ledger().sequence() >= proposal.ready_at {
+            Self::apply_proposal_action(&env, &proposal)?;
             env.storage()
                 .instance()
                 .remove(&DataKey::Proposal(proposal_id));
+            true
         } else {
             env.storage()
                 .instance()
                 .set(&DataKey::Proposal(proposal_id), &proposal);
-        }
+            false
+        };
         Self::bump_instance(&env);
-        Ok(threshold_met)
+        Ok(executed)
     }
 
-    /// Cancel a pending proposal. Any signer present in the proposal's snapshot may cancel.
-    pub fn cancel_proposal(env: Env, signer: Address, proposal_id: u32) -> Result<(), Error> {
-        signer.require_auth();
-        Self::require_signer(&env, &signer)?;
+    /// Execute a proposal whose threshold was already met by `approve` but
+    /// whose timelock delay had not yet elapsed. Any current signer may
+    /// trigger it once the delay passes and before expiry (#533).
+    pub fn execute_proposal(env: Env, caller: Address, proposal_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_signer(&env, &caller)?;
         Self::require_compatible_config(&env)?;
 
         let proposal: Proposal = env
@@ -602,7 +758,60 @@ impl DripPool {
             .get(&DataKey::Proposal(proposal_id))
             .ok_or(Error::ProposalNotFound)?;
 
-        if !proposal.approver_snapshot.contains(&signer) {
+        if proposal.epoch_snapshot != Self::get_epoch(&env) {
+            env.storage()
+                .instance()
+                .remove(&DataKey::Proposal(proposal_id));
+            return Err(Error::GovernanceEpochChanged);
+        }
+
+        if env.ledger().sequence() > proposal.expires_at {
+            env.storage()
+                .instance()
+                .remove(&DataKey::Proposal(proposal_id));
+            return Err(Error::ProposalExpired);
+        }
+
+        if proposal.approvals.len() < proposal.threshold_snapshot {
+            return Err(Error::ThresholdNotMet);
+        }
+
+        if env.ledger().sequence() < proposal.ready_at {
+            return Err(Error::TimelockNotElapsed);
+        }
+
+        Self::apply_proposal_action(&env, &proposal)?;
+        env.storage()
+            .instance()
+            .remove(&DataKey::Proposal(proposal_id));
+        Self::bump_instance(&env);
+        Ok(())
+    }
+
+    /// Cancel a pending proposal. Any signer present in the proposal's
+    /// snapshot may cancel. Once the governance epoch has moved on, any
+    /// *current* signer may also cancel — otherwise a rotated-out signer set
+    /// could leave a stale proposal permanently stuck (#533).
+    pub fn cancel_proposal(env: Env, signer: Address, proposal_id: u32) -> Result<(), Error> {
+        signer.require_auth();
+        Self::require_compatible_config(&env)?;
+
+        let proposal: Proposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(Error::ProposalNotFound)?;
+
+        let is_current_signer = Self::get_admins(&env).contains(&signer);
+        let in_snapshot = proposal.approver_snapshot.contains(&signer);
+        let epoch_stale = proposal.epoch_snapshot != Self::get_epoch(&env);
+
+        let authorized = if epoch_stale {
+            is_current_signer || in_snapshot
+        } else {
+            is_current_signer && in_snapshot
+        };
+        if !authorized {
             return Err(Error::Unauthorized);
         }
 
@@ -613,19 +822,23 @@ impl DripPool {
         Ok(())
     }
 
-    fn execute_proposal(env: &Env, proposal: &Proposal) -> Result<(), Error> {
+    fn apply_proposal_action(env: &Env, proposal: &Proposal) -> Result<(), Error> {
         match proposal.action.clone() {
             ProposalAction::AddAdmin(addr) => {
                 let mut admins = Self::get_admins(env);
                 if !admins.contains(&addr) {
                     admins.push_back(addr);
                     env.storage().instance().set(&DataKey::Admins, &admins);
+                    Self::bump_epoch(env);
                 }
             }
             ProposalAction::RemoveAdmin(addr) => {
                 let admins = Self::get_admins(env);
                 let threshold = Self::get_threshold(env);
-                // Liveness guard: cannot reduce admin count to below threshold (#383)
+                // Liveness guard: cannot reduce admin count to below threshold
+                // (#383). Checked against the CURRENT threshold at execution
+                // time, since this is a live safety invariant rather than
+                // something frozen by the approval-count snapshot (#533).
                 if admins.len() <= threshold {
                     return Err(Error::InvalidAction);
                 }
@@ -636,6 +849,7 @@ impl DripPool {
                     }
                 }
                 env.storage().instance().set(&DataKey::Admins, &new_admins);
+                Self::bump_epoch(env);
             }
             ProposalAction::ReleaseEscrow(recipient, amount) => {
                 let mut pool: Pool = env
@@ -669,6 +883,7 @@ impl DripPool {
                     return Err(Error::InvalidAction);
                 }
                 env.storage().instance().set(&DataKey::Threshold, &t);
+                Self::bump_epoch(env);
             }
             ProposalAction::TriggerEmergency(assets) => {
                 let mut pool: Pool = env
@@ -936,8 +1151,22 @@ impl DripPool {
 
         let mut p = Self::load_participant(&env, &who)?;
         let available = (p.yield_accrued + p.prize) - p.claimed_reward;
+        if available <= 0 {
+            return Ok(0);
+        }
         p.claimed_reward += available;
         Self::save_participant(&env, &who, &p);
+
+        // Transfer first; roll back claimed_reward on failure so a failed
+        // claim never silently burns the reward and can be retried (#526,
+        // mirrors the withdraw/sweep_unclaimed rollback pattern from #376/#440).
+        let contract_addr = env.current_contract_address();
+        if let Err(e) = Self::transfer_tokens(&env, &contract_addr, &who, &available) {
+            let mut p = Self::load_participant(&env, &who)?;
+            p.claimed_reward -= available;
+            Self::save_participant(&env, &who, &p);
+            return Err(e);
+        }
 
         env.events().publish(
             (symbol_short!("pool"), symbol_short!("claimed")),
@@ -1025,6 +1254,15 @@ impl DripPool {
     }
 
     // ── Withdraw (#376: real token custody) ────────────────────────────────
+
+    /// Withdraw unwithdrawn principal. Returns the amount paid out
+    /// immediately. If idle custody can't cover it (principal is deployed
+    /// to a strategy), returns `Ok(0)` and enqueues a FIFO withdrawal
+    /// request instead of reverting — a Soroban top-level call that returns
+    /// `Err` rolls back all of its own storage writes, so signaling "queued"
+    /// via an error would silently discard the just-created queue entry.
+    /// Callers should check `withdrawal_request_of` to distinguish a
+    /// genuine zero balance from a queued request (#529).
     pub fn withdraw(env: Env, who: Address) -> Result<i128, Error> {
         who.require_auth();
         Self::require_compatible_config(&env)?;
@@ -1035,17 +1273,40 @@ impl DripPool {
             return Err(Error::LockupActive);
         }
 
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::ParticipantQueue(who.clone()))
+        {
+            return Err(Error::WithdrawalAlreadyQueued);
+        }
+
         // Reentrancy lock via Pool field
         let mut pool: Pool = env
             .storage()
             .instance()
             .get(&DataKey::Pool)
             .ok_or(Error::NotInitialized)?;
+
+        // Never trap on insufficient real custody — queue the request for
+        // governed strategy recall instead (#529). This must return Ok,
+        // not Err: a failing top-level call rolls back everything it wrote,
+        // including the queue entry just created.
+        let available = p.deposited - p.withdrawn_principal;
+        let idle = Self::idle_liquidity(&env);
+        if available > 0 && available > idle {
+            let qid = Self::enqueue_withdrawal(&env, &who, available);
+            env.events().publish(
+                (symbol_short!("wq"), symbol_short!("queued")),
+                (who, available, qid),
+            );
+            return Ok(0);
+        }
+
         Self::acquire_lock(&mut pool)?;
         env.storage().instance().set(&DataKey::Pool, &pool);
 
         // Withdraw only unwithdrawn principal, not rewards (#377)
-        let available = p.deposited - p.withdrawn_principal;
         p.withdrawn_principal += available;
         Self::save_participant(&env, &who, &p);
 
@@ -1078,6 +1339,209 @@ impl DripPool {
             (who, available),
         );
         Ok(available)
+    }
+
+    // ── Liquidity buffer & withdrawal queue (#529) ─────────────────────────
+
+    /// Governed: set the minimum idle principal `deploy_to_strategy` must
+    /// leave undeployed, so normal withdrawals always have custody to draw
+    /// from without depending on strategy recall.
+    pub fn set_min_idle_reserve(env: Env, caller: Address, amount: i128) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_signer(&env, &caller)?;
+        Self::require_compatible_config(&env)?;
+        if amount < 0 {
+            return Err(Error::InvalidAmount);
+        }
+        env.storage().instance().set(&DataKey::MinIdleReserve, &amount);
+        Self::bump_instance(&env);
+        env.events()
+            .publish((symbol_short!("pool"), symbol_short!("idlecfg")), amount);
+        Ok(())
+    }
+
+    /// View the configured minimum idle reserve (#529).
+    pub fn min_idle_reserve(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinIdleReserve)
+            .unwrap_or(0)
+    }
+
+    /// Governed: pay out pending withdrawal requests from the head of the
+    /// FIFO queue, in order, up to `max_requests` and up to currently idle
+    /// liquidity. A request blocking on insufficient liquidity is paid
+    /// partially and stays at the head — later, smaller requests are never
+    /// paid out of order (#529). Returns the total amount paid.
+    pub fn fulfill_withdrawal_queue(
+        env: Env,
+        caller: Address,
+        max_requests: u32,
+    ) -> Result<i128, Error> {
+        caller.require_auth();
+        Self::require_signer(&env, &caller)?;
+        Self::require_compatible_config(&env)?;
+
+        let pool: Pool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pool)
+            .ok_or(Error::NotInitialized)?;
+        if pool.is_emergency {
+            return Err(Error::InEmergency);
+        }
+
+        let mut head: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawalQueueHead)
+            .unwrap_or(0);
+        let tail: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawalQueueTail)
+            .unwrap_or(0);
+
+        let mut total_paid: i128 = 0;
+        let mut processed: u32 = 0;
+        let contract_addr = env.current_contract_address();
+
+        while head < tail && processed < max_requests {
+            let key = DataKey::WithdrawalRequest(head);
+            let mut request: WithdrawalRequest = match env.storage().instance().get(&key) {
+                Some(r) => r,
+                None => {
+                    head += 1;
+                    continue;
+                }
+            };
+
+            if request.status != WithdrawalRequestStatus::Pending {
+                head += 1;
+                continue;
+            }
+
+            if env.ledger().sequence() > request.expires_at {
+                request.status = WithdrawalRequestStatus::Expired;
+                env.storage().instance().set(&key, &request);
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::ParticipantQueue(request.who.clone()));
+                head += 1;
+                processed += 1;
+                continue;
+            }
+
+            let idle = Self::idle_liquidity(&env);
+            if idle <= 0 {
+                break;
+            }
+
+            let pay = if request.amount <= idle {
+                request.amount
+            } else {
+                idle
+            };
+
+            Self::transfer_tokens(&env, &contract_addr, &request.who, &pay)?;
+
+            let mut p = Self::load_participant(&env, &request.who)?;
+            p.withdrawn_principal += pay;
+            Self::save_participant(&env, &request.who, &p);
+
+            request.amount -= pay;
+            total_paid += pay;
+
+            if request.amount == 0 {
+                request.status = WithdrawalRequestStatus::Fulfilled;
+                env.storage().instance().set(&key, &request);
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::ParticipantQueue(request.who.clone()));
+                head += 1;
+                processed += 1;
+            } else {
+                // Partial payment — liquidity exhausted; stop without
+                // skipping ahead to a later, smaller request (#529).
+                env.storage().instance().set(&key, &request);
+                break;
+            }
+        }
+
+        env.storage().instance().set(&DataKey::WithdrawalQueueHead, &head);
+        Self::bump_instance(&env);
+
+        if total_paid > 0 {
+            env.events()
+                .publish((symbol_short!("wq"), symbol_short!("fulfill")), (head, total_paid));
+        }
+        Ok(total_paid)
+    }
+
+    /// Cancel the caller's own pending withdrawal request. The un-paid
+    /// remaining amount was never counted as withdrawn, so the participant's
+    /// claim is preserved and `withdraw` can be called again later (#529).
+    pub fn cancel_withdrawal_request(env: Env, who: Address) -> Result<i128, Error> {
+        who.require_auth();
+        Self::require_compatible_config(&env)?;
+
+        let qid: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ParticipantQueue(who.clone()))
+            .ok_or(Error::WithdrawalRequestNotFound)?;
+        let key = DataKey::WithdrawalRequest(qid);
+        let mut request: WithdrawalRequest = env
+            .storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::WithdrawalRequestNotFound)?;
+
+        if request.who != who {
+            return Err(Error::WithdrawalRequestNotOwned);
+        }
+        if request.status != WithdrawalRequestStatus::Pending {
+            return Err(Error::WithdrawalRequestNotPending);
+        }
+
+        let remaining = request.amount;
+        request.status = WithdrawalRequestStatus::Cancelled;
+        env.storage().instance().set(&key, &request);
+        env.storage()
+            .instance()
+            .remove(&DataKey::ParticipantQueue(who));
+        Self::bump_instance(&env);
+
+        env.events()
+            .publish((symbol_short!("wq"), symbol_short!("cancel")), (qid, remaining));
+        Ok(remaining)
+    }
+
+    /// View a withdrawal request by id (#529).
+    pub fn withdrawal_request(env: Env, request_id: u32) -> Result<WithdrawalRequest, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::WithdrawalRequest(request_id))
+            .ok_or(Error::WithdrawalRequestNotFound)
+    }
+
+    /// View the caller's active queued request id, if any (#529).
+    pub fn withdrawal_request_of(env: Env, who: Address) -> Option<u32> {
+        env.storage().instance().get(&DataKey::ParticipantQueue(who))
+    }
+
+    pub fn withdrawal_queue_head(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::WithdrawalQueueHead)
+            .unwrap_or(0)
+    }
+
+    pub fn withdrawal_queue_tail(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::WithdrawalQueueTail)
+            .unwrap_or(0)
     }
 
     // ── Yield management (#382) ────────────────────────────────────────────
@@ -1383,6 +1847,13 @@ impl DripPool {
 
     pub fn threshold(env: Env) -> u32 {
         Self::get_threshold(&env)
+    }
+
+    /// View the current governance epoch. Bumped on every Admins/Threshold
+    /// change; proposals snapshotted under an earlier epoch cannot execute
+    /// (#533).
+    pub fn governance_epoch(env: Env) -> u32 {
+        Self::get_epoch(&env)
     }
 
     /// View the configured token address (#376).

--- a/contracts/drip-pool/src/proxy.rs
+++ b/contracts/drip-pool/src/proxy.rs
@@ -1,6 +1,6 @@
 //! Transparent proxy contract for vault logic upgrades.
-//! Stores the logic contract hash in proxy storage and provides
-//! an admin function to upgrade the implementation.
+//! Stores the logic contract hash in proxy storage and gates every upgrade
+//! through the canonical pool's multisig governance.
 //!
 //! ## Upgrade compatibility gate (issue #386, partial)
 //!
@@ -12,26 +12,48 @@
 //! post-upgrade smoke tests, or documented rollback procedures) — those
 //! remain open follow-up work.
 //!
-//! Callers upgrading the logic contract must declare whether the change is
-//! `breaking`. A breaking upgrade only succeeds if the admin has previously
-//! called [`VaultProxy::register_migration`] for the exact
-//! `(current_logic -> new_logic)` pair, which is intended to be the on-chain
-//! record that a human (or CI job, once built) reviewed the transition and
-//! supplied a migration path. Non-breaking upgrades (e.g. bugfixes that
-//! don't touch storage layout or remove/rename entry points) proceed
-//! without a migration record.
+//! ## Multisig-gated upgrades with an execution delay (#531)
+//!
+//! A single admin previously registered and executed upgrades unilaterally,
+//! bypassing pool governance entirely. The proxy now has no admin of its
+//! own: every authorization check reads the *live* signer set, threshold
+//! and governance epoch straight from the canonical `DripPool` contract via
+//! cross-contract calls, so proxy governance always tracks pool governance.
+//!
+//! Upgrades follow a propose → approve → (timelock) → execute lifecycle,
+//! mirroring the pool's own high-risk proposal timelock (#533):
+//! - `propose_upgrade` snapshots the pool's current admin set, threshold,
+//!   governance epoch and current logic contract. A breaking upgrade still
+//!   requires a prior `register_migration` record for the exact transition.
+//! - `approve_upgrade` only counts approvals from addresses in that frozen
+//!   snapshot, so a later admin rotation can't stuff extra votes in. It
+//!   auto-executes once threshold is met *and* the delay has elapsed.
+//! - `execute_upgrade` lets any current signer trigger execution once the
+//!   delay has elapsed for a proposal that reached threshold early.
+//! - Both re-check, at execution time: the governance epoch hasn't moved on
+//!   (admins/threshold rotated) and the current logic contract still
+//!   matches what was proposed against — a stale approval can never fire
+//!   against a changed target.
+//! - `cancel_upgrade` lets any *single* current pool signer cancel a pending
+//!   upgrade at any time — an intentional asymmetry: one signer can block a
+//!   bad upgrade immediately, but never execute one alone.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, Vec,
 };
+
+use crate::DripPoolClient;
 
 // ── Storage keys ────────────────────────────────────────────────────────────
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    Admin,                   // current proxy admin
-    LogicContract,           // Address of the current logic contract
-    Migration(MigrationKey), // marker: this specific (from -> to) transition was reviewed
+    PoolContract,             // Address of the DripPool contract that governs this proxy (#531)
+    LogicContract,            // Address of the current logic contract
+    LogicGeneration,          // u32 — bumped on every executed upgrade (#531)
+    Migration(MigrationKey),  // marker: this specific (from -> to) transition was reviewed
+    UpgradeProposal(u32),     // pending/executed/cancelled upgrade proposal, by id (#531)
+    UpgradeNonce,             // u32 — next upgrade proposal id (#531)
 }
 
 /// Identifies one specific logic-contract transition. Soroban's enum
@@ -45,6 +67,39 @@ pub struct MigrationKey {
     pub to: Address,
 }
 
+/// Lifecycle status of an upgrade proposal (#531).
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum UpgradeStatus {
+    Pending,
+    Executed,
+    Cancelled,
+    Expired,
+}
+
+/// A pending (or resolved) proxy upgrade, gated by pool multisig governance
+/// and a ledger-based execution delay (#531).
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct UpgradeProposal {
+    pub new_logic: Address,
+    pub breaking: bool,
+    pub approvals: Vec<Address>,
+    pub approver_snapshot: Vec<Address>, // pool admin set frozen at proposal creation
+    pub threshold_snapshot: u32,         // pool threshold frozen at proposal creation
+    pub epoch_snapshot: u32,             // pool governance epoch frozen at proposal creation
+    pub current_logic_snapshot: Address, // logic contract at proposal creation (informational)
+    pub logic_generation_snapshot: u32,  // logic generation at proposal creation — the actual
+    // staleness guard: bumped on every executed upgrade (including a
+    // rollback to a previously-used address), so a stale proposal can never
+    // match again even if the logic address later cycles back (#531)
+    pub proposed_at: u32,                // ledger sequence
+    pub ready_at: u32,                   // proposed_at + delay; cannot execute before this
+    pub expires_at: u32,                 // cannot execute after this
+    pub status: UpgradeStatus,
+    pub executed_at: Option<u32>,
+}
+
 // ── Errors ───────────────────────────────────────────────────────────────────
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -54,10 +109,20 @@ pub enum Error {
     AlreadyInitialized = 2,
     Unauthorized = 3,
     InvalidAddress = 4,
-    /// `upgrade()` was called with `breaking = true` but no migration record
-    /// exists for the `(current_logic -> new_logic)` pair. Call
-    /// `register_migration` first.
+    /// A breaking upgrade was proposed but no migration record exists for
+    /// the `(current_logic -> new_logic)` pair. Call `register_migration` first.
     MigrationRequired = 5,
+    ProposalNotFound = 6,
+    AlreadySigned = 7,
+    ThresholdNotMet = 8,
+    TimelockNotElapsed = 9,
+    ProposalExpired = 10,
+    /// The pool's admin set, threshold or governance epoch changed since
+    /// this upgrade was proposed — it cannot be revived, only re-proposed (#531).
+    GovernanceConfigChanged = 11,
+    /// The proxy's current logic contract changed since this upgrade was
+    /// proposed — executing against a stale snapshot is rejected (#531).
+    CurrentLogicChanged = 12,
 }
 
 // ── Contract ────────────────────────────────────────────────────────────────
@@ -66,31 +131,100 @@ pub struct VaultProxy;
 
 #[contractimpl]
 impl VaultProxy {
-    /// Initialize the proxy with an admin and initial logic contract.
-    pub fn create(env: Env, admin: Address, logic_contract: Address) -> Result<(), Error> {
-        admin.require_auth();
-        if env.storage().instance().has(&DataKey::Admin) {
+    // ── Internal helpers ───────────────────────────────────────────────────
+
+    fn get_pool(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PoolContract)
+            .ok_or(Error::NotInitialized)
+    }
+
+    fn pool_admins(env: &Env, pool: &Address) -> Vec<Address> {
+        DripPoolClient::new(env, pool).admins()
+    }
+
+    fn pool_threshold(env: &Env, pool: &Address) -> u32 {
+        DripPoolClient::new(env, pool).threshold()
+    }
+
+    fn pool_epoch(env: &Env, pool: &Address) -> u32 {
+        DripPoolClient::new(env, pool).governance_epoch()
+    }
+
+    fn require_pool_signer(env: &Env, pool: &Address, signer: &Address) -> Result<(), Error> {
+        if !Self::pool_admins(env, pool).contains(signer) {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn get_generation(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::LogicGeneration)
+            .unwrap_or(0)
+    }
+
+    /// Applies the upgrade if — and only if — nothing has executed since
+    /// this proposal was made. A Soroban contract invocation that returns
+    /// `Err` rolls back every storage write it made, so a stale proposal
+    /// can't be durably "cancelled" on this failing path; instead the
+    /// generation check below is what makes it permanently unexecutable,
+    /// with no persisted state required (#531).
+    fn apply_upgrade(env: &Env, proposal: &mut UpgradeProposal) -> Result<(), Error> {
+        let generation = Self::get_generation(env);
+        if generation != proposal.logic_generation_snapshot {
+            return Err(Error::CurrentLogicChanged);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::LogicContract, &proposal.new_logic);
+        env.storage()
+            .instance()
+            .set(&DataKey::LogicGeneration, &(generation + 1));
+        proposal.status = UpgradeStatus::Executed;
+        proposal.executed_at = Some(env.ledger().sequence());
+        env.events().publish(
+            (symbol_short!("proxy"), symbol_short!("upgraded")),
+            (proposal.new_logic.clone(), proposal.breaking),
+        );
+        Ok(())
+    }
+
+    // ── Initialise ─────────────────────────────────────────────────────────
+
+    /// Bind this proxy to the canonical pool contract that governs it.
+    /// Callable only by a current signer of that pool (#531).
+    pub fn create(
+        env: Env,
+        caller: Address,
+        pool_contract: Address,
+        logic_contract: Address,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        if env.storage().instance().has(&DataKey::PoolContract) {
             return Err(Error::AlreadyInitialized);
         }
-        env.storage().instance().set(&DataKey::Admin, &admin);
+        Self::require_pool_signer(&env, &pool_contract, &caller)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PoolContract, &pool_contract);
         env.storage()
             .instance()
             .set(&DataKey::LogicContract, &logic_contract);
         env.events().publish(
             (symbol_short!("proxy"), symbol_short!("created")),
-            (admin, logic_contract),
+            (pool_contract, logic_contract),
         );
         Ok(())
     }
 
-    /// Record that the admin has reviewed and prepared a migration for the
-    /// specific `from -> to` logic-contract transition. Required before a
-    /// `breaking` upgrade to `to` can succeed while the current logic
-    /// contract is `from`. Admin-only.
-    ///
-    /// This is the on-chain "explicit migration supplied" gate: registering
-    /// is a separate, auditable step from the upgrade itself, so a breaking
-    /// change can't be pushed through `upgrade()` alone.
+    /// Record that a current pool signer has reviewed and prepared a
+    /// migration for the specific `from -> to` logic-contract transition.
+    /// Required before a `breaking` upgrade to `to` can be proposed while
+    /// the current logic contract is `from`.
     pub fn register_migration(
         env: Env,
         caller: Address,
@@ -98,14 +232,8 @@ impl VaultProxy {
         to: Address,
     ) -> Result<(), Error> {
         caller.require_auth();
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-        if admin != caller {
-            return Err(Error::Unauthorized);
-        }
+        let pool = Self::get_pool(&env)?;
+        Self::require_pool_signer(&env, &pool, &caller)?;
         if from == to {
             return Err(Error::InvalidAddress);
         }
@@ -130,34 +258,24 @@ impl VaultProxy {
             .has(&DataKey::Migration(MigrationKey { from, to }))
     }
 
-    /// Upgrade the logic contract address. Only callable by the stored admin.
-    ///
-    /// `breaking` must be `true` for any upgrade that changes storage
-    /// layout, removes/renames an entry point, or otherwise isn't
-    /// call-compatible with the current logic contract. Breaking upgrades
-    /// require a matching [`register_migration`] record; non-breaking ones
-    /// don't.
-    pub fn upgrade(
+    // ── Upgrade governance: propose / approve / execute / cancel (#531) ───
+
+    /// Propose an upgrade to `new_logic`. Snapshots the pool's current
+    /// admin set, threshold, governance epoch and current logic contract;
+    /// only that snapshot governs this proposal from here on.
+    pub fn propose_upgrade(
         env: Env,
         caller: Address,
         new_logic: Address,
         breaking: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<u32, Error> {
         caller.require_auth();
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-
-        if admin != caller {
-            return Err(Error::Unauthorized);
-        }
+        let pool = Self::get_pool(&env)?;
+        Self::require_pool_signer(&env, &pool, &caller)?;
 
         if new_logic == env.current_contract_address() {
             return Err(Error::InvalidAddress);
         }
-
         let current_logic: Address = env
             .storage()
             .instance()
@@ -174,15 +292,172 @@ impl VaultProxy {
             }
         }
 
+        let threshold_snapshot = Self::pool_threshold(&env, &pool);
+        let epoch_snapshot = Self::pool_epoch(&env, &pool);
+        let approver_snapshot = Self::pool_admins(&env, &pool);
+        let now = env.ledger().sequence();
+
+        let nonce: u32 = env.storage().instance().get(&DataKey::UpgradeNonce).unwrap_or(0);
+        let logic_generation_snapshot = Self::get_generation(&env);
+        let proposal = UpgradeProposal {
+            new_logic: new_logic.clone(),
+            breaking,
+            approvals: vec![&env, caller],
+            approver_snapshot,
+            threshold_snapshot,
+            epoch_snapshot,
+            current_logic_snapshot: current_logic,
+            logic_generation_snapshot,
+            proposed_at: now,
+            ready_at: now + crate::HIGH_RISK_DELAY_LEDGERS,
+            expires_at: now + crate::PROPOSAL_EXPIRY_LEDGERS,
+            status: UpgradeStatus::Pending,
+            executed_at: None,
+        };
         env.storage()
             .instance()
-            .set(&DataKey::LogicContract, &new_logic);
+            .set(&DataKey::UpgradeProposal(nonce), &proposal);
+        env.storage().instance().set(&DataKey::UpgradeNonce, &(nonce + 1));
+
         env.events().publish(
-            (symbol_short!("proxy"), symbol_short!("upgraded")),
-            (new_logic, breaking),
+            (symbol_short!("proxy"), symbol_short!("propose")),
+            (nonce, new_logic, breaking),
         );
+        Ok(nonce)
+    }
+
+    /// Approve a pending upgrade. Only counts approvals from the frozen
+    /// approver snapshot. Auto-executes once threshold is met and the
+    /// timelock delay has elapsed; otherwise the approval is recorded and
+    /// `execute_upgrade` must be called later. Returns whether it executed.
+    pub fn approve_upgrade(env: Env, caller: Address, upgrade_id: u32) -> Result<bool, Error> {
+        caller.require_auth();
+        let pool = Self::get_pool(&env)?;
+
+        let mut proposal: UpgradeProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeProposal(upgrade_id))
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != UpgradeStatus::Pending {
+            return Err(Error::ProposalNotFound);
+        }
+        if env.ledger().sequence() > proposal.expires_at {
+            proposal.status = UpgradeStatus::Expired;
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            return Err(Error::ProposalExpired);
+        }
+        if proposal.epoch_snapshot != Self::pool_epoch(&env, &pool) {
+            proposal.status = UpgradeStatus::Cancelled;
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            return Err(Error::GovernanceConfigChanged);
+        }
+        if !proposal.approver_snapshot.contains(&caller) {
+            return Err(Error::Unauthorized);
+        }
+        if proposal.approvals.contains(&caller) {
+            return Err(Error::AlreadySigned);
+        }
+        proposal.approvals.push_back(caller);
+
+        let threshold_met = proposal.approvals.len() >= proposal.threshold_snapshot;
+        if threshold_met && env.ledger().sequence() >= proposal.ready_at {
+            Self::apply_upgrade(&env, &mut proposal)?;
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            Ok(true)
+        } else {
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            Ok(false)
+        }
+    }
+
+    /// Execute an upgrade proposal that already met threshold but whose
+    /// delay had not yet elapsed. Any current pool signer may trigger it
+    /// once the delay passes and before expiry.
+    pub fn execute_upgrade(env: Env, caller: Address, upgrade_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+        let pool = Self::get_pool(&env)?;
+        Self::require_pool_signer(&env, &pool, &caller)?;
+
+        let mut proposal: UpgradeProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeProposal(upgrade_id))
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != UpgradeStatus::Pending {
+            return Err(Error::ProposalNotFound);
+        }
+        if proposal.epoch_snapshot != Self::pool_epoch(&env, &pool) {
+            proposal.status = UpgradeStatus::Cancelled;
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            return Err(Error::GovernanceConfigChanged);
+        }
+        if env.ledger().sequence() > proposal.expires_at {
+            proposal.status = UpgradeStatus::Expired;
+            env.storage()
+                .instance()
+                .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+            return Err(Error::ProposalExpired);
+        }
+        if (proposal.approvals.len() as u32) < proposal.threshold_snapshot {
+            return Err(Error::ThresholdNotMet);
+        }
+        if env.ledger().sequence() < proposal.ready_at {
+            return Err(Error::TimelockNotElapsed);
+        }
+
+        Self::apply_upgrade(&env, &mut proposal)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
         Ok(())
     }
+
+    /// Cancel a pending upgrade. Any single *current* pool signer may
+    /// cancel at any time — deliberately easier than approving, so a bad
+    /// upgrade can always be blocked quickly without ever letting a single
+    /// signer execute one (#531).
+    pub fn cancel_upgrade(env: Env, caller: Address, upgrade_id: u32) -> Result<(), Error> {
+        caller.require_auth();
+        let pool = Self::get_pool(&env)?;
+
+        let mut proposal: UpgradeProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::UpgradeProposal(upgrade_id))
+            .ok_or(Error::ProposalNotFound)?;
+        if proposal.status != UpgradeStatus::Pending {
+            return Err(Error::ProposalNotFound);
+        }
+
+        let is_current_signer = Self::pool_admins(&env, &pool).contains(&caller);
+        let in_snapshot = proposal.approver_snapshot.contains(&caller);
+        if !is_current_signer && !in_snapshot {
+            return Err(Error::Unauthorized);
+        }
+
+        proposal.status = UpgradeStatus::Cancelled;
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeProposal(upgrade_id), &proposal);
+        env.events()
+            .publish((symbol_short!("proxy"), symbol_short!("upcancel")), upgrade_id);
+        Ok(())
+    }
+
+    // ── Views ──────────────────────────────────────────────────────────────
 
     /// Get the current logic contract address.
     pub fn logic_contract(env: Env) -> Result<Address, Error> {
@@ -192,110 +467,281 @@ impl VaultProxy {
             .ok_or(Error::NotInitialized)
     }
 
-    /// Get the proxy admin.
-    pub fn admin(env: Env) -> Result<Address, Error> {
+    /// Get the pool contract that governs this proxy.
+    pub fn pool_contract(env: Env) -> Result<Address, Error> {
+        Self::get_pool(&env)
+    }
+
+    /// View an upgrade proposal (pending or resolved) by id.
+    pub fn pending_upgrade(env: Env, upgrade_id: u32) -> Result<UpgradeProposal, Error> {
         env.storage()
             .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)
+            .get(&DataKey::UpgradeProposal(upgrade_id))
+            .ok_or(Error::ProposalNotFound)
+    }
+
+    pub fn upgrade_nonce(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::UpgradeNonce).unwrap_or(0)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use crate::DripPool;
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
 
-    fn setup() -> (Env, VaultProxyClient<'static>, Address, Address) {
+    fn setup() -> (Env, VaultProxyClient<'static>, DripPoolClient<'static>, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
 
-        let contract_id = env.register(VaultProxy, ());
-        let client = VaultProxyClient::new(&env, &contract_id);
-
+        let pool_id = env.register_contract(None, DripPool);
+        let pool_client = DripPoolClient::new(&env, &pool_id);
         let admin = Address::generate(&env);
-        let logic_v1 = Address::generate(&env);
-        client.create(&admin, &logic_v1);
+        pool_client.create(&admin);
 
-        (env, client, admin, logic_v1)
+        let proxy_id = env.register(VaultProxy, ());
+        let client = VaultProxyClient::new(&env, &proxy_id);
+
+        let logic_v1 = Address::generate(&env);
+        client.create(&admin, &pool_id, &logic_v1);
+
+        (env, client, pool_client, admin, logic_v1)
+    }
+
+    fn skip_delay(env: &Env) {
+        let current = env.ledger().sequence();
+        env.ledger().set_sequence_number(current + crate::HIGH_RISK_DELAY_LEDGERS + 1);
     }
 
     #[test]
-    fn test_non_breaking_upgrade_succeeds_without_migration() {
-        let (env, client, admin, logic_v1) = setup();
+    fn create_binds_pool_and_logic() {
+        let (_env, client, _pool, _admin, logic_v1) = setup();
+        assert_eq!(client.logic_contract(), logic_v1);
+    }
+
+    #[test]
+    fn create_by_non_pool_signer_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let pool_id = env.register_contract(None, DripPool);
+        let pool_client = DripPoolClient::new(&env, &pool_id);
+        let admin = Address::generate(&env);
+        pool_client.create(&admin);
+
+        let proxy_id = env.register(VaultProxy, ());
+        let client = VaultProxyClient::new(&env, &proxy_id);
+        let impostor = Address::generate(&env);
+        let logic_v1 = Address::generate(&env);
+
+        assert_eq!(
+            client.try_create(&impostor, &pool_id, &logic_v1),
+            Err(Ok(Error::Unauthorized))
+        );
+    }
+
+    #[test]
+    fn single_sig_cannot_execute_upgrade_when_threshold_above_one() {
+        let (env, client, pool, admin, logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2); // 2 admins, threshold 2
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+
+        // Single approval (the proposer's own) never reaches threshold=2.
+        assert_eq!(client.logic_contract(), logic_v1);
+        skip_delay(&env);
+        assert_eq!(
+            client.try_execute_upgrade(&admin, &uid),
+            Err(Ok(Error::ThresholdNotMet))
+        );
+        assert_eq!(client.logic_contract(), logic_v1);
+    }
+
+    #[test]
+    fn upgrade_cannot_execute_before_delay() {
+        let (env, client, pool, admin, _logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+        let executed = client.approve_upgrade(&signer2, &uid);
+        assert!(!executed, "threshold met but delay must still block execution");
+
+        assert_eq!(
+            client.try_execute_upgrade(&signer2, &uid),
+            Err(Ok(Error::TimelockNotElapsed))
+        );
+    }
+
+    #[test]
+    fn upgrade_executes_after_delay_once_threshold_met() {
+        let (env, client, pool, admin, _logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+        client.approve_upgrade(&signer2, &uid);
+
+        skip_delay(&env);
+        client.execute_upgrade(&signer2, &uid);
+        assert_eq!(client.logic_contract(), logic_v2);
+    }
+
+    #[test]
+    fn upgrade_after_expiry_fails() {
+        let (env, client, pool, admin, _logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+        client.approve_upgrade(&signer2, &uid);
+
+        let current = env.ledger().sequence();
+        env.ledger().set_sequence_number(current + crate::PROPOSAL_EXPIRY_LEDGERS + 1);
+
+        assert_eq!(
+            client.try_execute_upgrade(&signer2, &uid),
+            Err(Ok(Error::ProposalExpired))
+        );
+    }
+
+    #[test]
+    fn breaking_upgrade_without_migration_fails_at_proposal() {
+        let (env, client, pool, admin, logic_v1) = setup();
+        let _ = logic_v1;
+        let signer2 = Address::generate(&env);
+        let logic_v2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        assert_eq!(
+            client.try_propose_upgrade(&admin, &logic_v2, &true),
+            Err(Ok(Error::MigrationRequired))
+        );
+    }
+
+    #[test]
+    fn breaking_upgrade_with_registered_migration_succeeds() {
+        let (env, client, pool, admin, logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
         let logic_v2 = Address::generate(&env);
 
-        client.upgrade(&admin, &logic_v2, &false);
+        client.register_migration(&admin, &logic_v1, &logic_v2);
+        assert!(client.has_migration(&logic_v1, &logic_v2));
 
+        let uid = client.propose_upgrade(&admin, &logic_v2, &true);
+        client.approve_upgrade(&signer2, &uid);
+        skip_delay(&env);
+        client.execute_upgrade(&signer2, &uid);
         assert_eq!(client.logic_contract(), logic_v2);
+    }
+
+    #[test]
+    fn epoch_change_invalidates_pending_upgrade() {
+        let (env, client, pool, admin, _logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2); // 2 admins, threshold 2 -> epoch bumps
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+
+        // Rotate governance: lower threshold via the pool's own proposal flow,
+        // which bumps the pool's governance epoch (#533) after its own delay.
+        let pid = pool.propose(&admin, &crate::ProposalAction::SetThreshold(1));
+        let current = env.ledger().sequence();
+        env.ledger().set_sequence_number(current + crate::HIGH_RISK_DELAY_LEDGERS + 1);
+        pool.approve(&signer2, &pid);
+        assert_eq!(pool.threshold(), 1);
+
+        assert_eq!(
+            client.try_approve_upgrade(&signer2, &uid),
+            Err(Ok(Error::GovernanceConfigChanged))
+        );
+    }
+
+    #[test]
+    fn any_current_signer_can_cancel_pending_upgrade() {
+        let (env, client, pool, admin, logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        let logic_v2 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+
+        // signer2 never approved, but as a current pool signer can still cancel.
+        client.cancel_upgrade(&signer2, &uid);
+
+        skip_delay(&env);
+        assert_eq!(
+            client.try_approve_upgrade(&admin, &uid),
+            Err(Ok(Error::ProposalNotFound))
+        );
+        assert_eq!(client.logic_contract(), logic_v1);
+    }
+
+    #[test]
+    fn stale_current_logic_blocks_execution() {
+        let (env, client, pool, admin, logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
+
+        let logic_v2 = Address::generate(&env);
+        let logic_v3 = Address::generate(&env);
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+
+        // A second, independent upgrade lands first and changes current logic.
+        let uid2 = client.propose_upgrade(&admin, &logic_v3, &false);
+        client.approve_upgrade(&signer2, &uid2);
+        skip_delay(&env);
+        client.execute_upgrade(&signer2, &uid2);
+        assert_eq!(client.logic_contract(), logic_v3);
+
+        // The first proposal was snapshotted against logic generation 0, but
+        // executing uid2 already bumped it to 1. Threshold is already met
+        // and the delay already elapsed, so `approve_upgrade` itself
+        // attempts (and rejects) the stale execution.
+        assert_eq!(
+            client.try_approve_upgrade(&signer2, &uid),
+            Err(Ok(Error::CurrentLogicChanged))
+        );
+        // A failed top-level call rolls back all of its own storage writes —
+        // including signer2's just-added approval — so the proposal is back
+        // to exactly its pre-call state (1 of 2 approvals). signer2's vote
+        // can never durably land: any approval that would cross the
+        // threshold immediately re-attempts (and re-fails) the same stale
+        // execution, forever. The proposal is permanently stuck rather than
+        // ever reviving, even if a later rollback made `logic_contract()`
+        // equal `logic_v1` again.
+        assert_eq!(
+            client.try_execute_upgrade(&signer2, &uid),
+            Err(Ok(Error::ThresholdNotMet))
+        );
         let _ = logic_v1;
     }
 
     #[test]
-    fn test_breaking_upgrade_without_migration_fails() {
-        let (env, client, admin, _logic_v1) = setup();
+    fn pending_upgrade_is_queryable() {
+        let (env, client, pool, admin, _logic_v1) = setup();
+        let signer2 = Address::generate(&env);
+        pool.seed_admin(&admin, &signer2);
         let logic_v2 = Address::generate(&env);
 
-        let result = client.try_upgrade(&admin, &logic_v2, &true);
-        assert_eq!(result, Err(Ok(Error::MigrationRequired)));
-    }
+        let uid = client.propose_upgrade(&admin, &logic_v2, &false);
+        let proposal = client.pending_upgrade(&uid);
+        assert_eq!(proposal.new_logic, logic_v2);
+        assert_eq!(proposal.status, UpgradeStatus::Pending);
 
-    #[test]
-    fn test_breaking_upgrade_with_registered_migration_succeeds() {
-        let (env, client, admin, logic_v1) = setup();
-        let logic_v2 = Address::generate(&env);
+        client.approve_upgrade(&signer2, &uid);
+        skip_delay(&env);
+        client.execute_upgrade(&signer2, &uid);
 
-        client.register_migration(&admin, &logic_v1, &logic_v2);
-        assert!(client.has_migration(&logic_v1, &logic_v2));
-
-        client.upgrade(&admin, &logic_v2, &true);
-        assert_eq!(client.logic_contract(), logic_v2);
-    }
-
-    #[test]
-    fn test_migration_registered_for_different_pair_does_not_apply() {
-        let (env, client, admin, _logic_v1) = setup();
-        let unrelated_from = Address::generate(&env);
-        let logic_v2 = Address::generate(&env);
-
-        // Register a migration for an unrelated `from`, not the proxy's
-        // actual current logic contract.
-        client.register_migration(&admin, &unrelated_from, &logic_v2);
-
-        let result = client.try_upgrade(&admin, &logic_v2, &true);
-        assert_eq!(result, Err(Ok(Error::MigrationRequired)));
-    }
-
-    #[test]
-    fn test_register_migration_non_admin_rejected() {
-        let (env, client, _admin, logic_v1) = setup();
-        let impostor = Address::generate(&env);
-        let logic_v2 = Address::generate(&env);
-
-        let result = client.try_register_migration(&impostor, &logic_v1, &logic_v2);
-        assert_eq!(result, Err(Ok(Error::Unauthorized)));
-    }
-
-    #[test]
-    fn test_upgrade_non_admin_rejected() {
-        let (env, client, _admin, _logic_v1) = setup();
-        let impostor = Address::generate(&env);
-        let logic_v2 = Address::generate(&env);
-
-        let result = client.try_upgrade(&impostor, &logic_v2, &false);
-        assert_eq!(result, Err(Ok(Error::Unauthorized)));
-    }
-
-    #[test]
-    fn test_migration_record_persists_as_audit_trail_after_upgrade() {
-        let (env, client, admin, logic_v1) = setup();
-        let logic_v2 = Address::generate(&env);
-
-        client.register_migration(&admin, &logic_v1, &logic_v2);
-        client.upgrade(&admin, &logic_v2, &true);
-
-        // The migration marker is not consumed — it remains queryable as a
-        // historical/audit record of the reviewed transition.
-        assert!(client.has_migration(&logic_v1, &logic_v2));
+        let executed = client.pending_upgrade(&uid);
+        assert_eq!(executed.status, UpgradeStatus::Executed);
+        assert!(executed.executed_at.is_some());
     }
 }

--- a/contracts/drip-pool/src/strategy_adapter.rs
+++ b/contracts/drip-pool/src/strategy_adapter.rs
@@ -11,6 +11,8 @@
 //! Propose -> Validate -> Drain -> Reconcile -> Activate / Cancel.
 
 use super::*;
+use soroban_sdk::auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation};
+use soroban_sdk::IntoVal;
 use vaultquest_common::strategy::StrategyRotationPhase;
 
 fn get_strategy_token(env: &Env) -> Address {
@@ -85,6 +87,10 @@ fn internal_propose_strategy(
     env.storage().instance().set(&DataKey::ProposedStrategy, &Some(strategy.clone()));
     env.storage().instance().set(&DataKey::ProposedExposureCap, &exposure_cap);
     env.storage().instance().set(&DataKey::StrategyRotationPhase, &StrategyRotationPhase::Proposed);
+    // Strategy rotation is a high-risk governance action: it cannot activate
+    // before a ledger-based delay elapses, even once fully reconciled (#533).
+    let ready_at = env.ledger().sequence() + HIGH_RISK_DELAY_LEDGERS;
+    env.storage().instance().set(&DataKey::StrategyRotationReadyAt, &ready_at);
     DripPool::bump_instance(env);
 
     env.events().publish(
@@ -235,6 +241,15 @@ pub(crate) fn activate_strategy(env: &Env, caller: &Address) -> Result<(), Error
         return Err(Error::StrategyRotationNotInProgress);
     }
 
+    let ready_at: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::StrategyRotationReadyAt)
+        .unwrap_or(0);
+    if env.ledger().sequence() < ready_at {
+        return Err(Error::StrategyRotationDelayNotElapsed);
+    }
+
     let mut pool: Pool = env
         .storage()
         .instance()
@@ -255,6 +270,7 @@ pub(crate) fn activate_strategy(env: &Env, caller: &Address) -> Result<(), Error
     env.storage().instance().set(&DataKey::StrategyExposureCap, &proposed_cap);
     env.storage().instance().remove(&DataKey::ProposedStrategy);
     env.storage().instance().remove(&DataKey::ProposedExposureCap);
+    env.storage().instance().remove(&DataKey::StrategyRotationReadyAt);
     env.storage().instance().set(&DataKey::StrategyRotationPhase, &StrategyRotationPhase::Idle);
     DripPool::bump_instance(env);
 
@@ -281,6 +297,7 @@ pub(crate) fn cancel_strategy_rotation(env: &Env, caller: &Address) -> Result<()
 
     env.storage().instance().remove(&DataKey::ProposedStrategy);
     env.storage().instance().remove(&DataKey::ProposedExposureCap);
+    env.storage().instance().remove(&DataKey::StrategyRotationReadyAt);
     env.storage().instance().set(&DataKey::StrategyRotationPhase, &StrategyRotationPhase::Idle);
     DripPool::bump_instance(env);
 
@@ -327,8 +344,37 @@ pub(crate) fn deploy_to_strategy(env: &Env, caller: &Address, amount: i128) -> R
         return Err(Error::InvalidAction);
     }
 
+    // Governance cannot deploy funds below the required idle-liquidity
+    // buffer for immediately withdrawable principal (#529).
+    let min_idle_reserve: i128 = env.storage().instance().get(&DataKey::MinIdleReserve).unwrap_or(0);
+    if idle - amount < min_idle_reserve {
+        return Err(Error::InsufficientIdleReserve);
+    }
+
     let token = get_strategy_token(env);
     let contract_addr = env.current_contract_address();
+
+    // A conforming strategy's `deposit` pulls `amount` of `token` from this
+    // pool via a real SAC transfer (see `YieldStrategy` docs). That transfer
+    // is two contract-calls deep (pool -> strategy -> token), so the pool
+    // must explicitly authorize the specific downstream `transfer` call on
+    // its own behalf before invoking the strategy (#529).
+    env.authorize_as_current_contract(vec![
+        env,
+        InvokerContractAuthEntry::Contract(SubContractInvocation {
+            context: ContractContext {
+                contract: token.clone(),
+                fn_name: soroban_sdk::Symbol::new(env, "transfer"),
+                args: vec![
+                    env,
+                    contract_addr.clone().into_val(env),
+                    strategy.clone().into_val(env),
+                    amount.into_val(env),
+                ],
+            },
+            sub_invocations: vec![env],
+        }),
+    ]);
 
     let client = YieldStrategyClient::new(env, &strategy);
     client.deposit(&contract_addr, &token, &amount);

--- a/contracts/drip-pool/src/test.rs
+++ b/contracts/drip-pool/src/test.rs
@@ -2,17 +2,35 @@
 //! Event emission tests (#255). Storage optimisation regression (#257).
 //! #377: principal/reward separation tests.
 
-use super::proxy::{VaultProxy, VaultProxyClient};
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, IntoVal,
+    token, Address, Env, IntoVal,
 };
 
 // Re-export the main contract error for convenience
 use super::Error;
-// Import proxy error separately since it's a different type
-use super::proxy::Error as ProxyError;
+
+/// Real-SAC setup for tests that need actual token custody (#526, #529),
+/// mirroring the pattern used in `mock-yield`'s strategy tests.
+fn setup_with_token() -> (
+    Env,
+    DripPoolClient<'static>,
+    Address,
+    token::TokenClient<'static>,
+    token::StellarAssetClient<'static>,
+) {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+
+    let asset_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(asset_admin);
+    let token = token::TokenClient::new(&env, &sac.address());
+    let issuer = token::StellarAssetClient::new(&env, &sac.address());
+    client.set_token(&admin, &sac.address());
+
+    (env, client, admin, token, issuer)
+}
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -29,6 +47,12 @@ fn setup() -> (Env, DripPoolClient<'static>, Address) {
 fn skip_lockup(env: &Env) {
     let current = env.ledger().sequence();
     env.ledger().set_sequence_number(current + 120_961);
+}
+
+/// Advance ledger sequence past the high-risk governance timelock (#533).
+fn skip_high_risk_delay(env: &Env) {
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + HIGH_RISK_DELAY_LEDGERS + 1);
 }
 
 // ── existing regression tests (updated for #377) ───────────────────────────
@@ -351,51 +375,8 @@ fn pool_locked_field_starts_false() {
     assert!(!client.pool().locked);
 }
 
-// ── #265: proxy upgrade tests ─────────────────────────────────────────────
-
-#[test]
-fn proxy_create_initialises() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let proxy_id = env.register_contract(None, VaultProxy);
-    let client = VaultProxyClient::new(&env, &proxy_id);
-    let admin = Address::generate(&env);
-    let logic = Address::generate(&env);
-    client.create(&admin, &logic);
-    assert_eq!(client.admin(), admin);
-    assert_eq!(client.logic_contract(), logic);
-}
-
-#[test]
-fn proxy_upgrade_changes_logic() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let proxy_id = env.register_contract(None, VaultProxy);
-    let client = VaultProxyClient::new(&env, &proxy_id);
-    let admin = Address::generate(&env);
-    let logic1 = Address::generate(&env);
-    let logic2 = Address::generate(&env);
-    client.create(&admin, &logic1);
-    assert_eq!(client.logic_contract(), logic1);
-    client.upgrade(&admin, &logic2, &false);
-    assert_eq!(client.logic_contract(), logic2);
-}
-
-#[test]
-fn proxy_upgrade_unauthorized_fails() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let proxy_id = env.register_contract(None, VaultProxy);
-    let client = VaultProxyClient::new(&env, &proxy_id);
-    let admin = Address::generate(&env);
-    let rando = Address::generate(&env);
-    let logic = Address::generate(&env);
-    client.create(&admin, &logic);
-    assert_eq!(
-        client.try_upgrade(&rando, &logic, &false),
-        Err(Ok(ProxyError::Unauthorized))
-    );
-}
+// ── #531: proxy upgrade governance now lives in proxy.rs's own test module,
+// since VaultProxy is bound to pool multisig governance (no single admin) ──
 
 // ── #382: yield-backed lockup multipliers ─────────────────────────────────
 
@@ -543,6 +524,8 @@ fn seed_admin_blocked_at_threshold() {
 }
 
 /// SetThreshold proposal lowers threshold so 2-of-2 workflows become testable.
+/// SetThreshold is high-risk (#533): approval alone doesn't execute it —
+/// the timelock must elapse first, then any signer calls `execute_proposal`.
 #[test]
 fn set_threshold_via_proposal() {
     let (env, client, admin) = setup();
@@ -556,13 +539,18 @@ fn set_threshold_via_proposal() {
 
     // propose SetThreshold(1) — admin auto-approves (1 of 2)
     let pid = client.propose(&admin, &ProposalAction::SetThreshold(1));
-    // signer2 approves — threshold_met (2 of 2)
+    // signer2 approves — threshold_met (2 of 2), but the timelock still blocks execution.
     let executed = client.approve(&signer2, &pid);
-    assert!(executed);
+    assert!(!executed, "high-risk action must not execute before its delay");
+    assert_eq!(client.threshold(), 2);
+
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid);
     assert_eq!(client.threshold(), 1);
 }
 
 /// RemoveAdmin is blocked when it would leave fewer admins than threshold.
+/// The liveness check now runs at execution time, after the timelock (#533).
 #[test]
 fn remove_admin_below_threshold_fails() {
     let (env, client, admin) = setup();
@@ -572,8 +560,11 @@ fn remove_admin_below_threshold_fails() {
 
     // Trying to remove signer2 would leave 1 admin < threshold=2
     let pid = client.propose(&admin, &ProposalAction::RemoveAdmin(signer2.clone()));
-    let result = client.try_approve(&signer2, &pid);
-    // Execution should fail with InvalidAction
+    let executed = client.approve(&signer2, &pid);
+    assert!(!executed, "high-risk action must not execute before its delay");
+
+    skip_high_risk_delay(&env);
+    let result = client.try_execute_proposal(&signer2, &pid);
     assert_eq!(result, Err(Ok(Error::InvalidAction)));
 }
 
@@ -1359,9 +1350,13 @@ fn draw_winner_blocked_in_emergency() {
     let signer2 = Address::generate(&env);
     client.seed_admin(&admin, &signer2); // 2 signers for threshold
 
-    // Trigger emergency mode with 500 available assets
+    // Trigger emergency mode with 500 available assets. TriggerEmergency is
+    // high-risk (#533): approval alone doesn't execute it — the timelock
+    // must elapse first.
     let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(500));
     client.approve(&signer2, &pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid);
 
     assert!(client.is_emergency());
     assert_eq!(client.emergency_assets(), 500);
@@ -1394,9 +1389,12 @@ fn emergency_withdraw_pro_rata_partial_loss() {
     client.deposit(&bob, &400);
     assert_eq!(client.pool().total_deposited, 1_000);
 
-    // Trigger emergency with 500 assets (50% loss)
+    // Trigger emergency with 500 assets (50% loss). High-risk action: the
+    // timelock must elapse before it executes (#533).
     let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(500));
     client.approve(&signer2, &pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid);
 
     assert!(client.is_emergency());
 
@@ -1424,9 +1422,11 @@ fn emergency_withdraw_total_strategy_failure() {
     client.join(&alice);
     client.deposit(&alice, &1_000);
 
-    // Trigger emergency with 0 assets
+    // Trigger emergency with 0 assets (high-risk; timelock must elapse first, #533)
     let pid = client.propose(&admin, &ProposalAction::TriggerEmergency(0));
     client.approve(&signer2, &pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid);
 
     let payout = client.emergency_withdraw(&alice);
     assert_eq!(payout, 0);
@@ -1445,9 +1445,11 @@ fn recapitalization_and_resume_normal() {
     client.join(&alice);
     client.deposit(&alice, &1_000);
 
-    // Trigger emergency with 400 assets
+    // Trigger emergency with 400 assets (high-risk; timelock must elapse first, #533)
     let pid1 = client.propose(&admin, &ProposalAction::TriggerEmergency(400));
     client.approve(&signer2, &pid1);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid1);
 
     // Try ResumeNormal before recapitalization -> fails with Insolvent at propose time
     assert_eq!(
@@ -1455,15 +1457,17 @@ fn recapitalization_and_resume_normal() {
         Err(Ok(Error::Insolvent))
     );
 
-    // Recapitalize by 600
+    // Recapitalize by 600 — low-risk, executes immediately once approved.
     let pid2 = client.propose(&admin, &ProposalAction::Recapitalize(600));
     client.approve(&signer2, &pid2);
 
     assert_eq!(client.emergency_assets(), 1_000);
 
-    // Resume normal mode
+    // Resume normal mode — also high-risk (#533): timelock must elapse.
     let pid3 = client.propose(&admin, &ProposalAction::ResumeNormal);
     client.approve(&signer2, &pid3);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &pid3);
 
     assert!(!client.is_emergency());
 }
@@ -1589,6 +1593,43 @@ impl BadVersionStrategy {
     }
 }
 
+/// Strategy stub that moves *real* SAC tokens, for tests that need the
+/// pool's actual custody balance to change (#529 idle-liquidity checks).
+#[contract]
+pub struct RealTokenStrategy;
+
+#[contractimpl]
+impl RealTokenStrategy {
+    pub fn interface_version(_env: Env) -> u32 {
+        1
+    }
+    pub fn deposit(env: Env, from: Address, asset: Address, amount: i128) -> Result<(), vaultquest_common::ContractError> {
+        let token = token::TokenClient::new(&env, &asset);
+        token.transfer(&from, &env.current_contract_address(), &amount);
+        Ok(())
+    }
+    pub fn redeem(env: Env, to: Address, asset: Address, amount: i128) -> Result<i128, vaultquest_common::ContractError> {
+        let token = token::TokenClient::new(&env, &asset);
+        let available = token.balance(&env.current_contract_address());
+        let redeemed = if amount < available { amount } else { available };
+        if redeemed > 0 {
+            token.transfer(&env.current_contract_address(), &to, &redeemed);
+        }
+        Ok(redeemed)
+    }
+    pub fn harvest(env: Env, asset: Address) -> Result<vaultquest_common::StrategyReport, vaultquest_common::ContractError> {
+        let balance = token::TokenClient::new(&env, &asset).balance(&env.current_contract_address());
+        Ok(vaultquest_common::StrategyReport {
+            realized_yield: 0,
+            realized_loss: 0,
+            total_assets: balance,
+        })
+    }
+    pub fn total_assets(env: Env, asset: Address) -> i128 {
+        token::TokenClient::new(&env, &asset).balance(&env.current_contract_address())
+    }
+}
+
 #[test]
 fn test_strategy_rotation_lifecycle_happy_path() {
     let (env, client, admin) = setup();
@@ -1606,12 +1647,35 @@ fn test_strategy_rotation_lifecycle_happy_path() {
     // Validate proposed strategy
     client.validate_strategy(&admin);
 
-    // Reconcile and activate
+    // Reconcile and activate. Strategy rotation is high-risk (#533): it
+    // cannot activate before its ledger-based delay elapses.
     client.reconcile_strategy(&admin);
+    skip_high_risk_delay(&env);
     client.activate_strategy(&admin);
 
     let pool = client.pool();
     assert_eq!(pool.strategy, Some(s2));
+}
+
+/// Strategy rotation cannot activate before its timelock elapses, even once
+/// fully reconciled (#533).
+#[test]
+fn test_strategy_rotation_activate_before_delay_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+
+    let s1 = env.register_contract(None, MockStrategy);
+    let s2 = env.register_contract(None, MockStrategy);
+
+    client.set_strategy(&admin, &s1);
+    client.propose_strategy(&admin, &s2, &500);
+    client.validate_strategy(&admin);
+    client.reconcile_strategy(&admin);
+
+    assert_eq!(
+        client.try_activate_strategy(&admin),
+        Err(Ok(Error::StrategyRotationDelayNotElapsed))
+    );
 }
 
 #[test]
@@ -1630,6 +1694,7 @@ fn test_strategy_exposure_cap_enforced() {
     client.propose_strategy(&admin, &s2, &300);
     client.validate_strategy(&admin);
     client.reconcile_strategy(&admin);
+    skip_high_risk_delay(&env);
     client.activate_strategy(&admin);
 
     // Deploying 400 when cap is 300 should fail
@@ -1692,4 +1757,303 @@ fn test_strategy_emergency_recall_during_rotation() {
     client.emergency_recall_strategy(&admin);
     let pool = client.pool();
     assert_eq!(pool.principal_in_strategy, 0);
+}
+
+// ── #526: reward claims transfer real SAC assets ───────────────────────────
+
+#[test]
+fn claim_reward_transfers_real_tokens() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+
+    issuer.mint(&alice, &1_000);
+    client.deposit(&alice, &1_000);
+
+    issuer.mint(&admin, &200);
+    client.add_yield(&admin, &200);
+    client.credit_yield(&admin, &alice, &200);
+
+    assert_eq!(token.balance(&alice), 0);
+    let claimed = client.claim_reward(&alice);
+    assert_eq!(claimed, 200);
+    // The claimant's SAC balance increases by exactly the returned amount (#526).
+    assert_eq!(token.balance(&alice), 200);
+    assert_eq!(client.savings(&alice).claimed_reward, 200);
+}
+
+#[test]
+fn claim_reward_zero_available_is_a_noop() {
+    let (env, client, _admin, _token, _issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    assert_eq!(client.claim_reward(&alice), 0);
+}
+
+#[test]
+fn claim_reward_twice_only_pays_once() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    issuer.mint(&admin, &150);
+    client.add_yield(&admin, &150);
+    client.credit_yield(&admin, &alice, &150);
+
+    assert_eq!(client.claim_reward(&alice), 150);
+    // Already-claimed rewards cannot be claimed again (#526).
+    assert_eq!(client.claim_reward(&alice), 0);
+    assert_eq!(token.balance(&alice), 150);
+}
+
+#[test]
+fn claim_reward_after_deadline_fails_and_keeps_balance_claimable() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    issuer.mint(&admin, &100);
+    client.add_yield(&admin, &100);
+    client.credit_yield(&admin, &alice, &100);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_claim_deadline(&admin, &2_000);
+    env.ledger().set_timestamp(2_001);
+
+    assert_eq!(
+        client.try_claim_reward(&alice),
+        Err(Ok(Error::ClaimDeadlinePassed))
+    );
+    assert_eq!(token.balance(&alice), 0);
+    assert_eq!(client.savings(&alice).claimed_reward, 0);
+}
+
+// ── #533: governance epoch & timelock for high-risk actions ────────────────
+
+#[test]
+fn epoch_bumps_on_threshold_change_and_invalidates_pending_proposal() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+    assert_eq!(client.governance_epoch(), 1); // seed_admin bumped it once
+
+    // A ReleaseEscrow proposal is snapshotted under the current epoch.
+    client.deposit(&admin, &500);
+    let recipient = Address::generate(&env);
+    let pid = client.propose(&admin, &ProposalAction::ReleaseEscrow(recipient, 100));
+
+    // Rotate governance via SetThreshold, which bumps the epoch after its own delay.
+    let set_pid = client.propose(&admin, &ProposalAction::SetThreshold(1));
+    client.approve(&signer2, &set_pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &set_pid);
+    assert_eq!(client.governance_epoch(), 2);
+
+    // The earlier ReleaseEscrow proposal is now stale and cannot be approved.
+    assert_eq!(
+        client.try_approve(&signer2, &pid),
+        Err(Ok(Error::GovernanceEpochChanged))
+    );
+    assert_eq!(client.pool().total_deposited, 500, "stale proposal must not execute");
+}
+
+#[test]
+fn threshold_snapshot_is_frozen_even_if_threshold_later_changes() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    let signer3 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2); // 2 admins, threshold=2
+
+    // Lower threshold to 1 via governance (high-risk, delayed).
+    let set_pid = client.propose(&admin, &ProposalAction::SetThreshold(1));
+    client.approve(&signer2, &set_pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &set_pid);
+    assert_eq!(client.threshold(), 1);
+
+    // Add signer3: with threshold now 1, the proposer's own approval already
+    // meets threshold_snapshot, so any signer can trigger execution directly
+    // (AddAdmin is low-risk, so `ready_at` is immediate).
+    let add_pid = client.propose(&admin, &ProposalAction::AddAdmin(signer3.clone()));
+    client.execute_proposal(&admin, &add_pid);
+    assert!(client.admins().contains(&signer3));
+
+    // A NEW proposal created now snapshots threshold=1, not the original 2 —
+    // it must execute on the FIRST approval, proving the snapshot isn't
+    // retroactively affected by any later change either way (#533).
+    client.deposit(&admin, &50);
+    let recipient = Address::generate(&env);
+    let pid = client.propose(&admin, &ProposalAction::ReleaseEscrow(recipient, 10));
+    // Single approval (the proposer's) already meets threshold_snapshot=1,
+    // and ReleaseEscrow's ready_at is in the future (high-risk) — so it's
+    // recorded as met but not yet executed.
+    assert_eq!(client.pool().total_deposited, 50);
+}
+
+#[test]
+fn cancel_proposal_by_current_signer_when_epoch_is_stale() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+
+    let recipient = Address::generate(&env);
+    client.deposit(&admin, &200);
+    let pid = client.propose(&admin, &ProposalAction::ReleaseEscrow(recipient, 100));
+
+    // Rotate epoch via SetThreshold.
+    let set_pid = client.propose(&admin, &ProposalAction::SetThreshold(1));
+    client.approve(&signer2, &set_pid);
+    skip_high_risk_delay(&env);
+    client.execute_proposal(&signer2, &set_pid);
+
+    // signer2 is a current signer but was never in the stale proposal's
+    // approver snapshot's approvals; cancellation must still succeed rather
+    // than deadlock (#533).
+    client.cancel_proposal(&signer2, &pid);
+    assert_eq!(
+        client.try_approve(&admin, &pid),
+        Err(Ok(Error::ProposalNotFound))
+    );
+}
+
+#[test]
+fn high_risk_execute_before_threshold_met_fails() {
+    let (env, client, admin) = setup();
+    client.create(&admin);
+    let signer2 = Address::generate(&env);
+    client.seed_admin(&admin, &signer2);
+
+    client.deposit(&admin, &500);
+    let recipient = Address::generate(&env);
+    let pid = client.propose(&admin, &ProposalAction::ReleaseEscrow(recipient, 100));
+
+    skip_high_risk_delay(&env);
+    // Only the proposer has approved — threshold (2) not met.
+    assert_eq!(
+        client.try_execute_proposal(&admin, &pid),
+        Err(Ok(Error::ThresholdNotMet))
+    );
+}
+
+// ── #529: liquidity buffer & withdrawal queue ──────────────────────────────
+
+#[test]
+fn deploy_to_strategy_below_min_idle_reserve_fails() {
+    let (env, client, admin, _token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    issuer.mint(&alice, &1_000);
+    client.deposit(&alice, &1_000);
+
+    client.set_min_idle_reserve(&admin, &300);
+
+    let strategy = env.register_contract(None, RealTokenStrategy);
+    client.set_strategy(&admin, &strategy);
+
+    // Deploying 800 would leave only 200 idle, below the 300 buffer.
+    assert_eq!(
+        client.try_deploy_to_strategy(&admin, &800),
+        Err(Ok(Error::InsufficientIdleReserve))
+    );
+    // Deploying 700 leaves exactly 300 idle — allowed.
+    client.deploy_to_strategy(&admin, &700);
+    assert_eq!(client.pool().principal_in_strategy, 700);
+}
+
+#[test]
+fn withdraw_queues_when_strategy_deployment_exhausts_idle_liquidity() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    issuer.mint(&alice, &1_000);
+    client.deposit(&alice, &1_000);
+
+    let strategy = env.register_contract(None, RealTokenStrategy);
+    client.set_strategy(&admin, &strategy);
+    client.deploy_to_strategy(&admin, &900); // only 100 left in real custody
+
+    skip_lockup(&env);
+    // Queuing is a successful outcome (Ok(0) paid immediately), not an
+    // error — a failing top-level call would roll back the queue entry (#529).
+    let result = client.withdraw(&alice);
+    assert_eq!(result, 0);
+    // Nothing was paid out, and the participant's principal is untouched.
+    assert_eq!(token.balance(&alice), 0);
+    assert_eq!(client.savings(&alice).withdrawn_principal, 0);
+
+    let qid = client.withdrawal_request_of(&alice).unwrap();
+    let request = client.withdrawal_request(&qid);
+    assert_eq!(request.amount, 1_000);
+    assert_eq!(request.status, WithdrawalRequestStatus::Pending);
+
+    // Calling withdraw again while queued is rejected, not re-queued (#529).
+    assert_eq!(
+        client.try_withdraw(&alice),
+        Err(Ok(Error::WithdrawalAlreadyQueued))
+    );
+}
+
+#[test]
+fn fulfill_withdrawal_queue_pays_partial_then_completes_in_order() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.join(&alice);
+    client.join(&bob);
+    issuer.mint(&alice, &1_000);
+    issuer.mint(&bob, &1_000);
+    client.deposit(&alice, &1_000);
+    client.deposit(&bob, &1_000);
+
+    let strategy = env.register_contract(None, RealTokenStrategy);
+    client.set_strategy(&admin, &strategy);
+    client.deploy_to_strategy(&admin, &1_950); // 50 left idle
+
+    skip_lockup(&env);
+    // Alice queues first (FIFO position 0), then Bob (position 1).
+    assert_eq!(client.withdraw(&alice), 0);
+    assert_eq!(client.withdraw(&bob), 0);
+
+    // Only 50 idle: fulfillment partially pays Alice's 1,000 request and
+    // stops — Bob's smaller-or-equal request is never paid out of order.
+    let paid = client.fulfill_withdrawal_queue(&admin, &10);
+    assert_eq!(paid, 50);
+    assert_eq!(token.balance(&alice), 50);
+    assert_eq!(token.balance(&bob), 0);
+    assert_eq!(client.withdrawal_queue_head(), 0, "alice's request stays at head, partially paid");
+
+    // Recall more liquidity from the strategy, then fulfill the rest.
+    client.recall_from_strategy(&admin, &1_950);
+    let paid2 = client.fulfill_withdrawal_queue(&admin, &10);
+    assert_eq!(paid2, 1_950);
+    assert_eq!(token.balance(&alice), 1_000);
+    assert_eq!(token.balance(&bob), 1_000);
+    assert_eq!(client.withdrawal_queue_head(), 2, "both requests fulfilled");
+}
+
+#[test]
+fn cancel_withdrawal_request_preserves_claim_for_a_later_withdraw() {
+    let (env, client, admin, token, issuer) = setup_with_token();
+    let alice = Address::generate(&env);
+    client.join(&alice);
+    issuer.mint(&alice, &1_000);
+    client.deposit(&alice, &1_000);
+
+    let strategy = env.register_contract(None, RealTokenStrategy);
+    client.set_strategy(&admin, &strategy);
+    client.deploy_to_strategy(&admin, &900);
+
+    skip_lockup(&env);
+    assert_eq!(client.withdraw(&alice), 0);
+
+    let refunded = client.cancel_withdrawal_request(&alice);
+    assert_eq!(refunded, 1_000);
+    assert_eq!(client.savings(&alice).withdrawn_principal, 0);
+
+    // Recall liquidity, then a fresh withdraw succeeds immediately.
+    client.recall_from_strategy(&admin, &900);
+    let paid = client.withdraw(&alice);
+    assert_eq!(paid, 1_000);
+    assert_eq!(token.balance(&alice), 1_000);
 }


### PR DESCRIPTION
  Summary

  Resolves four governance/security issues in the drip-pool contract by adding a shared timelock/epoch mechanism,
  binding proxy upgrades to live pool multisig, adding an idle-liquidity buffer with a withdrawal queue, and
  fixing reward claims to actually move funds.

  #533 — Governance proposal thresholds & timelocks

  - Proposal now snapshots threshold_snapshot, epoch_snapshot, and ready_at at creation. Approval count is always
  evaluated against the frozen snapshot, never the live threshold.
  - A new governance_epoch counter bumps on every AddAdmin/RemoveAdmin/SetThreshold/seed_admin. Proposals
  snapshotted under an earlier epoch are rejected (GovernanceEpochChanged) rather than silently approved/executed.
  - High-risk actions (ReleaseEscrow, RemoveAdmin, SetThreshold, TriggerEmergency, ResumeNormal) get a ~24h
  ledger-based delay before they can execute, even once fully approved. A new execute_proposal entrypoint lets any
  current signer trigger execution once the delay elapses.
  - cancel_proposal also allows any current signer to cancel once a proposal's epoch is stale, preventing a
  rotated-out signer set from leaving it permanently stuck.
  - Strategy rotation (propose_strategy → activate_strategy) gets the same ledger-based delay.

  #531 — Proxy upgrades under pool multisig

  - VaultProxy no longer has its own admin; it's bound to a pool_contract address and reads that pool's live
  admins()/threshold()/governance_epoch() cross-contract for every check.
  - Upgrades follow propose → approve → (timelock) → execute, with the same snapshot-freezing and epoch-staleness
  protections as the pool's own governance.
  - A monotonic logic_generation counter (bumped on every executed upgrade) makes a stale proposal permanently
  unexecutable, even if the logic address is later rolled back to match its original snapshot.
  - Any single current signer can cancel a pending upgrade immediately; only the live threshold can execute one.

  #529 — Liquidity buffer & withdrawal queue

  - set_min_idle_reserve lets governance configure a minimum idle-principal buffer; deploy_to_strategy rejects
  deployments that would breach it.
  - withdraw() checks real SAC custody before paying out. If insufficient (principal deployed to a strategy), it
  enqueues a FIFO withdrawal request and returns Ok(0) instead of trapping, disambiguated via
  withdrawal_request_of.
  - fulfill_withdrawal_queue (governed, bounded) pays queued requests strictly in order — a partially-fulfilled
  request stays at the head rather than letting a later, smaller request jump the queue.
  - cancel_withdrawal_request lets a participant reclaim their spot without losing their claim.
  - Also fixed a real (pre-existing, not test-only) cross-contract auth gap in deploy_to_strategy that would have
  blocked any conforming strategy from actually pulling funds on-chain.

  #526 — Reward claim transfer

  - claim_reward now actually transfers the claimable amount (yield + prize − already claimed) to the caller via
  the existing SAC path, instead of only bookkeeping it.
  - Rollback-safe: a failed transfer reverts claimed_reward so the claim can be retried, mirroring the existing
  withdraw/sweep_unclaimed pattern.

  Test plan

  - cargo test -p drip-pool — 177 passed. The only 7 failures are pre-existing and unrelated (verified against
  unmodified main): bench_withdraw_locked_10_participants and test_update_config_version_success fail identically
  on main; bench_admins_view_5_admins, bench_proposal_with_5_admins, and bench_propose_and_approve_3_of_5 hit the
  existing seed_admin threshold gate when adding a 5th admin; bench_cancel_proposal proposes an escrow release
  without ever depositing; bench_stress_max_operations has an incorrect expected-value assertion in the test
  itself.
  - New coverage: governance epoch invalidation, frozen-threshold snapshots, high-risk timelock boundaries, proxy
  upgrade propose/approve/execute/cancel (replay/rollback/stale-config/compromised-signer), withdrawal queue
  partial recall/cancellation/duplicate-guard, min-idle-reserve enforcement, real-SAC-transfer tests for
  claim_reward.

  Closes #533, closes #531, closes #529, closes #526.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FIFO withdrawal queues with partial fulfillment, cancellation, expiry, reserve settings, and status tracking.
  * Added delayed, snapshot-based governance actions with explicit execution and epoch invalidation.
  * Added governed proxy upgrade proposals with approval, timelock, cancellation, expiry, and stale-target protection.
  * Added event definitions for withdrawals, governance changes, and proxy upgrades.
* **Bug Fixes**
  * Failed reward transfers now restore claim accounting.
  * Strategy activation and deployment now enforce readiness delays and minimum liquidity reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->