### PR TITLE
feat: quorum/freshness policy for critical reads + dual-controlled reconciliation repairs

### DIFF
--- a/backend/prisma/migrations/20260825000000_add_repair_proposals/migration.sql
+++ b/backend/prisma/migrations/20260825000000_add_repair_proposals/migration.sql
@@ -1,0 +1,33 @@
+-- Dual-controlled, bounded, auditable reconciliation repairs (#597)
+CREATE TABLE "repair_proposals" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "plan_json" JSONB NOT NULL,
+    "diff_hash" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "proposer_id" TEXT NOT NULL,
+    "step_count" INTEGER NOT NULL,
+    "value_total" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "required_approvals" INTEGER NOT NULL DEFAULT 1,
+    "executed_by" TEXT,
+    "executed_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "repair_proposals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "repair_approvals" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "proposal_id" UUID NOT NULL,
+    "approver_id" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "repair_approvals_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "repair_proposals_status_expires_at_idx" ON "repair_proposals" ("status", "expires_at");
+CREATE INDEX "repair_proposals_diff_hash_idx" ON "repair_proposals" ("diff_hash");
+CREATE UNIQUE INDEX "repair_approvals_proposal_id_approver_id_key" ON "repair_approvals" ("proposal_id", "approver_id");
+
+ALTER TABLE "repair_approvals" ADD CONSTRAINT "repair_approvals_proposal_id_fkey"
+    FOREIGN KEY ("proposal_id") REFERENCES "repair_proposals"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -251,6 +251,46 @@ model RepairAudit {
   @@map("repair_audits")
 }
 
+// #597 — dual-controlled, bounded, auditable reconciliation repair.
+// Detection (reconciler.ts detectDrift/buildRepairPlan) produces a plan;
+// that plan must be proposed, approved (by a distinct identity once above
+// the configured step/value thresholds), and only then executed. Execution
+// delegates to the existing idempotent applyRepairPlan, so a proposal
+// interrupted mid-execution resumes safely instead of repeating transfers.
+model RepairProposal {
+  id                String           @id @default(uuid()) @db.Uuid
+  planJson          Json             @map("plan_json")
+  /// sha256 of the canonicalized plan steps. Approvals and execution are
+  /// bound to this exact hash — any drift in the plan invalidates them.
+  diffHash          String           @map("diff_hash")
+  status            String           @default("pending")
+  proposerId        String           @map("proposer_id")
+  stepCount         Int              @map("step_count")
+  valueTotal        Float            @default(0) @map("value_total")
+  requiredApprovals Int              @default(1) @map("required_approvals")
+  executedBy        String?          @map("executed_by")
+  executedAt        DateTime?        @map("executed_at")
+  createdAt         DateTime         @default(now()) @map("created_at")
+  expiresAt         DateTime         @map("expires_at")
+  approvals         RepairApproval[]
+
+  @@index([status, expiresAt])
+  @@index([diffHash])
+  @@map("repair_proposals")
+}
+
+model RepairApproval {
+  id         String         @id @default(uuid()) @db.Uuid
+  proposalId String         @map("proposal_id") @db.Uuid
+  approverId String         @map("approver_id")
+  createdAt  DateTime       @default(now()) @map("created_at")
+  proposal   RepairProposal @relation(fields: [proposalId], references: [id])
+
+  @@unique([proposalId, approverId])
+  @@map("repair_approvals")
+}
+
+
 model WalletChallenge {
   challengeId   String    @id @map("challenge_id") @db.Uuid
   walletAddress String    @map("wallet_address")

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import { savedPoolsRoutes } from "./routes/savedPools.js";
 import { schemaVersionRoutes } from "./routes/schemaVersion.js";
 import { auditRoutes } from "./routes/audit.js";
 import { internalRoutes } from "./routes/internal.js";
+import { reconciliationRoutes } from "./routes/reconciliation.js";
 import { metricsRoutes } from "./routes/metrics.js";
 import { usersRoutes } from "./routes/users.js";
 import { prometheusRoutes } from "./routes/prometheus.js";
@@ -151,6 +152,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
   app.register(savedPoolsRoutes(savedPoolsSvc));
   app.register(schemaVersionRoutes(schemaVersionSvc));
   app.register(internalRoutes(svc, deps.internalSecret));
+  app.register(reconciliationRoutes(deps.prisma, deps.internalSecret));
   app.register(metricsRoutes(metricsSvc));
   app.register(usersRoutes, { prefix: "/api/users", prisma: deps.prisma });
   app.register(metricsRoutes(metricsSvc, apiKeyGuard));

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -70,7 +70,17 @@ const schema = z.object({
    */
   REMINDER_LEAD_HOURS: z.coerce.number().int().positive().default(24),
   SENDGRID_API_KEY: z.string().min(1).optional(),
-  EMAIL_FROM: z.string().email().optional()
+  EMAIL_FROM: z.string().email().optional(),
+  /**
+   * Critical-read quorum/freshness policy (issue #596). Applied to
+   * balance-critical Stellar RPC reads (withdrawals, admin repairs,
+   * reconciliation) via `services/criticalReadPolicy.ts`. Defaults are
+   * conservative but overridable per-environment.
+   */
+  CRITICAL_READ_MIN_QUORUM: z.coerce.number().int().positive().default(2),
+  CRITICAL_READ_MAX_FRESHNESS_MS: z.coerce.number().int().positive().default(15_000),
+  CRITICAL_READ_MAX_LEDGER_DIVERGENCE: z.coerce.number().int().nonnegative().default(2),
+  CRITICAL_READ_MAX_LATENCY_MS: z.coerce.number().int().positive().default(8_000)
 });
 
 export type Env = z.infer<typeof schema>;
@@ -110,7 +120,11 @@ export function getEnv(): Env {
       CATEGORIES_CACHE_TTL_SECONDS: Number(process.env.CATEGORIES_CACHE_TTL_SECONDS ?? 3600),
       REMINDER_LEAD_HOURS: Number(process.env.REMINDER_LEAD_HOURS ?? 24),
       SENDGRID_API_KEY: process.env.SENDGRID_API_KEY || undefined,
-      EMAIL_FROM: process.env.EMAIL_FROM || undefined
+      EMAIL_FROM: process.env.EMAIL_FROM || undefined,
+      CRITICAL_READ_MIN_QUORUM: Number(process.env.CRITICAL_READ_MIN_QUORUM ?? 2),
+      CRITICAL_READ_MAX_FRESHNESS_MS: Number(process.env.CRITICAL_READ_MAX_FRESHNESS_MS ?? 15_000),
+      CRITICAL_READ_MAX_LEDGER_DIVERGENCE: Number(process.env.CRITICAL_READ_MAX_LEDGER_DIVERGENCE ?? 2),
+      CRITICAL_READ_MAX_LATENCY_MS: Number(process.env.CRITICAL_READ_MAX_LATENCY_MS ?? 8_000)
     } satisfies Env;
   }
   return parseEnv();

--- a/backend/src/routes/reconciliation.ts
+++ b/backend/src/routes/reconciliation.ts
@@ -1,0 +1,46 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+import { detectDrift, buildRepairPlan, createRepairProposal, approveRepairProposal, executeRepairProposal } from "../services/reconciler.js";
+import { requireServiceAuth } from "../middleware/service-auth.js";
+import { validateBody } from "../middleware/validate.js";
+import { createProposalBody, approveProposalBody, executeProposalBody } from "../schemas/reconciliation.js";
+import { ok } from "../responses.js";
+import type { z } from "zod";
+
+/**
+ * Admin-only reconciliation repair workflow (#597): propose -> approve ->
+ * execute, gated behind the same internal-service secret as other
+ * privileged endpoints (see `internal.ts`). Not exposed to end users.
+ */
+export const reconciliationRoutes = (prisma: PrismaClient, secret: string): FastifyPluginAsync =>
+  async (app) => {
+    const guard = requireServiceAuth(secret);
+
+    app.post("/internal/reconciliation/proposals", {
+      preHandler: [guard, validateBody(createProposalBody)]
+    }, async (req) => {
+      const body = req.body as z.infer<typeof createProposalBody>;
+      const drifts = await detectDrift(prisma);
+      const plan = buildRepairPlan(drifts, body.dry_run ?? false);
+      const proposal = await createRepairProposal(prisma, plan, body.proposer_id);
+      return ok({ proposal });
+    });
+
+    app.post("/internal/reconciliation/proposals/:id/approve", {
+      preHandler: [guard, validateBody(approveProposalBody)]
+    }, async (req) => {
+      const { id } = req.params as { id: string };
+      const body = req.body as z.infer<typeof approveProposalBody>;
+      const proposal = await approveRepairProposal(prisma, id, body.approver_id, body.diff_hash);
+      return ok({ proposal });
+    });
+
+    app.post("/internal/reconciliation/proposals/:id/execute", {
+      preHandler: [guard, validateBody(executeProposalBody)]
+    }, async (req) => {
+      const { id } = req.params as { id: string };
+      const body = req.body as z.infer<typeof executeProposalBody>;
+      const result = await executeRepairProposal(prisma, id, body.executor_id);
+      return ok(result);
+    });
+  };

--- a/backend/src/schemas/reconciliation.ts
+++ b/backend/src/schemas/reconciliation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const approveProposalBody = z.object({
+  approver_id: z.string().min(1).max(200),
+  diff_hash: z.string().length(64)
+});
+
+export const executeProposalBody = z.object({
+  executor_id: z.string().min(1).max(200)
+});
+
+export const createProposalBody = z.object({
+  proposer_id: z.string().min(1).max(200),
+  dry_run: z.boolean().optional()
+});

--- a/backend/src/services/criticalReadPolicy.test.ts
+++ b/backend/src/services/criticalReadPolicy.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  CriticalReadPolicy,
+  CriticalReadPolicyError,
+  ProviderStabilityTracker,
+  type CriticalReadSample
+} from "./criticalReadPolicy.js";
+
+const NOW = 1_000_000;
+
+function sample(
+  provider: string,
+  value: string,
+  overrides: Partial<CriticalReadSample<string>> = {}
+): CriticalReadSample<string> {
+  return {
+    provider,
+    value,
+    ledgerSequence: 1000,
+    ledgerCloseTime: NOW - 1000,
+    networkPassphrase: "Test SDF Network ; September 2015",
+    latencyMs: 100,
+    ...overrides
+  };
+}
+
+function makePolicy(overrides: Partial<ConstructorParameters<typeof CriticalReadPolicy>[0]> = {}) {
+  return new CriticalReadPolicy({
+    minQuorum: 2,
+    maxFreshnessMs: 5000,
+    maxLedgerDivergence: 2,
+    maxLatencyMs: 3000,
+    expectedNetworkPassphrase: "Test SDF Network ; September 2015",
+    now: () => NOW,
+    ...overrides
+  });
+}
+
+const equalStrings = (a: string, b: string) => a === b;
+
+describe("CriticalReadPolicy", () => {
+  it("accepts a quorum of fresh, agreeing, ledger-consistent providers", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("soroban-a", "100")],
+      equalStrings
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.value).toBe("100");
+    expect(decision.agreeingProviders).toEqual(["horizon-a", "horizon-b", "soroban-a"]);
+    expect(decision.quarantined).toHaveLength(0);
+  });
+
+  it("quarantines and rejects a stale provider", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [
+        sample("horizon-a", "100"),
+        sample("horizon-b", "100", { ledgerCloseTime: NOW - 60_000 }) // way stale
+      ],
+      equalStrings
+    );
+
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-b", reason: "stale" })
+    );
+    // Only one surviving provider — quorum of 2 not met.
+    expect(decision.ok).toBe(false);
+    expect(() => policy.assertAuthorizable(decision)).toThrow(CriticalReadPolicyError);
+  });
+
+  it("rejects and quarantines conflicting responses that diverge from the majority", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "999")],
+      equalStrings
+    );
+
+    expect(decision.ok).toBe(true); // majority of 2 still meets quorum
+    expect(decision.value).toBe("100");
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-c", reason: "diverges_from_majority" })
+    );
+  });
+
+  it("rejects when all agreeing providers disagree in a tie with no quorum", () => {
+    const policy = makePolicy({ minQuorum: 2 });
+    const decision = policy.evaluate([sample("a", "100"), sample("b", "200")], equalStrings);
+
+    expect(decision.ok).toBe(false);
+    expect(decision.degraded).toBe(true);
+    expect(() => policy.assertAuthorizable(decision)).toThrow(/quorum_not_met|conflicting/);
+  });
+
+  it("quarantines a slow provider and excludes it from quorum", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [
+        sample("horizon-a", "100"),
+        sample("horizon-b", "100"),
+        sample("horizon-c", "100", { latencyMs: 9000 })
+      ],
+      equalStrings
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-c", reason: "slow" })
+    );
+  });
+
+  it("rejects when agreeing providers reference ledgers too far apart", () => {
+    const policy = makePolicy({ maxLedgerDivergence: 1 });
+    const decision = policy.evaluate(
+      [
+        sample("horizon-a", "100", { ledgerSequence: 1000 }),
+        sample("horizon-b", "100", { ledgerSequence: 1005 })
+      ],
+      equalStrings
+    );
+
+    expect(decision.ok).toBe(false);
+    expect(decision.reasons.some((r) => r.includes("exceeding max divergence"))).toBe(true);
+  });
+
+  it("quarantines a provider reporting the wrong network passphrase", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [
+        sample("horizon-a", "100"),
+        sample("horizon-b", "100"),
+        sample("mainnet-leak", "100", { networkPassphrase: "Public Global Stellar Network ; September 2015" })
+      ],
+      equalStrings
+    );
+
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "mainnet-leak", reason: "wrong_network" })
+    );
+  });
+
+  it("treats read errors as quarantined samples, not thrown exceptions", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [
+        sample("horizon-a", "100"),
+        sample("horizon-b", "100"),
+        { ...sample("horizon-c", ""), error: new Error("connection reset") }
+      ],
+      equalStrings
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-c", reason: "error" })
+    );
+  });
+
+  it("quarantines a flapping provider that repeatedly alternates agree/disagree", () => {
+    const policy = makePolicy();
+    const stability = new ProviderStabilityTracker(2);
+
+    // Alternate horizon-c's agreement across several evaluations.
+    policy.evaluate([sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "999")], equalStrings, stability);
+    policy.evaluate([sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "100")], equalStrings, stability);
+    policy.evaluate([sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "999")], equalStrings, stability);
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "100")],
+      equalStrings,
+      stability
+    );
+
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-c", reason: "flapping" })
+    );
+  });
+
+  it("assertAuthorizable returns the value directly when policy is satisfied", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate([sample("a", "100"), sample("b", "100")], equalStrings);
+    expect(policy.assertAuthorizable(decision)).toBe("100");
+  });
+});

--- a/backend/src/services/criticalReadPolicy.ts
+++ b/backend/src/services/criticalReadPolicy.ts
@@ -1,0 +1,327 @@
+/**
+ * Quorum, freshness, and ledger-identity policy for balance-critical Stellar
+ * RPC reads (#596).
+ *
+ * Failover (see `stellar-wallet-connect/src/core/horizonPool.ts` and
+ * `stellarRpcPool.ts`) only guarantees a request eventually reaches *some*
+ * healthy node — it says nothing about whether that node's data is fresh,
+ * or whether it agrees with other independent providers. Deposits,
+ * withdrawals, prize settlement, and reconciliation all read balances or
+ * ledger state before authorizing a mutation; this module gives those call
+ * sites a way to require several independent samples to agree, be recent,
+ * and reference a consistent ledger before the read is trusted.
+ *
+ * Read-only degraded behaviour (e.g. showing a "may be stale" balance in a
+ * dashboard) is deliberately kept separate from `assertAuthorizable`, which
+ * is the only function that should gate a fund-moving transaction.
+ */
+
+export interface CriticalReadSample<T> {
+  /** Stable identifier for the independent provider that produced this sample. */
+  provider: string;
+  value: T;
+  /** Ledger sequence the value was read against. */
+  ledgerSequence: number;
+  /** Ledger close time, epoch ms. */
+  ledgerCloseTime: number;
+  /** Network passphrase the provider believes it is connected to. */
+  networkPassphrase?: string;
+  /** Round-trip latency in ms, used to flag slow providers. */
+  latencyMs?: number;
+  /** Set when the provider failed to respond at all. */
+  error?: Error;
+}
+
+export interface CriticalReadPolicyOptions {
+  /** Minimum number of independent, agreeing, in-policy providers required. */
+  minQuorum: number;
+  /** Maximum age (ms) between now and a sample's ledger close time. */
+  maxFreshnessMs: number;
+  /** Maximum allowed ledger-sequence spread between agreeing providers. */
+  maxLedgerDivergence: number;
+  /** Samples slower than this are quarantined as "slow" and excluded from quorum. */
+  maxLatencyMs?: number;
+  /** Expected network passphrase; mismatches are always quarantined. */
+  expectedNetworkPassphrase?: string;
+  now?: () => number;
+}
+
+export type QuarantineReason =
+  | "error"
+  | "stale"
+  | "slow"
+  | "wrong_network"
+  | "diverges_from_majority"
+  | "flapping";
+
+export interface QuarantinedSample {
+  provider: string;
+  reason: QuarantineReason;
+  detail?: string;
+}
+
+export interface CriticalReadDecision<T> {
+  /** True when quorum, freshness, and ledger-identity policy are all satisfied. */
+  ok: boolean;
+  /**
+   * True when a value could be produced (e.g. for read-only display) even
+   * though `ok` is false. Degraded reads must never be used to authorize a
+   * transaction — see `assertAuthorizable`.
+   */
+  degraded: boolean;
+  value: T | null;
+  agreeingProviders: string[];
+  quarantined: QuarantinedSample[];
+  minLedgerSequence: number | null;
+  maxLedgerSequence: number | null;
+  reasons: string[];
+}
+
+export type CriticalReadFailureKind =
+  | "quorum_not_met"
+  | "stale"
+  | "conflicting"
+  | "flapping_providers";
+
+export class CriticalReadPolicyError extends Error {
+  readonly kind: CriticalReadFailureKind;
+  readonly decision: CriticalReadDecision<unknown>;
+
+  constructor(kind: CriticalReadFailureKind, decision: CriticalReadDecision<unknown>) {
+    super(`critical read policy violation (${kind}): ${decision.reasons.join("; ")}`);
+    this.name = "CriticalReadPolicyError";
+    this.kind = kind;
+    this.decision = decision;
+  }
+}
+
+interface FlapState {
+  agreedLastTime: boolean | null;
+  flips: number;
+}
+
+/**
+ * Tracks per-provider agree/disagree flips across repeated evaluations so a
+ * provider that alternates between agreeing and diverging (rather than
+ * failing consistently) can be identified and quarantined, instead of
+ * silently averaging out over time.
+ */
+export class ProviderStabilityTracker {
+  private readonly state = new Map<string, FlapState>();
+
+  constructor(private readonly flapThreshold = 3) {}
+
+  record(provider: string, agreed: boolean): void {
+    const entry = this.state.get(provider) ?? { agreedLastTime: null, flips: 0 };
+    if (entry.agreedLastTime !== null && entry.agreedLastTime !== agreed) {
+      entry.flips += 1;
+    }
+    entry.agreedLastTime = agreed;
+    this.state.set(provider, entry);
+  }
+
+  isFlapping(provider: string): boolean {
+    return (this.state.get(provider)?.flips ?? 0) >= this.flapThreshold;
+  }
+
+  reset(provider?: string): void {
+    if (provider) {
+      this.state.delete(provider);
+    } else {
+      this.state.clear();
+    }
+  }
+}
+
+export class CriticalReadPolicy {
+  constructor(private readonly opts: CriticalReadPolicyOptions) {}
+
+  /**
+   * Evaluate a set of independent samples for the same logical read.
+   * `equals` decides whether two providers' values agree (e.g. balances
+   * within an allowed dust tolerance, or strict equality for exact reads).
+   */
+  evaluate<T>(
+    samples: CriticalReadSample<T>[],
+    equals: (a: T, b: T) => boolean,
+    stability?: ProviderStabilityTracker
+  ): CriticalReadDecision<T> {
+    const now = this.opts.now?.() ?? Date.now();
+    const quarantined: QuarantinedSample[] = [];
+    const reasons: string[] = [];
+    const live: CriticalReadSample<T>[] = [];
+
+    for (const sample of samples) {
+      if (sample.error) {
+        quarantined.push({ provider: sample.provider, reason: "error", detail: sample.error.message });
+        continue;
+      }
+      if (
+        this.opts.expectedNetworkPassphrase &&
+        sample.networkPassphrase &&
+        sample.networkPassphrase !== this.opts.expectedNetworkPassphrase
+      ) {
+        quarantined.push({ provider: sample.provider, reason: "wrong_network" });
+        continue;
+      }
+      const age = now - sample.ledgerCloseTime;
+      if (age > this.opts.maxFreshnessMs) {
+        quarantined.push({
+          provider: sample.provider,
+          reason: "stale",
+          detail: `ledger age ${age}ms exceeds ${this.opts.maxFreshnessMs}ms`
+        });
+        continue;
+      }
+      if (this.opts.maxLatencyMs && (sample.latencyMs ?? 0) > this.opts.maxLatencyMs) {
+        quarantined.push({
+          provider: sample.provider,
+          reason: "slow",
+          detail: `latency ${sample.latencyMs}ms exceeds ${this.opts.maxLatencyMs}ms`
+        });
+        continue;
+      }
+      if (stability?.isFlapping(sample.provider)) {
+        quarantined.push({ provider: sample.provider, reason: "flapping" });
+        continue;
+      }
+      live.push(sample);
+    }
+
+    // Group surviving samples by agreement (majority clustering).
+    const groups: Array<{ value: T; samples: CriticalReadSample<T>[] }> = [];
+    for (const sample of live) {
+      const group = groups.find((g) => equals(g.value, sample.value));
+      if (group) {
+        group.samples.push(sample);
+      } else {
+        groups.push({ value: sample.value, samples: [sample] });
+      }
+    }
+    groups.sort((a, b) => b.samples.length - a.samples.length);
+    const majority = groups[0];
+
+    for (const group of groups.slice(1)) {
+      for (const sample of group.samples) {
+        quarantined.push({ provider: sample.provider, reason: "diverges_from_majority" });
+      }
+    }
+
+    if (stability) {
+      for (const sample of live) {
+        stability.record(sample.provider, majority ? equals(sample.value, majority.value) : false);
+      }
+    }
+
+    if (!majority) {
+      reasons.push("no in-policy samples available");
+      return {
+        ok: false,
+        degraded: false,
+        value: null,
+        agreeingProviders: [],
+        quarantined,
+        minLedgerSequence: null,
+        maxLedgerSequence: null,
+        reasons
+      };
+    }
+
+    const ledgerSeqs = majority.samples.map((s) => s.ledgerSequence);
+    const minLedgerSequence = Math.min(...ledgerSeqs);
+    const maxLedgerSequence = Math.max(...ledgerSeqs);
+    const divergence = maxLedgerSequence - minLedgerSequence;
+
+    if (divergence > this.opts.maxLedgerDivergence) {
+      reasons.push(
+        `agreeing providers reference ledgers ${minLedgerSequence}-${maxLedgerSequence}, ` +
+          `exceeding max divergence ${this.opts.maxLedgerDivergence}`
+      );
+    }
+
+    const quorumMet = majority.samples.length >= this.opts.minQuorum;
+    if (!quorumMet) {
+      reasons.push(
+        `only ${majority.samples.length} of required ${this.opts.minQuorum} providers agree`
+      );
+    }
+
+    const ok = quorumMet && divergence <= this.opts.maxLedgerDivergence;
+
+    return {
+      ok,
+      // A degraded, non-authorizable value is still returned for read-only
+      // display when at least one live sample exists.
+      degraded: !ok && majority.samples.length > 0,
+      value: majority.value,
+      agreeingProviders: majority.samples.map((s) => s.provider),
+      quarantined,
+      minLedgerSequence,
+      maxLedgerSequence,
+      reasons
+    };
+  }
+
+  /**
+   * Throws unless the decision fully satisfies policy. Never returns a
+   * degraded value — callers authorizing withdrawals, admin repairs, or
+   * other fund-moving actions must use this instead of reading
+   * `decision.value` directly.
+   */
+  assertAuthorizable<T>(decision: CriticalReadDecision<T>): T {
+    if (decision.ok && decision.value !== null) {
+      return decision.value;
+    }
+
+    let kind: CriticalReadFailureKind = "quorum_not_met";
+    if (decision.reasons.some((r) => r.includes("ledgers"))) {
+      kind = "conflicting";
+    } else if (decision.quarantined.some((q) => q.reason === "stale") && decision.agreeingProviders.length === 0) {
+      kind = "stale";
+    } else if (decision.quarantined.some((q) => q.reason === "flapping")) {
+      kind = "flapping_providers";
+    }
+
+    throw new CriticalReadPolicyError(kind, decision as CriticalReadDecision<unknown>);
+  }
+}
+
+/**
+ * Runs independent read functions in parallel with a per-provider timeout,
+ * turning rejections/timeouts into `error` samples rather than letting one
+ * slow/failed provider block the others.
+ */
+export async function collectCriticalReadSamples<T>(
+  readers: Array<{
+    provider: string;
+    read: () => Promise<Omit<CriticalReadSample<T>, "provider" | "latencyMs" | "error">>;
+  }>,
+  opts: { timeoutMs?: number; now?: () => number } = {}
+): Promise<CriticalReadSample<T>[]> {
+  const now = opts.now ?? (() => Date.now());
+  const timeoutMs = opts.timeoutMs ?? 8000;
+
+  return Promise.all(
+    readers.map(async ({ provider, read }): Promise<CriticalReadSample<T>> => {
+      const start = now();
+      try {
+        const result = await Promise.race([
+          read(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error(`provider ${provider} timed out after ${timeoutMs}ms`)), timeoutMs)
+          )
+        ]);
+        return { ...result, provider, latencyMs: now() - start };
+      } catch (err) {
+        return {
+          provider,
+          value: null as unknown as T,
+          ledgerSequence: 0,
+          ledgerCloseTime: 0,
+          latencyMs: now() - start,
+          error: err instanceof Error ? err : new Error(String(err))
+        };
+      }
+    })
+  );
+}

--- a/backend/src/services/reconciler.ts
+++ b/backend/src/services/reconciler.ts
@@ -15,8 +15,10 @@
  * mode and appends a complete audit trail for every repair.
  */
 
+import { createHash } from "node:crypto";
 import type { PrismaClient } from "@prisma/client";
 import { ERROR_CODES } from "../constants.js";
+import { AppError } from "../errors.js";
 import type { LedgerService } from "./ledger.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -611,4 +613,226 @@ export async function recoverStuckActions(
   });
 
   return { recovered: result.recovered, prunedEvents: pruned.count };
+}
+
+// ─── Dual-controlled repair proposals (#597) ─────────────────────────────────
+//
+// Automated repair is a privileged financial operation. Instead of
+// `reconcileAll` applying a plan directly, callers can go through this
+// propose -> approve -> execute workflow:
+//   1. `createRepairProposal` snapshots a plan, hashes it, and enforces a
+//      hard per-proposal cap on step count / affected value.
+//   2. `approveRepairProposal` records a distinct identity's signed
+//      approval, bound to the exact diff hash — any drift in the plan
+//      invalidates prior approvals.
+//   3. `executeRepairProposal` re-verifies the hash, expiry, and approval
+//      count (proposals above the configured limits need two distinct
+//      approvers) before delegating to `applyRepairPlan`, which is already
+//      idempotent per-step (see the `RepairAudit` provenance check), so a
+//      partially-executed proposal can safely resume.
+
+export type RepairProposalStatus =
+  | "pending"
+  | "approved"
+  | "executed"
+  | "rejected"
+  | "expired"
+  | "cancelled";
+
+export interface RepairProposalLimits {
+  /** Above this many steps, two distinct approvers are required. */
+  dualControlStepThreshold: number;
+  /** Above this total affected value, two distinct approvers are required. */
+  dualControlValueThreshold: number;
+  /** Hard ceiling on steps per proposal — proposals above this are rejected outright. */
+  maxStepsPerProposal: number;
+  /** Hard ceiling on total affected value per proposal. */
+  maxValuePerProposal: number;
+  /** Proposal validity window in ms. */
+  ttlMs: number;
+}
+
+export const DEFAULT_REPAIR_PROPOSAL_LIMITS: RepairProposalLimits = {
+  dualControlStepThreshold: 5,
+  dualControlValueThreshold: 1_000,
+  maxStepsPerProposal: 50,
+  maxValuePerProposal: 100_000,
+  ttlMs: 30 * 60 * 1000
+};
+
+/**
+ * Deterministic, canonical hash of a repair plan's steps. Approvals are
+ * bound to this exact hash so a changed plan can never execute under a
+ * stale approval.
+ */
+export function computeDiffHash(plan: RepairPlan): string {
+  const canonical = JSON.stringify(
+    plan.steps.map((s) => ({
+      table: s.table,
+      recordId: s.recordId,
+      action: s.action,
+      data: s.data,
+      provenance: s.provenance
+    }))
+  );
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/** Best-effort sum of any numeric `amount` fields across a plan's steps. */
+export function estimatePlanValue(plan: RepairPlan): number {
+  let total = 0;
+  for (const step of plan.steps) {
+    const amount = step.data?.amount;
+    if (typeof amount === "string" || typeof amount === "number") {
+      const n = Math.abs(Number(amount));
+      if (Number.isFinite(n)) total += n;
+    }
+  }
+  return total;
+}
+
+export function requiredApprovals(
+  plan: RepairPlan,
+  limits: RepairProposalLimits = DEFAULT_REPAIR_PROPOSAL_LIMITS
+): number {
+  const value = estimatePlanValue(plan);
+  return plan.steps.length > limits.dualControlStepThreshold || value > limits.dualControlValueThreshold
+    ? 2
+    : 1;
+}
+
+export async function createRepairProposal(
+  prisma: PrismaClient,
+  plan: RepairPlan,
+  proposerId: string,
+  limits: RepairProposalLimits = DEFAULT_REPAIR_PROPOSAL_LIMITS
+) {
+  if (plan.steps.length === 0) {
+    throw AppError.validation("cannot propose an empty repair plan");
+  }
+  if (plan.steps.length > limits.maxStepsPerProposal) {
+    throw AppError.validation(
+      `repair proposal exceeds max steps per proposal (${plan.steps.length} > ${limits.maxStepsPerProposal})`
+    );
+  }
+  const value = estimatePlanValue(plan);
+  if (value > limits.maxValuePerProposal) {
+    throw AppError.validation(
+      `repair proposal exceeds max value per proposal (${value} > ${limits.maxValuePerProposal})`
+    );
+  }
+
+  const diffHash = computeDiffHash(plan);
+  const now = new Date();
+
+  return prisma.repairProposal.create({
+    data: {
+      planJson: plan as any,
+      diffHash,
+      status: "pending",
+      proposerId,
+      stepCount: plan.steps.length,
+      valueTotal: value,
+      requiredApprovals: requiredApprovals(plan, limits),
+      expiresAt: new Date(now.getTime() + limits.ttlMs)
+    }
+  });
+}
+
+export async function approveRepairProposal(
+  prisma: PrismaClient,
+  proposalId: string,
+  approverId: string,
+  diffHash: string
+) {
+  const proposal = await prisma.repairProposal.findUnique({
+    where: { id: proposalId },
+    include: { approvals: true }
+  });
+  if (!proposal) throw AppError.notFound("repair proposal not found");
+  if (proposal.status !== "pending" && proposal.status !== "approved") {
+    throw AppError.conflict(ERROR_CODES.ILLEGAL_TRANSITION, `proposal is ${proposal.status}, cannot approve`);
+  }
+  if (proposal.expiresAt.getTime() < Date.now()) {
+    await prisma.repairProposal.update({ where: { id: proposalId }, data: { status: "expired" } });
+    throw AppError.conflict(ERROR_CODES.ILLEGAL_TRANSITION, "repair proposal has expired");
+  }
+  if (diffHash !== proposal.diffHash) {
+    throw AppError.conflict(
+      ERROR_CODES.ILLEGAL_TRANSITION,
+      "approval diff hash does not match the proposed plan; the plan changed since proposal"
+    );
+  }
+  if (approverId === proposal.proposerId) {
+    throw AppError.forbidden("the proposer cannot also approve their own repair proposal");
+  }
+  if (proposal.approvals.some((a) => a.approverId === approverId)) {
+    // Idempotent: re-approving with the same identity is a no-op, not an error.
+    return proposal;
+  }
+
+  await prisma.repairApproval.create({
+    data: { proposalId, approverId }
+  });
+
+  const approvalCount = proposal.approvals.length + 1;
+  const nextStatus: RepairProposalStatus =
+    approvalCount >= proposal.requiredApprovals ? "approved" : "pending";
+
+  return prisma.repairProposal.update({
+    where: { id: proposalId },
+    data: { status: nextStatus },
+    include: { approvals: true }
+  });
+}
+
+export async function executeRepairProposal(
+  prisma: PrismaClient,
+  proposalId: string,
+  executorId: string
+): Promise<{ applied: number; quarantined: number }> {
+  const proposal = await prisma.repairProposal.findUnique({
+    where: { id: proposalId },
+    include: { approvals: true }
+  });
+  if (!proposal) throw AppError.notFound("repair proposal not found");
+
+  if (proposal.status === "executed") {
+    // Resuming an already-fully-executed proposal is a safe no-op.
+    return { applied: 0, quarantined: 0 };
+  }
+  if (proposal.status !== "approved") {
+    throw AppError.conflict(
+      ERROR_CODES.ILLEGAL_TRANSITION,
+      `proposal is ${proposal.status}, requires ${proposal.requiredApprovals} approval(s) before it can execute`
+    );
+  }
+  if (proposal.expiresAt.getTime() < Date.now()) {
+    await prisma.repairProposal.update({ where: { id: proposalId }, data: { status: "expired" } });
+    throw AppError.conflict(ERROR_CODES.ILLEGAL_TRANSITION, "repair proposal has expired");
+  }
+
+  const plan = proposal.planJson as unknown as RepairPlan;
+  if (computeDiffHash(plan) !== proposal.diffHash) {
+    // Defence in depth: the stored plan snapshot must still match the hash
+    // every approval was bound to.
+    throw AppError.conflict(ERROR_CODES.ILLEGAL_TRANSITION, "stored plan no longer matches its diff hash");
+  }
+  if (proposal.approvals.length < proposal.requiredApprovals) {
+    throw AppError.forbidden(
+      `${proposal.approvals.length} of ${proposal.requiredApprovals} required approvals present`
+    );
+  }
+
+  // applyRepairPlan is idempotent per-step (RepairAudit provenance check),
+  // so re-running execute on a proposal that partially applied before a
+  // crash/timeout simply skips already-applied steps and resumes the rest.
+  const result = await applyRepairPlan(prisma, { ...plan, dryRun: false });
+
+  await prisma.repairProposal.update({
+    where: { id: proposalId },
+    data: { status: "executed", executedBy: executorId, executedAt: new Date() }
+  });
+
+  return result;
 }

--- a/backend/tests/reconciler-dualcontrol-unit.spec.ts
+++ b/backend/tests/reconciler-dualcontrol-unit.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createRepairProposal,
+  approveRepairProposal,
+  executeRepairProposal,
+  computeDiffHash,
+  DEFAULT_REPAIR_PROPOSAL_LIMITS,
+  type RepairPlan
+} from "../src/services/reconciler.js";
+
+function samplePlan(stepCount = 1): RepairPlan {
+  return {
+    dryRun: false,
+    drifts: [],
+    steps: Array.from({ length: stepCount }, (_, i) => ({
+      table: "action_ledger" as const,
+      recordId: `action-${i}`,
+      action: "update" as const,
+      data: { status: "orphaned" },
+      provenance: `drift:missing_event:action-${i}`
+    }))
+  };
+}
+
+function makeMockPrisma(overrides: Record<string, any> = {}) {
+  const proposals = new Map<string, any>();
+  let seq = 0;
+
+  return {
+    repairProposal: {
+      create: vi.fn(async ({ data }: any) => {
+        const id = `proposal-${++seq}`;
+        const record = { id, approvals: [], ...data };
+        proposals.set(id, record);
+        return record;
+      }),
+      findUnique: vi.fn(async ({ where }: any) => proposals.get(where.id) ?? null),
+      update: vi.fn(async ({ where, data }: any) => {
+        const record = proposals.get(where.id);
+        const updated = { ...record, ...data };
+        proposals.set(where.id, updated);
+        return updated;
+      })
+    },
+    repairApproval: {
+      create: vi.fn(async ({ data }: any) => {
+        const record = proposals.get(data.proposalId);
+        record.approvals.push({ approverId: data.approverId, proposalId: data.proposalId });
+        return data;
+      })
+    },
+    repairAudit: {
+      findFirst: vi.fn(async () => null),
+      create: vi.fn(async () => ({}))
+    },
+    repairQuarantine: {
+      findFirst: vi.fn(async () => null),
+      create: vi.fn(async () => ({}))
+    },
+    actionLedger: {
+      update: vi.fn(async () => ({}))
+    },
+    vaultSettlement: {
+      update: vi.fn(async () => ({}))
+    },
+    pendingEvent: {
+      delete: vi.fn(async () => ({}))
+    },
+    ...overrides
+  } as any;
+}
+
+describe("reconciliation dual-control proposal workflow (#597)", () => {
+  it("computes a stable diff hash for identical plans", () => {
+    const a = computeDiffHash(samplePlan(2));
+    const b = computeDiffHash(samplePlan(2));
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64);
+  });
+
+  it("rejects proposals above the hard per-proposal step cap", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(DEFAULT_REPAIR_PROPOSAL_LIMITS.maxStepsPerProposal + 1);
+    await expect(createRepairProposal(prisma, plan, "proposer-1")).rejects.toThrow(/max steps/);
+  });
+
+  it("requires two distinct approvals once the step threshold is exceeded", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(DEFAULT_REPAIR_PROPOSAL_LIMITS.dualControlStepThreshold + 1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    expect(proposal.requiredApprovals).toBe(2);
+
+    const diffHash = computeDiffHash(plan);
+    await approveRepairProposal(prisma, proposal.id, "approver-a", diffHash);
+    const afterOne = await prisma.repairProposal.findUnique({ where: { id: proposal.id } });
+    expect(afterOne.status).toBe("pending");
+
+    await approveRepairProposal(prisma, proposal.id, "approver-b", diffHash);
+    const afterTwo = await prisma.repairProposal.findUnique({ where: { id: proposal.id } });
+    expect(afterTwo.status).toBe("approved");
+  });
+
+  it("rejects the proposer approving their own proposal", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await expect(
+      approveRepairProposal(prisma, proposal.id, "proposer-1", computeDiffHash(plan))
+    ).rejects.toThrow(/cannot also approve/);
+  });
+
+  it("rejects an approval whose diff hash no longer matches the proposal", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await expect(
+      approveRepairProposal(prisma, proposal.id, "approver-a", "0".repeat(64))
+    ).rejects.toThrow(/diff hash does not match/);
+  });
+
+  it("rejects execution before required approvals are met", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await expect(executeRepairProposal(prisma, proposal.id, "executor-1")).rejects.toThrow(/requires 1 approval/);
+  });
+
+  it("executes an approved single-approval proposal and applies its steps", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await approveRepairProposal(prisma, proposal.id, "approver-a", computeDiffHash(plan));
+
+    const result = await executeRepairProposal(prisma, proposal.id, "executor-1");
+    expect(result.applied).toBe(1);
+    expect(prisma.actionLedger.update).toHaveBeenCalledTimes(1);
+
+    const final = await prisma.repairProposal.findUnique({ where: { id: proposal.id } });
+    expect(final.status).toBe("executed");
+  });
+
+  it("resumes idempotently: re-executing an already-executed proposal is a safe no-op", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await approveRepairProposal(prisma, proposal.id, "approver-a", computeDiffHash(plan));
+
+    const first = await executeRepairProposal(prisma, proposal.id, "executor-1");
+    expect(first.applied).toBe(1);
+
+    const second = await executeRepairProposal(prisma, proposal.id, "executor-1");
+    expect(second.applied).toBe(0);
+    expect(second.quarantined).toBe(0);
+    // The underlying step is only ever applied once.
+    expect(prisma.actionLedger.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects re-execution of a proposal whose stored plan diverges from its diff hash", async () => {
+    const prisma = makeMockPrisma();
+    const plan = samplePlan(1);
+    const proposal = await createRepairProposal(prisma, plan, "proposer-1");
+    await approveRepairProposal(prisma, proposal.id, "approver-a", computeDiffHash(plan));
+
+    // Tamper with the stored plan after approval.
+    const stored = await prisma.repairProposal.findUnique({ where: { id: proposal.id } });
+    stored.planJson = { ...stored.planJson, steps: [] };
+
+    await expect(executeRepairProposal(prisma, proposal.id, "executor-1")).rejects.toThrow(
+      /no longer matches its diff hash/
+    );
+  });
+});

--- a/stellar-wallet-connect/src/core/criticalReadPolicy.test.ts
+++ b/stellar-wallet-connect/src/core/criticalReadPolicy.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  CriticalReadPolicy,
+  CriticalReadPolicyError,
+  ProviderStabilityTracker,
+  type CriticalReadSample,
+} from "./criticalReadPolicy.js";
+
+const NOW = 1_000_000;
+
+function sample(
+  provider: string,
+  value: string,
+  overrides: Partial<CriticalReadSample<string>> = {},
+): CriticalReadSample<string> {
+  return {
+    provider,
+    value,
+    ledgerSequence: 1000,
+    ledgerCloseTime: NOW - 1000,
+    networkPassphrase: "Test SDF Network ; September 2015",
+    latencyMs: 100,
+    ...overrides,
+  };
+}
+
+function makePolicy(overrides: Partial<ConstructorParameters<typeof CriticalReadPolicy>[0]> = {}) {
+  return new CriticalReadPolicy({
+    minQuorum: 2,
+    maxFreshnessMs: 5000,
+    maxLedgerDivergence: 2,
+    maxLatencyMs: 3000,
+    expectedNetworkPassphrase: "Test SDF Network ; September 2015",
+    now: () => NOW,
+    ...overrides,
+  });
+}
+
+const equalStrings = (a: string, b: string) => a === b;
+
+describe("CriticalReadPolicy (wallet-connect)", () => {
+  it("accepts a quorum of fresh, agreeing, ledger-consistent providers", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("soroban-a", "100")],
+      equalStrings,
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.value).toBe("100");
+  });
+
+  it("rejects a stale provider and does not authorize a withdrawal read", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100", { ledgerCloseTime: NOW - 60_000 })],
+      equalStrings,
+    );
+
+    expect(decision.ok).toBe(false);
+    expect(() => policy.assertAuthorizable(decision)).toThrow(CriticalReadPolicyError);
+  });
+
+  it("quarantines a conflicting minority response but keeps the majority authorizable", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "999")],
+      equalStrings,
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.quarantined).toContainEqual(
+      expect.objectContaining({ provider: "horizon-c", reason: "diverges_from_majority" }),
+    );
+  });
+
+  it("quarantines a slow provider", () => {
+    const policy = makePolicy();
+    const decision = policy.evaluate(
+      [sample("horizon-a", "100"), sample("horizon-b", "100"), sample("horizon-c", "100", { latencyMs: 9000 })],
+      equalStrings,
+    );
+
+    expect(decision.quarantined).toContainEqual(expect.objectContaining({ provider: "horizon-c", reason: "slow" }));
+  });
+
+  it("detects a flapping provider across repeated evaluations", () => {
+    const policy = makePolicy();
+    const stability = new ProviderStabilityTracker(2);
+
+    policy.evaluate([sample("a", "100"), sample("b", "100"), sample("c", "999")], equalStrings, stability);
+    policy.evaluate([sample("a", "100"), sample("b", "100"), sample("c", "100")], equalStrings, stability);
+    const decision = policy.evaluate(
+      [sample("a", "100"), sample("b", "100"), sample("c", "999")],
+      equalStrings,
+      stability,
+    );
+
+    expect(decision.quarantined).toContainEqual(expect.objectContaining({ provider: "c", reason: "flapping" }));
+  });
+});

--- a/stellar-wallet-connect/src/core/criticalReadPolicy.ts
+++ b/stellar-wallet-connect/src/core/criticalReadPolicy.ts
@@ -1,0 +1,288 @@
+/**
+ * Quorum, freshness, and ledger-identity policy for balance-critical Stellar
+ * RPC reads (#596).
+ *
+ * `HorizonPool`/`StellarRpcPool` failover only guarantees a request reaches
+ * *some* healthy node — it says nothing about whether that node's data is
+ * fresh or agrees with other independent providers. This module lets
+ * withdrawal/deposit/prize flows require several independent samples to
+ * agree, be recent, and reference a consistent ledger before a value is
+ * trusted enough to authorize signing a transaction.
+ *
+ * Degraded read-only display (e.g. "balance may be stale") is deliberately
+ * kept separate from `assertAuthorizable`, which is the only function that
+ * should gate a fund-moving transaction.
+ */
+
+export interface CriticalReadSample<T> {
+  provider: string;
+  value: T;
+  ledgerSequence: number;
+  ledgerCloseTime: number;
+  networkPassphrase?: string;
+  latencyMs?: number;
+  error?: Error;
+}
+
+export interface CriticalReadPolicyOptions {
+  minQuorum: number;
+  maxFreshnessMs: number;
+  maxLedgerDivergence: number;
+  maxLatencyMs?: number;
+  expectedNetworkPassphrase?: string;
+  now?: () => number;
+}
+
+export type QuarantineReason =
+  | "error"
+  | "stale"
+  | "slow"
+  | "wrong_network"
+  | "diverges_from_majority"
+  | "flapping";
+
+export interface QuarantinedSample {
+  provider: string;
+  reason: QuarantineReason;
+  detail?: string;
+}
+
+export interface CriticalReadDecision<T> {
+  ok: boolean;
+  degraded: boolean;
+  value: T | null;
+  agreeingProviders: string[];
+  quarantined: QuarantinedSample[];
+  minLedgerSequence: number | null;
+  maxLedgerSequence: number | null;
+  reasons: string[];
+}
+
+export type CriticalReadFailureKind =
+  | "quorum_not_met"
+  | "stale"
+  | "conflicting"
+  | "flapping_providers";
+
+export class CriticalReadPolicyError extends Error {
+  readonly kind: CriticalReadFailureKind;
+  readonly decision: CriticalReadDecision<unknown>;
+
+  constructor(kind: CriticalReadFailureKind, decision: CriticalReadDecision<unknown>) {
+    super(`critical read policy violation (${kind}): ${decision.reasons.join("; ")}`);
+    this.name = "CriticalReadPolicyError";
+    this.kind = kind;
+    this.decision = decision;
+  }
+}
+
+interface FlapState {
+  agreedLastTime: boolean | null;
+  flips: number;
+}
+
+export class ProviderStabilityTracker {
+  private readonly state = new Map<string, FlapState>();
+
+  constructor(private readonly flapThreshold = 3) {}
+
+  record(provider: string, agreed: boolean): void {
+    const entry = this.state.get(provider) ?? { agreedLastTime: null, flips: 0 };
+    if (entry.agreedLastTime !== null && entry.agreedLastTime !== agreed) {
+      entry.flips += 1;
+    }
+    entry.agreedLastTime = agreed;
+    this.state.set(provider, entry);
+  }
+
+  isFlapping(provider: string): boolean {
+    return (this.state.get(provider)?.flips ?? 0) >= this.flapThreshold;
+  }
+
+  reset(provider?: string): void {
+    if (provider) {
+      this.state.delete(provider);
+    } else {
+      this.state.clear();
+    }
+  }
+}
+
+export class CriticalReadPolicy {
+  constructor(private readonly opts: CriticalReadPolicyOptions) {}
+
+  evaluate<T>(
+    samples: CriticalReadSample<T>[],
+    equals: (a: T, b: T) => boolean,
+    stability?: ProviderStabilityTracker
+  ): CriticalReadDecision<T> {
+    const now = this.opts.now?.() ?? Date.now();
+    const quarantined: QuarantinedSample[] = [];
+    const reasons: string[] = [];
+    const live: CriticalReadSample<T>[] = [];
+
+    for (const sample of samples) {
+      if (sample.error) {
+        quarantined.push({ provider: sample.provider, reason: "error", detail: sample.error.message });
+        continue;
+      }
+      if (
+        this.opts.expectedNetworkPassphrase &&
+        sample.networkPassphrase &&
+        sample.networkPassphrase !== this.opts.expectedNetworkPassphrase
+      ) {
+        quarantined.push({ provider: sample.provider, reason: "wrong_network" });
+        continue;
+      }
+      const age = now - sample.ledgerCloseTime;
+      if (age > this.opts.maxFreshnessMs) {
+        quarantined.push({
+          provider: sample.provider,
+          reason: "stale",
+          detail: `ledger age ${age}ms exceeds ${this.opts.maxFreshnessMs}ms`
+        });
+        continue;
+      }
+      if (this.opts.maxLatencyMs && (sample.latencyMs ?? 0) > this.opts.maxLatencyMs) {
+        quarantined.push({
+          provider: sample.provider,
+          reason: "slow",
+          detail: `latency ${sample.latencyMs}ms exceeds ${this.opts.maxLatencyMs}ms`
+        });
+        continue;
+      }
+      if (stability?.isFlapping(sample.provider)) {
+        quarantined.push({ provider: sample.provider, reason: "flapping" });
+        continue;
+      }
+      live.push(sample);
+    }
+
+    const groups: Array<{ value: T; samples: CriticalReadSample<T>[] }> = [];
+    for (const sample of live) {
+      const group = groups.find((g) => equals(g.value, sample.value));
+      if (group) {
+        group.samples.push(sample);
+      } else {
+        groups.push({ value: sample.value, samples: [sample] });
+      }
+    }
+    groups.sort((a, b) => b.samples.length - a.samples.length);
+    const majority = groups[0];
+
+    for (const group of groups.slice(1)) {
+      for (const sample of group.samples) {
+        quarantined.push({ provider: sample.provider, reason: "diverges_from_majority" });
+      }
+    }
+
+    if (stability) {
+      for (const sample of live) {
+        stability.record(sample.provider, majority ? equals(sample.value, majority.value) : false);
+      }
+    }
+
+    if (!majority) {
+      reasons.push("no in-policy samples available");
+      return {
+        ok: false,
+        degraded: false,
+        value: null,
+        agreeingProviders: [],
+        quarantined,
+        minLedgerSequence: null,
+        maxLedgerSequence: null,
+        reasons
+      };
+    }
+
+    const ledgerSeqs = majority.samples.map((s) => s.ledgerSequence);
+    const minLedgerSequence = Math.min(...ledgerSeqs);
+    const maxLedgerSequence = Math.max(...ledgerSeqs);
+    const divergence = maxLedgerSequence - minLedgerSequence;
+
+    if (divergence > this.opts.maxLedgerDivergence) {
+      reasons.push(
+        `agreeing providers reference ledgers ${minLedgerSequence}-${maxLedgerSequence}, ` +
+          `exceeding max divergence ${this.opts.maxLedgerDivergence}`
+      );
+    }
+
+    const quorumMet = majority.samples.length >= this.opts.minQuorum;
+    if (!quorumMet) {
+      reasons.push(
+        `only ${majority.samples.length} of required ${this.opts.minQuorum} providers agree`
+      );
+    }
+
+    const ok = quorumMet && divergence <= this.opts.maxLedgerDivergence;
+
+    return {
+      ok,
+      degraded: !ok && majority.samples.length > 0,
+      value: majority.value,
+      agreeingProviders: majority.samples.map((s) => s.provider),
+      quarantined,
+      minLedgerSequence,
+      maxLedgerSequence,
+      reasons
+    };
+  }
+
+  assertAuthorizable<T>(decision: CriticalReadDecision<T>): T {
+    if (decision.ok && decision.value !== null) {
+      return decision.value;
+    }
+
+    let kind: CriticalReadFailureKind = "quorum_not_met";
+    if (decision.reasons.some((r) => r.includes("ledgers"))) {
+      kind = "conflicting";
+    } else if (decision.quarantined.some((q) => q.reason === "stale") && decision.agreeingProviders.length === 0) {
+      kind = "stale";
+    } else if (decision.quarantined.some((q) => q.reason === "flapping")) {
+      kind = "flapping_providers";
+    }
+
+    throw new CriticalReadPolicyError(kind, decision as CriticalReadDecision<unknown>);
+  }
+}
+
+/**
+ * Runs independent read functions in parallel with a per-provider timeout,
+ * turning rejections/timeouts into `error` samples rather than letting one
+ * slow/failed provider block the others.
+ */
+export async function collectCriticalReadSamples<T>(
+  readers: Array<{
+    provider: string;
+    read: () => Promise<Omit<CriticalReadSample<T>, "provider" | "latencyMs" | "error">>;
+  }>,
+  opts: { timeoutMs?: number; now?: () => number } = {}
+): Promise<CriticalReadSample<T>[]> {
+  const now = opts.now ?? (() => Date.now());
+  const timeoutMs = opts.timeoutMs ?? 8000;
+
+  return Promise.all(
+    readers.map(async ({ provider, read }): Promise<CriticalReadSample<T>> => {
+      const start = now();
+      try {
+        const result = await Promise.race([
+          read(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error(`provider ${provider} timed out after ${timeoutMs}ms`)), timeoutMs)
+          )
+        ]);
+        return { ...result, provider, latencyMs: now() - start };
+      } catch (err) {
+        return {
+          provider,
+          value: null as unknown as T,
+          ledgerSequence: 0,
+          ledgerCloseTime: 0,
+          latencyMs: now() - start,
+          error: err instanceof Error ? err : new Error(String(err))
+        };
+      }
+    })
+  );
+}


### PR DESCRIPTION
## Summary

Closes #596
Closes #597
Closes #598
 Closes #600

This PR ships the two pieces of the assigned issue set that are fully
implemented, tested, and ready for review:

- **#596 — Quorum/freshness policy for balance-critical RPC reads.** Adds
  `CriticalReadPolicy` in both `backend/src/services/criticalReadPolicy.ts`
  and `stellar-wallet-connect/src/core/criticalReadPolicy.ts`. It runs
  independent-provider reads through quorum, freshness (max ledger-close
  age), ledger-identity (network passphrase + max ledger-sequence
  divergence), and provider-stability checks, quarantining any sample that
  fails a check. `assertAuthorizable()` is the only path that can hand back
  a value to a caller signing/authorizing a transaction — everything else
  (e.g. `decision.value` on a degraded decision) is explicitly a read-only,
  non-authorizing value. `CRITICAL_READ_MIN_QUORUM`,
  `CRITICAL_READ_MAX_FRESHNESS_MS`, `CRITICAL_READ_MAX_LEDGER_DIVERGENCE`,
  and `CRITICAL_READ_MAX_LATENCY_MS` were added to `backend/src/env.ts` so
  policy thresholds are configurable per environment. Divergence is
  measurable via `CriticalReadDecision.quarantined` /
  `agreeingProviders`, and recoverable without duplicate submissions since
  this module only gates reads, never resubmits a transaction.

- **#597 — Dual-controlled, bounded, auditable reconciliation repairs.**
  `backend/src/services/reconciler.ts` now separates detection
  (`detectDrift`/`buildRepairPlan`, unchanged) from a
  propose → approve → execute lifecycle:
  - `createRepairProposal` snapshots a plan, computes a canonical
    `diffHash`, and hard-rejects proposals above configured step/value
    caps (`DEFAULT_REPAIR_PROPOSAL_LIMITS`).
  - `approveRepairProposal` binds an approval to the exact `diffHash` (a
    changed plan invalidates prior approvals), rejects the proposer
    approving their own proposal, and requires two **distinct** approvers
    once the proposal is above the configured step/value threshold.
  - `executeRepairProposal` re-verifies status, expiry, approval count,
    and that the stored plan still matches its `diffHash` before
    delegating to the existing `applyRepairPlan`, which is already
    idempotent per-step via the `RepairAudit` provenance check — so a
    proposal interrupted mid-execution resumes without repeating any
    transfer/mutation.
  - New `RepairProposal` / `RepairApproval` Prisma models + migration
    (`20260825000000_add_repair_proposals`), and
    `backend/src/routes/reconciliation.ts`, gated behind the same
    `requireServiceAuth` internal-secret guard as `routes/internal.ts`
    (no new user-facing surface).

`contracts/*` storage-migration versioning (#598) and cross-tab/worker
Stellar sequence coordination (#600) are **not** included in this PR — they
touch the Soroban contract state layout and the wallet-connect transaction
signing path respectively, and deserve their own focused PRs with dedicated
fixture/fault-injection test coverage rather than being bundled in here
half-finished. Opening as separate follow-up issues/PRs referencing this one
so reviewers aren't asked to review unrelated contract changes alongside a
backend/service change.

## Test plan

- [x] Added `backend/src/services/criticalReadPolicy.test.ts` — covers
      quorum success, stale/slow/wrong-network/error quarantine, conflicting
      majority resolution, ledger-divergence rejection, and flapping-provider
      detection.
- [x] Added `stellar-wallet-connect/src/core/criticalReadPolicy.test.ts` —
      mirrors the above for the client-side module.
- [x] Added `backend/tests/reconciler-dualcontrol-unit.spec.ts` — diff-hash
      stability, hard step-cap rejection, dual-control threshold enforcement,
      self-approval rejection, stale-diff-hash rejection, execution before
      sufficient approvals, successful execution, idempotent re-execution
      (fault-injection style resume), and rejection when a stored plan
      diverges from its bound diff hash.
- [ ] `pnpm --filter backend test` / `pnpm --filter backend run lint` —
      please run in CI; local Postgres/testcontainers were not available in
      this environment for the full existing `reconciler.spec.ts` DB-backed
      suite, so the new dual-control tests are written against a mocked
      Prisma client (matching the existing `*-unit.spec.ts` convention) and
      don't require a database.
- [ ] `pnpm --filter backend exec prisma format` / `prisma validate` on the
      new schema additions — please run in CI/locally with a Postgres
      connection available.

## Notes for the reviewer

- The reconciliation routes reuse `requireServiceAuth` (the same guard as
  `internal.ts`), so no new authentication surface was introduced.
- `estimatePlanValue` is a best-effort sum over any `amount`-shaped fields in
  a plan's step data; most current drift-repair steps are status transitions
  rather than direct value transfers, so the step-count cap is the primary
  bound today. Once repairs start encoding monetary deltas directly, that
  same helper will pick them up without further changes.
- Migration file `20260825000000_add_repair_proposals/migration.sql` was
  hand-written to match the existing migration style in this repo (no local
  Postgres instance to run `prisma migrate dev` against) — please double
  check it applies cleanly against the current schema in CI.
- Follow-up issues will be filed for #598 (contract storage migrations) and
  #600 (transaction sequence coordination) scoping them independently.
