### PR TITLE
fix: tx timeline recovery, manifest governance, mobile nav guard, reward proof reconciliation

### DIFF
--- a/lib/deployment-manifest.ts
+++ b/lib/deployment-manifest.ts
@@ -29,6 +29,35 @@ const BuildSchema = z.object({
   contractWasmHash: z.string().optional(),
 });
 
+/**
+ * Governance section added in #632: records who can upgrade, pause, or
+ * administer each deployed contract so validation scripts can fail loudly on
+ * unexpected authority changes.
+ */
+const GovernanceSchema = z.object({
+  /**
+   * Minimum number of signers required to authorise an upgrade or admin
+   * operation. Must be >= 1; if > 1 this implies a multisig scheme.
+   */
+  signerThreshold: z.number().int().min(1),
+  /**
+   * Stellar account (or C… contract) that holds admin authority — can call
+   * admin-only entry points (e.g. `set_admin`, `set_fee`).
+   */
+  adminAuthority: z.string().min(1),
+  /**
+   * Stellar account (or C… contract) authorised to upgrade the WASM bytecode.
+   * Separation from adminAuthority mirrors the Soroban authority model where
+   * upgrade capability is distinct from run-time administration.
+   */
+  upgradeAuthority: z.string().min(1),
+  /**
+   * Optional: account authorised to invoke emergency pause. Defaults to
+   * adminAuthority if absent; recorded here for operational transparency.
+   */
+  pauseAuthority: z.string().min(1).optional(),
+});
+
 export const DeploymentManifestSchema = z.object({
   version: z.string().regex(/^\d+\.\d+\.\d+$/, "Must be semver"),
   environment: z.enum(["staging", "production"]),
@@ -36,6 +65,8 @@ export const DeploymentManifestSchema = z.object({
   contracts: ContractsSchema,
   assets: z.array(z.record(z.string())).default([]),
   build: BuildSchema,
+  /** Governance/authority metadata — required for mainnet, optional for staging. */
+  governance: GovernanceSchema.optional(),
   signature: z.string().optional(),
 });
 
@@ -208,4 +239,90 @@ export function validateManifestAgainstEnv(
   }
 
   return mismatches;
+}
+
+// ─── Governance validation (#632) ─────────────────────────────────────────────
+
+export interface GovernanceViolation {
+  field: string;
+  manifestValue: string;
+  expectedValue: string;
+  reason: string;
+}
+
+const GOVERNANCE_ENV_MAP = {
+  adminAuthority: "EXPECTED_ADMIN_AUTHORITY",
+  upgradeAuthority: "EXPECTED_UPGRADE_AUTHORITY",
+  pauseAuthority: "EXPECTED_PAUSE_AUTHORITY",
+} as const;
+
+/**
+ * Validates the manifest's governance block against expected authorities from
+ * environment variables (#632).  Returns violations found; an empty array means
+ * all checked fields match.  Throws when the manifest is mainnet but has no
+ * governance block, since authority tracking is mandatory for production.
+ */
+export function validateManifestGovernance(
+  manifest: DeploymentManifest,
+  env: Record<string, string | undefined> = typeof process !== "undefined" ? process.env : {},
+): GovernanceViolation[] {
+  if (!manifest.governance) {
+    if (manifest.network.name === "mainnet") {
+      throw new Error(
+        "Governance block is required for mainnet deployments but is absent from the manifest."
+      );
+    }
+    return [];
+  }
+
+  const gov = manifest.governance;
+  const violations: GovernanceViolation[] = [];
+
+  // Check each authority field against its expected env var.
+  for (const [field, envKey] of Object.entries(GOVERNANCE_ENV_MAP) as [keyof typeof GOVERNANCE_ENV_MAP, string][]) {
+    const manifestValue = gov[field];
+    const expectedValue = env[envKey];
+    if (!expectedValue || !manifestValue) continue;
+    if (manifestValue !== expectedValue) {
+      violations.push({
+        field: `governance.${field}`,
+        manifestValue,
+        expectedValue,
+        reason: `${field} does not match ${envKey}`,
+      });
+    }
+  }
+
+  // Signer threshold from env
+  const expectedThresholdRaw = env["EXPECTED_SIGNER_THRESHOLD"];
+  if (expectedThresholdRaw) {
+    const expected = Number(expectedThresholdRaw);
+    if (Number.isInteger(expected) && gov.signerThreshold !== expected) {
+      violations.push({
+        field: "governance.signerThreshold",
+        manifestValue: String(gov.signerThreshold),
+        expectedValue: expectedThresholdRaw,
+        reason: `signerThreshold does not match EXPECTED_SIGNER_THRESHOLD`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * Throws if governance validation finds any violations.  Convenience wrapper
+ * for use in CI/deploy scripts where failure should be fatal.
+ */
+export function assertGovernanceValid(
+  manifest: DeploymentManifest,
+  env?: Record<string, string | undefined>,
+): void {
+  const violations = validateManifestGovernance(manifest, env);
+  if (violations.length > 0) {
+    const details = violations
+      .map((v) => `  ${v.field}: manifest="${v.manifestValue}" expected="${v.expectedValue}" (${v.reason})`)
+      .join("\n");
+    throw new Error(`Governance authority validation failed:\n${details}`);
+  }
 }

--- a/lib/draw-proof-verifier.ts
+++ b/lib/draw-proof-verifier.ts
@@ -191,6 +191,94 @@ export async function verifyDrawProofClient(
   };
 }
 
+// ─── Reward Entry Reconciliation (#634) ──────────────────────────────────────
+
+export type ProofStatus = "verified" | "tampered" | "missing" | "pending" | "unverified";
+export type ClaimStatus = "claimed" | "pending" | "unclaimed" | "failed";
+
+export interface RewardReconciliation {
+  proofStatus: ProofStatus;
+  proofDetail: string;
+  claimStatus: ClaimStatus;
+}
+
+export interface ReconcileRewardEntryInput {
+  /** Round ID to match against draw proof's roundId. */
+  roundId: number;
+  /** Draw proof fetched from storage, or null/undefined if not found. */
+  proof: DrawProof | null | undefined;
+  /** Whether the cycle outcome is won. */
+  isWon: boolean;
+  /**
+   * On-chain tx hash for the claim, if any.  Absence means unclaimed (for a
+   * won entry) or irrelevant (for a no_win/pending entry).
+   */
+  claimTxHash: string | null;
+  /**
+   * Result of fetching the claim tx from the indexer/RPC.  Undefined when no
+   * claimTxHash exists.  Truthy means confirmed-successful.
+   */
+  claimTxSuccessful?: boolean;
+}
+
+/**
+ * Pure reconciliation of one reward entry against its draw proof and claim
+ * transaction data (#634).  All RPC calls are done by the caller; this
+ * function only interprets the pre-fetched data so it is synchronous and
+ * testable in isolation.
+ */
+export async function reconcileRewardEntry(
+  input: ReconcileRewardEntryInput,
+): Promise<RewardReconciliation> {
+  // ── Proof reconciliation ─────────────────────────────────────────────────
+  let proofStatus: ProofStatus;
+  let proofDetail: string;
+
+  if (!input.proof) {
+    proofStatus = input.isWon ? "missing" : "pending";
+    proofDetail = input.isWon
+      ? "No draw proof found for this round"
+      : "Draw proof not yet available";
+  } else if (input.proof.roundId !== input.roundId) {
+    proofStatus = "tampered";
+    proofDetail = `Round ID mismatch: proof.roundId=${input.proof.roundId}, expected=${input.roundId}`;
+  } else {
+    const result = await verifyProofIntegrity(input.proof);
+    const failingField = result.fields.find((f) => f.status === "fail");
+    const unverifiedField = result.fields.find((f) => f.status === "unverified");
+
+    if (failingField) {
+      proofStatus = "tampered";
+      proofDetail = `${failingField.name}: ${failingField.detail ?? "check failed"}`;
+    } else if (unverifiedField) {
+      proofStatus = "unverified";
+      proofDetail = `${unverifiedField.name}: ${unverifiedField.detail ?? "could not verify"}`;
+    } else {
+      proofStatus = "verified";
+      proofDetail = "All proof integrity checks passed";
+    }
+  }
+
+  // ── Claim reconciliation ─────────────────────────────────────────────────
+  let claimStatus: ClaimStatus;
+
+  if (!input.isWon) {
+    // Non-winning entries never have a claim.
+    claimStatus = "unclaimed";
+  } else if (!input.claimTxHash) {
+    claimStatus = "unclaimed";
+  } else if (input.claimTxSuccessful === undefined) {
+    // txHash exists but we couldn't fetch the result (RPC unavailable or still indexing).
+    claimStatus = "pending";
+  } else if (input.claimTxSuccessful) {
+    claimStatus = "claimed";
+  } else {
+    claimStatus = "failed";
+  }
+
+  return { proofStatus, proofDetail, claimStatus };
+}
+
 // ─── Fetch-based RPC Client ───────────────────────────────────────────────────
 
 export function createFetchRpcClient(rpcUrl: string): StellarRpcClient {

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -22,7 +22,7 @@ import { writeFileSync, readFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execSync } from "child_process";
-import { DeploymentManifestSchema } from "../lib/deployment-manifest.js";
+import { DeploymentManifestSchema, assertGovernanceValid } from "../lib/deployment-manifest.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -83,6 +83,14 @@ const manifest = {
     buildTimestamp: new Date().toISOString(),
     contractWasmHash: env("CONTRACT_WASM_HASH"),
   },
+  ...(env("GOVERNANCE_ADMIN_AUTHORITY") ? {
+    governance: {
+      signerThreshold: Number(env("GOVERNANCE_SIGNER_THRESHOLD", "1")),
+      adminAuthority: env("GOVERNANCE_ADMIN_AUTHORITY"),
+      upgradeAuthority: env("GOVERNANCE_UPGRADE_AUTHORITY") || env("GOVERNANCE_ADMIN_AUTHORITY"),
+      ...(env("GOVERNANCE_PAUSE_AUTHORITY") ? { pauseAuthority: env("GOVERNANCE_PAUSE_AUTHORITY") } : {}),
+    },
+  } : {}),
 };
 
 const result = DeploymentManifestSchema.safeParse(manifest);
@@ -104,8 +112,19 @@ if (existsSync(outPath)) {
   }
 }
 
+// Validate governance authorities against expected env vars when present.
+try {
+  assertGovernanceValid(result.data, process.env);
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}
+
 writeFileSync(outPath, JSON.stringify(result.data, null, 2) + "\n");
 console.log(`Wrote deployment-manifest.json v${manifest.version} (${manifest.environment})`);
 console.log(`  Network: ${manifest.network.name} (${manifest.network.passphrase.substring(0, 30)}...)`);
 console.log(`  Commit:  ${manifest.build.commitSha}`);
 console.log(`  Drip pool: ${manifest.contracts.dripPool.contractId || "(not set)"}`);
+if (result.data.governance) {
+  console.log(`  Governance: threshold=${result.data.governance.signerThreshold}, admin=${result.data.governance.adminAuthority}`);
+}

--- a/stellar-wallet-connect/src/components/MobileBottomNav.tsx
+++ b/stellar-wallet-connect/src/components/MobileBottomNav.tsx
@@ -11,9 +11,40 @@ const NAV_ITEMS = [
 export interface MobileBottomNavProps {
   currentPath: string;
   onNavigate: (href: string) => void;
+  /**
+   * When true, the user is mid-transaction (signing, submitting, confirming).
+   * Navigation taps show a warning dialog asking the user to confirm they want
+   * to leave — the transaction state will be persisted and can be recovered on
+   * return (#633).
+   */
+  txBusy?: boolean;
+  /**
+   * Human-readable label for the active transaction stage, shown in the
+   * navigation-guard prompt (e.g. "awaiting-signature").  Falls back to a
+   * generic message when absent.
+   */
+  txStageLabel?: string;
 }
 
-export const MobileBottomNav: FC<MobileBottomNavProps> = ({ currentPath, onNavigate }) => {
+export const MobileBottomNav: FC<MobileBottomNavProps> = ({
+  currentPath,
+  onNavigate,
+  txBusy = false,
+  txStageLabel,
+}) => {
+  function handleNavClick(href: string) {
+    if (txBusy) {
+      const stage = txStageLabel ? ` (${txStageLabel})` : "";
+      const confirmed = window.confirm(
+        `You have a transaction in progress${stage}.\n\n` +
+          "Navigating away will not cancel it — your progress will be saved and you can recover it when you return.\n\n" +
+          "Leave anyway?"
+      );
+      if (!confirmed) return;
+    }
+    onNavigate(href);
+  }
+
   return (
     <nav
       aria-label="Mobile navigation"
@@ -33,7 +64,7 @@ export const MobileBottomNav: FC<MobileBottomNavProps> = ({ currentPath, onNavig
             <button
               key={href}
               type="button"
-              onClick={() => onNavigate(href)}
+              onClick={() => handleNavClick(href)}
               className="group relative flex flex-col items-center gap-0.5 px-3 py-1 transition-all"
               aria-current={isActive ? "page" : undefined}
             >

--- a/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
+++ b/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
@@ -7,7 +7,7 @@ import {
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
 import { DataRefreshControl } from "../../components/DataRefreshControl";
-import type { RewardHistoryEntry, RewardOutcome } from "../contract/types";
+import type { RewardHistoryEntry, RewardOutcome, ProofStatus } from "../contract/types";
 import { explorerTxUrl, formatAmount, formatDate, truncateAddress, type StellarNetwork } from "../lib/format";
 import { TransactionTimeline } from "../../components/TransactionTimeline";
 import type { TxFlowResult } from "../lib/txStateMachine";
@@ -49,6 +49,43 @@ const OutcomeBadge: FC<{ status: RewardOutcome }> = ({ status }) => {
   const badge = OUTCOME_BADGE[status];
   return (
     <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${badge.className}`}>
+      {badge.label}
+    </span>
+  );
+};
+
+const PROOF_BADGE: Record<ProofStatus, { label: string; className: string; title: string }> = {
+  verified: { label: "Proof ✓", className: "bg-emerald-500/10 text-emerald-400 border border-emerald-500/30", title: "Draw proof verified" },
+  tampered: { label: "Proof ✗", className: "bg-red-500/10 text-red-400 border border-red-500/30", title: "Draw proof integrity check failed" },
+  missing: { label: "No proof", className: "bg-gray-500/10 text-gray-400 border border-gray-600/30", title: "No draw proof found for this round" },
+  pending: { label: "Proof pending", className: "bg-amber-500/10 text-amber-400 border border-amber-500/30", title: "Draw proof not yet available" },
+  unverified: { label: "Proof ?", className: "bg-gray-500/10 text-gray-400 border border-gray-600/30", title: "Proof present but could not be fully verified" },
+};
+
+const CLAIM_STATUS_BADGE: Record<string, { label: string; className: string }> = {
+  claimed: { label: "Claimed", className: "bg-emerald-500/10 text-emerald-400" },
+  pending: { label: "Claim pending", className: "bg-amber-500/10 text-amber-400" },
+  unclaimed: { label: "Unclaimed", className: "bg-gray-500/10 text-gray-300" },
+  failed: { label: "Claim failed", className: "bg-red-500/10 text-red-400" },
+};
+
+const ProofBadge: FC<{ proofStatus: ProofStatus; detail?: string }> = ({ proofStatus, detail }) => {
+  const badge = PROOF_BADGE[proofStatus];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badge.className}`}
+      title={detail || badge.title}
+      aria-label={detail || badge.title}
+    >
+      {badge.label}
+    </span>
+  );
+};
+
+const ClaimStatusBadge: FC<{ claimStatus: string }> = ({ claimStatus }) => {
+  const badge = CLAIM_STATUS_BADGE[claimStatus] ?? { label: claimStatus, className: "bg-gray-500/10 text-gray-400" };
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badge.className}`}>
       {badge.label}
     </span>
   );
@@ -134,6 +171,8 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
               <th scope="col" className="px-4 py-3 font-medium">Reward</th>
               <th scope="col" className="px-4 py-3 font-medium">Winner</th>
               <th scope="col" className="px-4 py-3 font-medium">Status</th>
+              <th scope="col" className="px-4 py-3 font-medium">Proof</th>
+              <th scope="col" className="px-4 py-3 font-medium">Claim</th>
               <th scope="col" className="px-4 py-3 font-medium">Tx</th>
               {onClaim && <th scope="col" className="px-4 py-3 font-medium">Action</th>}
             </tr>
@@ -148,6 +187,20 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
                   {entry.winnerAddress ? truncateAddress(entry.winnerAddress) : "—"}
                 </td>
                 <td className="px-4 py-3"><OutcomeBadge status={entry.status} /></td>
+                <td className="px-4 py-3">
+                  {entry.proofStatus ? (
+                    <ProofBadge proofStatus={entry.proofStatus} detail={entry.proofDetail} />
+                  ) : (
+                    <span className="text-gray-600 text-xs">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  {entry.claimStatus ? (
+                    <ClaimStatusBadge claimStatus={entry.claimStatus} />
+                  ) : (
+                    <span className="text-gray-600 text-xs">—</span>
+                  )}
+                </td>
                 <td className="px-4 py-3"><TxLink txHash={entry.txHash} network={network} /></td>
                 {onClaim && (
                   <td className="px-4 py-3">
@@ -192,6 +245,18 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
                   {entry.winnerAddress ? truncateAddress(entry.winnerAddress) : "—"}
                 </dd>
               </div>
+              {entry.proofStatus && (
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-400">Proof</dt>
+                  <dd><ProofBadge proofStatus={entry.proofStatus} detail={entry.proofDetail} /></dd>
+                </div>
+              )}
+              {entry.claimStatus && (
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-400">Claim</dt>
+                  <dd><ClaimStatusBadge claimStatus={entry.claimStatus} /></dd>
+                </div>
+              )}
               <div className="flex justify-between gap-2">
                 <dt className="text-gray-400">Tx</dt>
                 <dd><TxLink txHash={entry.txHash} network={network} /></dd>

--- a/stellar-wallet-connect/src/vault/contract/types.ts
+++ b/stellar-wallet-connect/src/vault/contract/types.ts
@@ -45,6 +45,18 @@ export interface UserPosition {
 
 export type RewardOutcome = "won" | "no_win" | "pending";
 
+/**
+ * Proof reconciliation status attached to a reward entry (#634).
+ *
+ * - `verified`   — draw proof exists and all integrity checks pass.
+ * - `tampered`   — proof exists but one or more hash checks failed.
+ * - `missing`    — no proof record found for this round/draw.
+ * - `pending`    — proof not yet available (draw not finalised).
+ * - `unverified` — proof present but optional fields (e.g. HMAC secret) were
+ *                  not supplied, so full verification could not complete.
+ */
+export type ProofStatus = "verified" | "tampered" | "missing" | "pending" | "unverified";
+
 export interface RewardHistoryEntry {
   id: string;
   poolId: string;
@@ -58,6 +70,29 @@ export interface RewardHistoryEntry {
   winnerAddress: string | null;
   /** On-chain reference for explorer links, when available. */
   txHash: string | null;
+  /**
+   * Round ID on-chain (links to draw proof). Added in #634.
+   * Absent on legacy entries that pre-date proof recording.
+   */
+  roundId?: number;
+  /**
+   * Draw proof integrity status resolved at display time (#634).
+   * Absent when the proof system is not enabled for this environment.
+   */
+  proofStatus?: ProofStatus;
+  /**
+   * Human-readable detail about the proof check (first failing field or
+   * "verified" for a clean proof). Used for tooltip/ARIA descriptions.
+   */
+  proofDetail?: string;
+  /**
+   * Wallet claim status cross-checked against wallet/indexer data (#634).
+   * - `claimed`   — txHash confirmed on-chain as successful
+   * - `pending`   — txHash present but not yet confirmed
+   * - `unclaimed` — won but no claim tx recorded
+   * - `failed`    — claim tx found but reverted/failed
+   */
+  claimStatus?: "claimed" | "pending" | "unclaimed" | "failed";
 }
 
 export type PoolActionType = "create" | "join" | "drip" | "claim" | "withdraw";

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.test.tsx
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.test.tsx
@@ -220,3 +220,74 @@ describe("useTxFlow", () => {
     expect(result.current.state).toEqual({ stage: "success", txHash: "tx-retry" });
   });
 });
+
+// ─── usePersistentTxFlow (#631) ───────────────────────────────────────────────
+
+describe("usePersistentTxFlow – persistence and recovery", () => {
+  const scopeKey = "test-wallet:testnet";
+  const STORAGE_KEY = `vaultquest:pending_tx:${scopeKey}`;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("clears storage on success", async () => {
+    const { usePersistentTxFlow } = await import("./txStateMachine");
+    const client = clientWithSubmit(async () => ({ txHash: "tx-ok", status: "submitted" }));
+    const { result } = renderHook(() => usePersistentTxFlow({ scopeKey }));
+
+    await act(async () => {
+      await result.current.run(client, "claim", input, { indexingDelayMs: 0 });
+    });
+
+    expect(result.current.state.stage).toBe("success");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("clears storage on failure", async () => {
+    const { usePersistentTxFlow } = await import("./txStateMachine");
+    const err = new Error("RPC fail");
+    (err as any).kind = "rpc_failure";
+    const client = clientWithSubmit(async () => { throw err; });
+    const { result } = renderHook(() => usePersistentTxFlow({ scopeKey }));
+
+    await act(async () => {
+      await result.current.run(client, "claim", input, { indexingDelayMs: 0 });
+    });
+
+    expect(result.current.state.stage).toBe("failed");
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("surfaces a recovered interrupted transaction as failed with a descriptive message", async () => {
+    const { usePersistentTxFlow } = await import("./txStateMachine");
+    const record = { stage: "confirming", txHash: "tx-interrupted", savedAt: Date.now() };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+
+    const { result } = renderHook(() => usePersistentTxFlow({ scopeKey }));
+
+    await waitFor(() => expect(result.current.state.stage).toBe("failed"));
+    expect(result.current.recovered).toBe(true);
+    if (result.current.state.stage === "failed") {
+      expect(result.current.state.message).toMatch(/tx-interrupted/);
+    }
+  });
+
+  it("ignores stale persisted records older than 24 hours", async () => {
+    const { usePersistentTxFlow } = await import("./txStateMachine");
+    const staleRecord = {
+      stage: "confirming",
+      txHash: "tx-stale",
+      savedAt: Date.now() - 25 * 60 * 60 * 1000,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(staleRecord));
+
+    const { result } = renderHook(() => usePersistentTxFlow({ scopeKey }));
+
+    // Wait briefly; state should stay idle since record is expired.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.state.stage).toBe("idle");
+    expect(result.current.recovered).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
@@ -6,7 +6,7 @@
  * invalid transitions can be regression-tested without mounting React.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { TimelineStage } from "../../components/TransactionTimeline";
 import type { PoolActionInput, PoolActionType, VaultContractClient } from "../contract/types";
 
@@ -169,6 +169,146 @@ function withTimeout(
 function stateFailureFallback(state: TxFlowState): ActiveTxStage {
   if (isActiveState(state)) return state.stage;
   return "confirming";
+}
+
+// ─── Persistence helpers (#631) ───────────────────────────────────────────────
+
+interface PersistedTxRecord {
+  txHash: string | null;
+  stage: ActiveTxStage;
+  savedAt: number;
+}
+
+const PERSIST_KEY_PREFIX = "vaultquest:pending_tx:";
+const PERSIST_TTL_MS = 24 * 60 * 60 * 1000; // 24 h
+
+function persistTxRecord(scopeKey: string, record: PersistedTxRecord): void {
+  try {
+    localStorage.setItem(PERSIST_KEY_PREFIX + scopeKey, JSON.stringify(record));
+  } catch {
+    // quota exceeded or SSR — ignore
+  }
+}
+
+function loadPersistedTxRecord(scopeKey: string): PersistedTxRecord | null {
+  try {
+    const raw = localStorage.getItem(PERSIST_KEY_PREFIX + scopeKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedTxRecord;
+    if (Date.now() - parsed.savedAt > PERSIST_TTL_MS) {
+      localStorage.removeItem(PERSIST_KEY_PREFIX + scopeKey);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function clearPersistedTxRecord(scopeKey: string): void {
+  try {
+    localStorage.removeItem(PERSIST_KEY_PREFIX + scopeKey);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Returns a sorted, deduplicated list of in-flight tx hashes seen in this
+ * session. Prevents duplicate wallet submissions from creating parallel flows.
+ */
+const _seenHashes = new Set<string>();
+export function markTxHashSeen(txHash: string): boolean {
+  if (_seenHashes.has(txHash)) return false;
+  _seenHashes.add(txHash);
+  return true;
+}
+
+export interface PersistentTxFlowOptions {
+  /**
+   * Unique scope key: typically `${walletAddress}:${network}` so each wallet
+   * on each network has its own recovery slot.
+   */
+  scopeKey: string;
+}
+
+export interface PersistentTxFlowResult extends TxFlowResult {
+  /** True when the flow was recovered from a previous interrupted session. */
+  recovered: boolean;
+}
+
+/**
+ * Wraps `useTxFlow` with localStorage persistence (#631).
+ *
+ * On mount: if a non-terminal tx record exists in storage (tab close,
+ * navigation away mid-flow), the state is restored to `failed` with a
+ * recovery message so the user sees the last known stage and can retry or
+ * check the explorer.  Pending hashes that reach `success` or `failed`
+ * clear their record automatically.
+ */
+export function usePersistentTxFlow({ scopeKey }: PersistentTxFlowOptions): PersistentTxFlowResult {
+  const flow = useTxFlow();
+  const [recovered, setRecovered] = useState(false);
+
+  useEffect(() => {
+    const record = loadPersistedTxRecord(scopeKey);
+    if (!record) return;
+
+    // A previously-pending tx was interrupted. Surface it as failed so the
+    // user knows to verify on-chain rather than silently losing the status.
+    clearPersistedTxRecord(scopeKey);
+    flow.reset();
+    // We cannot drive the machine to "preparing" → ... → "failed" purely from
+    // localStorage, so we directly inject the terminal failure state.  The
+    // txHash, if present, was already submitted — the user should verify it.
+    const message =
+      record.txHash
+        ? `Transaction interrupted at '${record.stage}' stage. ` +
+          `Hash ${record.txHash.slice(0, 12)}… may have landed — check the explorer.`
+        : `Transaction interrupted at '${record.stage}' stage before a hash was recorded.`;
+
+    // Use the internal transition sequence to reach "failed" legally:
+    // idle → preparing → awaiting-signature → failed
+    // We call reset first (already done), then drive through the minimal path.
+    // Because useTxFlow exposes `run`, not `transition`, we replicate only the
+    // final state via a synthetic call path using the public reset + a no-op
+    // run that immediately throws. This keeps the stateRef consistent.
+    (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (flow as any).run(
+        {
+          submitAction: async () => {
+            const err: Error & { kind?: string } = new Error(message);
+            err.kind = record.txHash ? "confirmation_timeout" : "rpc_failure";
+            throw err;
+          },
+        },
+        "claim",
+        { poolId: "", walletAddress: "" },
+        { confirmationTimeoutMs: 0, indexingDelayMs: 0 },
+      );
+    })().catch(() => undefined);
+
+    setRecovered(true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopeKey]);
+
+  // Persist whenever the state advances to a non-idle, non-terminal stage.
+  useEffect(() => {
+    const { state } = flow;
+    if (state.stage === "idle" || state.stage === "success" || state.stage === "failed") {
+      clearPersistedTxRecord(scopeKey);
+      return;
+    }
+    const record: PersistedTxRecord = {
+      stage: state.stage as ActiveTxStage,
+      txHash: "txHash" in state ? (state.txHash ?? null) : null,
+      savedAt: Date.now(),
+    };
+    persistTxRecord(scopeKey, record);
+  }, [flow, flow.state, scopeKey]);
+
+  return { ...flow, recovered };
 }
 
 export function useTxFlow(): TxFlowResult {

--- a/tests/deployment-manifest.test.ts
+++ b/tests/deployment-manifest.test.ts
@@ -5,6 +5,8 @@ import {
   assertContractSpecNotDeprecated,
   DEPRECATED_CONTRACT_SPEC_HASHES,
   clearManifestCache,
+  validateManifestGovernance,
+  assertGovernanceValid,
   type DeploymentManifest,
 } from "@/lib/deployment-manifest";
 
@@ -373,5 +375,101 @@ describe("rotation scenarios", () => {
     };
     const mismatches = validateManifestAgainstEnv(VALID_MANIFEST, env);
     expect(mismatches.some((m) => m.field === "network.passphrase")).toBe(true);
+  });
+});
+
+// ─── Governance validation (#632) ─────────────────────────────────────────────
+
+const GOVERNANCE_MANIFEST: DeploymentManifest = {
+  ...VALID_MANIFEST,
+  governance: {
+    signerThreshold: 2,
+    adminAuthority: "GADMIN1234567890ABCDEF",
+    upgradeAuthority: "GUPGRADE1234567890ABCDEF",
+    pauseAuthority: "GPAUSE1234567890ABCDEF",
+  },
+};
+
+describe("validateManifestGovernance", () => {
+  it("returns empty array when no governance block is present (non-mainnet)", () => {
+    const violations = validateManifestGovernance(VALID_MANIFEST, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  it("throws for mainnet manifest missing governance block", () => {
+    const mainnetManifest: DeploymentManifest = {
+      ...VALID_MANIFEST,
+      network: { ...VALID_MANIFEST.network, name: "mainnet" },
+    };
+    expect(() => validateManifestGovernance(mainnetManifest, {})).toThrow(/required for mainnet/i);
+  });
+
+  it("returns empty array when env vars are not set (no expected values to compare)", () => {
+    const violations = validateManifestGovernance(GOVERNANCE_MANIFEST, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  it("reports violation when adminAuthority does not match EXPECTED_ADMIN_AUTHORITY", () => {
+    const env = { EXPECTED_ADMIN_AUTHORITY: "GDIFFERENT1234567890ABCDEF" };
+    const violations = validateManifestGovernance(GOVERNANCE_MANIFEST, env);
+    const v = violations.find((x) => x.field === "governance.adminAuthority");
+    expect(v).toBeTruthy();
+    expect(v?.manifestValue).toBe("GADMIN1234567890ABCDEF");
+    expect(v?.expectedValue).toBe("GDIFFERENT1234567890ABCDEF");
+  });
+
+  it("reports violation when signerThreshold does not match EXPECTED_SIGNER_THRESHOLD", () => {
+    const env = { EXPECTED_SIGNER_THRESHOLD: "3" };
+    const violations = validateManifestGovernance(GOVERNANCE_MANIFEST, env);
+    const v = violations.find((x) => x.field === "governance.signerThreshold");
+    expect(v).toBeTruthy();
+    expect(v?.manifestValue).toBe("2");
+  });
+
+  it("passes when all authority env vars match manifest values", () => {
+    const env = {
+      EXPECTED_ADMIN_AUTHORITY: "GADMIN1234567890ABCDEF",
+      EXPECTED_UPGRADE_AUTHORITY: "GUPGRADE1234567890ABCDEF",
+      EXPECTED_PAUSE_AUTHORITY: "GPAUSE1234567890ABCDEF",
+      EXPECTED_SIGNER_THRESHOLD: "2",
+    };
+    const violations = validateManifestGovernance(GOVERNANCE_MANIFEST, env);
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe("assertGovernanceValid", () => {
+  it("throws when violations are found", () => {
+    const env = { EXPECTED_ADMIN_AUTHORITY: "GWRONG" };
+    expect(() => assertGovernanceValid(GOVERNANCE_MANIFEST, env)).toThrow(/Governance authority validation failed/);
+  });
+
+  it("does not throw when all checks pass", () => {
+    const env = {
+      EXPECTED_ADMIN_AUTHORITY: "GADMIN1234567890ABCDEF",
+      EXPECTED_UPGRADE_AUTHORITY: "GUPGRADE1234567890ABCDEF",
+      EXPECTED_SIGNER_THRESHOLD: "2",
+    };
+    expect(() => assertGovernanceValid(GOVERNANCE_MANIFEST, env)).not.toThrow();
+  });
+});
+
+describe("DeploymentManifestSchema – governance field", () => {
+  it("accepts a manifest with a valid governance block", () => {
+    const result = DeploymentManifestSchema.safeParse(GOVERNANCE_MANIFEST);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects governance with signerThreshold below 1", () => {
+    const result = DeploymentManifestSchema.safeParse({
+      ...GOVERNANCE_MANIFEST,
+      governance: { ...GOVERNANCE_MANIFEST.governance!, signerThreshold: 0 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a manifest without governance (optional field)", () => {
+    const result = DeploymentManifestSchema.safeParse(VALID_MANIFEST);
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/draw-proof.test.ts
+++ b/tests/draw-proof.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import {
   canonicalize,
   computeHash,
@@ -467,5 +467,94 @@ describe("assembleDrawProof", () => {
     expect(proof.snapshot.participantCount).toBe(1);
     const result = await verifyProofIntegrity(proof, SIGNING_SECRET);
     expect(result.verified).toBe(true);
+  });
+});
+
+// ─── reconcileRewardEntry (#634) ──────────────────────────────────────────────
+
+import { reconcileRewardEntry } from "@/lib/draw-proof-verifier";
+
+describe("reconcileRewardEntry", () => {
+  let baseProof: DrawProof;
+
+  beforeAll(async () => {
+    baseProof = await assembleSignedProof(
+      await makeInput({
+        participants: PARTICIPANTS,
+        poolState: {},
+        winnerAddress: PARTICIPANTS[0].address,
+        payoutAmount: "50",
+        payoutAsset: "USDC",
+        payoutConfirmed: true,
+      })
+    );
+  });
+
+  it("verifies a clean proof and a confirmed claim tx", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 1,
+      proof: baseProof,
+      isWon: true,
+      claimTxHash: "tx-abc",
+      claimTxSuccessful: true,
+    });
+    expect(result.proofStatus).toBe("verified");
+    expect(result.claimStatus).toBe("claimed");
+  });
+
+  it("reports tampered when round ID does not match", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 999,
+      proof: baseProof,
+      isWon: true,
+      claimTxHash: null,
+      claimTxSuccessful: undefined,
+    });
+    expect(result.proofStatus).toBe("tampered");
+    expect(result.proofDetail).toMatch(/round id mismatch/i);
+    expect(result.claimStatus).toBe("unclaimed");
+  });
+
+  it("reports missing when no proof provided for a won entry", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 1,
+      proof: null,
+      isWon: true,
+      claimTxHash: null,
+    });
+    expect(result.proofStatus).toBe("missing");
+    expect(result.claimStatus).toBe("unclaimed");
+  });
+
+  it("reports pending proof for a pending (not-won) entry", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 1,
+      proof: undefined,
+      isWon: false,
+      claimTxHash: null,
+    });
+    expect(result.proofStatus).toBe("pending");
+  });
+
+  it("reports claim pending when txHash exists but result unknown", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 1,
+      proof: baseProof,
+      isWon: true,
+      claimTxHash: "tx-pending",
+      claimTxSuccessful: undefined,
+    });
+    expect(result.claimStatus).toBe("pending");
+  });
+
+  it("reports claim failed when tx was unsuccessful", async () => {
+    const result = await reconcileRewardEntry({
+      roundId: 1,
+      proof: baseProof,
+      isWon: true,
+      claimTxHash: "tx-failed",
+      claimTxSuccessful: false,
+    });
+    expect(result.claimStatus).toBe("failed");
   });
 });


### PR DESCRIPTION
Closes #631
Closes #632
Closes #633
Closes #634

## Summary

- **#631**: Added `usePersistentTxFlow` hook wrapping `useTxFlow` with localStorage persistence keyed by `${walletAddress}:${network}`. Pending transaction state (stage + txHash) is saved on every transition and cleared on success/failure. On mount, stale interrupted records are recovered as `failed` with a message pointing the user to the explorer — tab close and route change no longer silently lose in-flight tx state.

- **#632**: Extended `DeploymentManifestSchema` with an optional `governance` block (`signerThreshold`, `adminAuthority`, `upgradeAuthority`, `pauseAuthority`). Added `validateManifestGovernance()` and `assertGovernanceValid()` functions that compare manifest authorities against `EXPECTED_*` env vars and throw on mismatch. Mainnet manifests require the governance block. `generate-manifest.ts` reads `GOVERNANCE_*` env vars and runs the authority check before writing.

- **#633**: Added `txBusy` and `txStageLabel` props to `MobileBottomNav`. Navigation taps while `txBusy=true` show a `window.confirm` guard explaining the tx is in progress and will be recoverable on return — preventing accidental abandonment of unsigned actions without blocking routing entirely.

- **#634**: Extended `RewardHistoryEntry` type with `roundId`, `proofStatus`, `proofDetail`, and `claimStatus` fields. Added `reconcileRewardEntry()` to `draw-proof-verifier.ts` — a pure function that takes pre-fetched proof and claim-tx data, runs `verifyProofIntegrity`, and returns typed `ProofStatus`/`ClaimStatus` results. `RewardHistory` renders proof and claim columns in both desktop table and mobile card views.