### PR TITLE
feat(env): enforce asset issuer allow-list validation on startup

### DIFF
--- a/stellar-wallet-connect/src/core/env.test.ts
+++ b/stellar-wallet-connect/src/core/env.test.ts
@@ -1,27 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { parseFrontendEnv } from "./env.js";
 
+// Valid Stellar account ID used across tests (G + 55 base32 chars).
+const VALID_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const BASE_ENV = {
+  NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "wallet-id-123",
+  NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
+  NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+  NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: "CA1234DRIPPOOL",
+  NEXT_PUBLIC_VAULT_ASSET_CODE: "USDC",
+  NEXT_PUBLIC_VAULT_ASSET_ISSUER: VALID_ISSUER,
+};
+
 describe("parseFrontendEnv", () => {
   it("accepts valid env", () => {
-    const env = parseFrontendEnv({
-      NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "wallet-id-123",
-      NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
-      NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
-      NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
-      NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: "CA1234DRIPPOOL"
-    });
-
+    const env = parseFrontendEnv(BASE_ENV);
     expect(env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID).toBe("wallet-id-123");
     expect(env.NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID).toBe("CA1234DRIPPOOL");
+    expect(env.NEXT_PUBLIC_VAULT_ASSET_CODE).toBe("USDC");
+    expect(env.NEXT_PUBLIC_VAULT_ASSET_ISSUER).toBe(VALID_ISSUER);
   });
 
   it("rejects missing required values", () => {
     expect(() =>
       parseFrontendEnv({
-        NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
-        NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
-        NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
-        NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: "CA1234DRIPPOOL"
+        ...BASE_ENV,
+        NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "",
       })
     ).toThrow(/NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID/);
   });
@@ -29,11 +35,8 @@ describe("parseFrontendEnv", () => {
   it("rejects placeholder values", () => {
     expect(() =>
       parseFrontendEnv({
+        ...BASE_ENV,
         NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "YOUR_PROJECT_ID",
-        NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
-        NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
-        NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
-        NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: "CA_PLACEHOLDER_DRIP_POOL_CONTRACT_ID"
       })
     ).toThrow(/placeholder/i);
   });
@@ -41,13 +44,42 @@ describe("parseFrontendEnv", () => {
   it("rejects invalid URLs", () => {
     expect(() =>
       parseFrontendEnv({
-        NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "wallet-id-123",
-        NEXT_PUBLIC_SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+        ...BASE_ENV,
         NEXT_PUBLIC_HORIZON_URL: "not-a-url",
-        NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
-        NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: "CA1234DRIPPOOL"
       })
     ).toThrow(/NEXT_PUBLIC_HORIZON_URL/);
+  });
+
+  // ── Asset issuer allow-list tests (#638) ──────────────────────────────────
+
+  it("rejects a missing vault asset issuer", () => {
+    expect(() =>
+      parseFrontendEnv({ ...BASE_ENV, NEXT_PUBLIC_VAULT_ASSET_ISSUER: "" })
+    ).toThrow(/NEXT_PUBLIC_VAULT_ASSET_ISSUER/);
+  });
+
+  it("rejects a placeholder vault asset issuer", () => {
+    expect(() =>
+      parseFrontendEnv({ ...BASE_ENV, NEXT_PUBLIC_VAULT_ASSET_ISSUER: "YOUR_ISSUER_ADDRESS" })
+    ).toThrow(/placeholder/i);
+  });
+
+  it("rejects an issuer that is not a valid Stellar account ID (wrong prefix)", () => {
+    expect(() =>
+      parseFrontendEnv({ ...BASE_ENV, NEXT_PUBLIC_VAULT_ASSET_ISSUER: "XBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" })
+    ).toThrow(/Stellar account ID/i);
+  });
+
+  it("rejects an issuer that is too short", () => {
+    expect(() =>
+      parseFrontendEnv({ ...BASE_ENV, NEXT_PUBLIC_VAULT_ASSET_ISSUER: "GBBD47IF6LWK7" })
+    ).toThrow(/Stellar account ID/i);
+  });
+
+  it("rejects a missing vault asset code", () => {
+    expect(() =>
+      parseFrontendEnv({ ...BASE_ENV, NEXT_PUBLIC_VAULT_ASSET_CODE: "" })
+    ).toThrow(/NEXT_PUBLIC_VAULT_ASSET_CODE/);
   });
 });
 

--- a/stellar-wallet-connect/src/core/env.ts
+++ b/stellar-wallet-connect/src/core/env.ts
@@ -4,6 +4,10 @@ export interface FrontendEnv {
   NEXT_PUBLIC_HORIZON_URL: string;
   NEXT_PUBLIC_SOROBAN_RPC_URL: string;
   NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: string;
+  /** Asset code accepted for vault deposits (e.g. "USDC"). Required. */
+  NEXT_PUBLIC_VAULT_ASSET_CODE: string;
+  /** Stellar account ID of the allowed asset issuer. Must be a valid G-address. Required. */
+  NEXT_PUBLIC_VAULT_ASSET_ISSUER: string;
   NEXT_PUBLIC_TRUSTLESS_WORK_ESCROW_CONTRACT_ID?: string;
   TRUSTLESS_WORK_API_BASE_URL?: string;
   TRUSTLESS_WORK_API_KEY?: string;
@@ -77,6 +81,18 @@ function validateOptionalUrl(name: string, value?: string): string | undefined {
   return undefined;
 }
 
+// Stellar account IDs are 56-character base32 strings starting with "G".
+const stellarAccountIdPattern = /^G[A-Z2-7]{55}$/;
+
+function validateStellarAccountId(name: string, value: string): string | undefined {
+  const missing = validateRequiredString(name, value);
+  if (missing) return missing;
+  if (!stellarAccountIdPattern.test(value)) {
+    return `${name} must be a valid Stellar account ID (G… 56 characters)`;
+  }
+  return undefined;
+}
+
 export function parseFrontendEnv(
   source: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env
 ): FrontendEnv {
@@ -90,6 +106,8 @@ export function parseFrontendEnv(
     NEXT_PUBLIC_HORIZON_URL: readEnvValue(source, "NEXT_PUBLIC_HORIZON_URL", "PUBLIC_HORIZON_URL"),
     NEXT_PUBLIC_SOROBAN_RPC_URL: readEnvValue(source, "NEXT_PUBLIC_SOROBAN_RPC_URL"),
     NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID: readEnvValue(source, "NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID"),
+    NEXT_PUBLIC_VAULT_ASSET_CODE: readEnvValue(source, "NEXT_PUBLIC_VAULT_ASSET_CODE"),
+    NEXT_PUBLIC_VAULT_ASSET_ISSUER: readEnvValue(source, "NEXT_PUBLIC_VAULT_ASSET_ISSUER"),
     NEXT_PUBLIC_TRUSTLESS_WORK_ESCROW_CONTRACT_ID: readEnvValue(
       source,
       "NEXT_PUBLIC_TRUSTLESS_WORK_ESCROW_CONTRACT_ID"
@@ -123,6 +141,18 @@ export function parseFrontendEnv(
     env.NEXT_PUBLIC_DRIP_POOL_CONTRACT_ID
   );
   if (contractError) errors.push(contractError);
+
+  const assetCodeError = validateRequiredString(
+    "NEXT_PUBLIC_VAULT_ASSET_CODE",
+    env.NEXT_PUBLIC_VAULT_ASSET_CODE
+  );
+  if (assetCodeError) errors.push(assetCodeError);
+
+  const assetIssuerError = validateStellarAccountId(
+    "NEXT_PUBLIC_VAULT_ASSET_ISSUER",
+    env.NEXT_PUBLIC_VAULT_ASSET_ISSUER
+  );
+  if (assetIssuerError) errors.push(assetIssuerError);
 
   const trustlessBaseUrlError = validateOptionalUrl(
     "TRUSTLESS_WORK_API_BASE_URL",


### PR DESCRIPTION
Closes #635
Closes #636
Closes #637
Closes #638

Adds `NEXT_PUBLIC_VAULT_ASSET_CODE` and `NEXT_PUBLIC_VAULT_ASSET_ISSUER` as required fields in `FrontendEnv`, validated at startup by `parseFrontendEnv` in `stellar-wallet-connect/src/core/env.ts`.

**Changes to `env.ts`:**
- Two new required fields added to `FrontendEnv` — `NEXT_PUBLIC_VAULT_ASSET_CODE` (non-empty string) and `NEXT_PUBLIC_VAULT_ASSET_ISSUER` (valid Stellar G-address)
- New `validateStellarAccountId` helper: checks the value is present, not a placeholder, and matches the Stellar base32 G-address format (`/^G[A-Z2-7]{55}$/`)
- Both fields are read in `parseFrontendEnv` and validated alongside the other required env checks — invalid config throws on startup before any transaction is constructed

**Changes to `env.test.ts`:**
- Extracted `BASE_ENV` constant so all cases share a valid baseline (existing tests updated to use it)
- Five new cases covering: missing issuer, placeholder issuer, wrong prefix (X instead of G), too-short address, and missing asset code