### PR TITLE
Add vault metadata discovery schema

### DIFF
--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -6,6 +6,7 @@ import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
 import { useTranslation } from "next-i18next";
 import { Sparkles } from "lucide-react";
+import { VaultApiClient } from "@vaultquest/stellar-wallet-connect/src/vault/data/apiClient";
 import OnboardingCards from "@/components/app/OnboardingCards";
 import PublicStatsBar from "@/components/app/PublicStatsBar";
 import VaultMetricsCards from "@/components/app/VaultMetricsCards";
@@ -101,9 +102,28 @@ export default function AppDashboardPage() {
   const [hasJoinedVault] = useState(false);
   const [onboardingForceOpen, setOnboardingForceOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [vaultMetadata, setVaultMetadata] = useState([]);
 
   useEffect(() => {
     setMounted(true);
+    const client = new VaultApiClient();
+    let active = true;
+
+    client.listVaultMetadata()
+      .then((records) => {
+        if (active) {
+          setVaultMetadata(records.slice(0, 3));
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setVaultMetadata([]);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
   }, []);
 
   const isWinner = false;
@@ -163,6 +183,35 @@ export default function AppDashboardPage() {
 
       {/* Vault Metrics (full-width, below hero) */}
       <VaultMetricsCards />
+
+      {vaultMetadata.length > 0 && (
+        <section className="vq-glass p-6">
+          <div className="flex items-center justify-between gap-4 pb-4 border-b border-vault-border/30">
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-vault-muted">Canonical vault metadata</p>
+              <h2 className="mt-2 text-xl font-semibold text-vault-text">Factory-backed discovery signals</h2>
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            {vaultMetadata.map((item) => (
+              <div key={item.id} className="rounded-xl border border-vault-border bg-vault-surface/60 p-4">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold text-vault-text">{item.id}</span>
+                  <span className="rounded-full bg-vault-accent/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-vault-accent">
+                    v{item.metadata_version ?? 1}
+                  </span>
+                </div>
+                <dl className="mt-3 space-y-2 text-sm text-vault-muted">
+                  <div className="flex justify-between gap-3"><dt>Risk</dt><dd className="font-medium text-vault-text">{item.risk_tier ?? "unknown"}</dd></div>
+                  <div className="flex justify-between gap-3"><dt>Strategy</dt><dd className="font-medium text-vault-text">{item.strategy ?? "unknown"}</dd></div>
+                  <div className="flex justify-between gap-3"><dt>Asset</dt><dd className="font-medium text-vault-text">{item.accepted_asset ?? "unknown"}</dd></div>
+                  <div className="flex justify-between gap-3"><dt>Status</dt><dd className="font-medium text-vault-text">{item.operational_status ?? "unknown"}</dd></div>
+                </dl>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Main Grid */}
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">

--- a/contracts/vault-factory/src/lib.rs
+++ b/contracts/vault-factory/src/lib.rs
@@ -49,6 +49,7 @@ pub enum Error {
     AssetNotApproved = 5,    // asset not on the admin-managed allowlist
     WasmHashNotApproved = 6, // deploying with anything but the currently-approved drip-pool build
     PoolNotFound = 7,
+    MetadataStale = 8,
 }
 
 #[derive(Clone)]
@@ -70,6 +71,26 @@ pub struct PoolMetadata {
     pub wasm_hash: BytesN<32>,
     pub deployed_at_ledger: u32,
     pub active: bool,
+    pub risk_tier: Symbol,
+    pub strategy: Symbol,
+    pub lockup_days: u32,
+    pub fee_bps: u32,
+    pub accepted_asset: Address,
+    pub operational_status: Symbol,
+    pub metadata_version: u32,
+    pub metadata_updated_at_ledger: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct PoolMetadataUpdate {
+    pub risk_tier: Symbol,
+    pub strategy: Symbol,
+    pub lockup_days: u32,
+    pub fee_bps: u32,
+    pub accepted_asset: Address,
+    pub operational_status: Symbol,
+    pub expected_version: u32,
 }
 
 /// Registry event payload (#507). Published as a single-symbol-topic event
@@ -87,9 +108,30 @@ pub struct PoolDeployedEvent {
     pub admin: Address,
     pub asset: Address,
     pub wasm_hash: BytesN<32>,
+    pub risk_tier: Symbol,
+    pub strategy: Symbol,
+    pub lockup_days: u32,
+    pub fee_bps: u32,
+    pub accepted_asset: Address,
+    pub operational_status: Symbol,
+    pub metadata_version: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct PoolMetadataUpdatedEvent {
+    pub salt: BytesN<32>,
+    pub risk_tier: Symbol,
+    pub strategy: Symbol,
+    pub lockup_days: u32,
+    pub fee_bps: u32,
+    pub accepted_asset: Address,
+    pub operational_status: Symbol,
+    pub metadata_version: u32,
 }
 
 const FACTORY_POOL_DEPLOYED_TOPIC: Symbol = symbol_short!("fpooldep");
+const FACTORY_POOL_METADATA_UPDATED_TOPIC: Symbol = symbol_short!("fmetaup");
 
 #[contract]
 pub struct VaultFactory;
@@ -200,10 +242,18 @@ impl VaultFactory {
         let metadata = PoolMetadata {
             pool_address: deployed_address.clone(),
             admin: pool_admin,
-            asset,
-            wasm_hash,
+            asset: asset.clone(),
+            wasm_hash: wasm_hash.clone(),
             deployed_at_ledger: env.ledger().sequence(),
             active: true,
+            risk_tier: symbol_short!("medium"),
+            strategy: symbol_short!("default"),
+            lockup_days: 0,
+            fee_bps: 0,
+            accepted_asset: asset.clone(),
+            operational_status: symbol_short!("active"),
+            metadata_version: 1,
+            metadata_updated_at_ledger: env.ledger().sequence(),
         };
         env.storage()
             .instance()
@@ -216,15 +266,69 @@ impl VaultFactory {
         env.events().publish(
             (FACTORY_POOL_DEPLOYED_TOPIC,),
             PoolDeployedEvent {
-                salt,
+                salt: salt.clone(),
                 pool_address: deployed_address.clone(),
                 admin: metadata.admin.clone(),
                 asset: metadata.asset.clone(),
                 wasm_hash: metadata.wasm_hash.clone(),
+                risk_tier: metadata.risk_tier.clone(),
+                strategy: metadata.strategy.clone(),
+                lockup_days: metadata.lockup_days,
+                fee_bps: metadata.fee_bps,
+                accepted_asset: metadata.accepted_asset.clone(),
+                operational_status: metadata.operational_status.clone(),
+                metadata_version: metadata.metadata_version,
             },
         );
 
         Ok(deployed_address)
+    }
+
+    /// Updates discoverable metadata for an existing pool. Metadata changes are
+    /// versioned so indexers can identify stale or replayed metadata snapshots.
+    pub fn update_pool_metadata(
+        env: Env,
+        caller: Address,
+        salt: BytesN<32>,
+        metadata: PoolMetadataUpdate,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &caller)?;
+        let mut pool = Self::get_pool(env.clone(), salt.clone())?;
+
+        if metadata.expected_version != pool.metadata_version {
+            return Err(Error::MetadataStale);
+        }
+
+        let approved_assets = Self::get_approved_assets(&env);
+        if !approved_assets.contains(&metadata.accepted_asset) {
+            return Err(Error::AssetNotApproved);
+        }
+
+        pool.risk_tier = metadata.risk_tier;
+        pool.strategy = metadata.strategy;
+        pool.lockup_days = metadata.lockup_days;
+        pool.fee_bps = metadata.fee_bps;
+        pool.accepted_asset = metadata.accepted_asset.clone();
+        pool.operational_status = metadata.operational_status;
+        pool.metadata_version += 1;
+        pool.metadata_updated_at_ledger = env.ledger().sequence();
+
+        env.storage().instance().set(&DataKey::PoolMeta(salt.clone()), &pool);
+        env.events().publish(
+            (FACTORY_POOL_METADATA_UPDATED_TOPIC,),
+            PoolMetadataUpdatedEvent {
+                salt,
+                risk_tier: pool.risk_tier.clone(),
+                strategy: pool.strategy.clone(),
+                lockup_days: pool.lockup_days,
+                fee_bps: pool.fee_bps,
+                accepted_asset: pool.accepted_asset.clone(),
+                operational_status: pool.operational_status.clone(),
+                metadata_version: pool.metadata_version,
+            },
+        );
+
+        Ok(())
     }
 
     /// Marks a pool inactive in the registry (does not pause or otherwise

--- a/contracts/vault-factory/src/test.rs
+++ b/contracts/vault-factory/src/test.rs
@@ -81,7 +81,71 @@ fn deploy_pool_succeeds_and_registers_metadata() {
     assert_eq!(meta.admin, pool_admin);
     assert_eq!(meta.asset, approved_asset);
     assert_eq!(meta.wasm_hash, wasm_hash);
+    assert_eq!(meta.accepted_asset, approved_asset);
+    assert_eq!(meta.risk_tier, symbol_short!("medium"));
+    assert_eq!(meta.strategy, symbol_short!("default"));
+    assert_eq!(meta.operational_status, symbol_short!("active"));
+    assert_eq!(meta.metadata_version, 1);
     assert!(meta.active);
+}
+
+#[test]
+fn update_pool_metadata_versions_and_audits_changes() {
+    let (env, client, admin, _wasm_hash) = setup();
+    let pool_admin = Address::generate(&env);
+    let approved_asset = Address::generate(&env);
+    client.approve_asset(&admin, &approved_asset);
+
+    let s = salt(&env, 3);
+    client.deploy_pool(&admin, &s, &pool_admin, &approved_asset);
+
+    let update = PoolMetadataUpdate {
+        risk_tier: symbol_short!("low"),
+        strategy: symbol_short!("stable"),
+        lockup_days: 7,
+        fee_bps: 125,
+        accepted_asset: approved_asset.clone(),
+        operational_status: symbol_short!("paused"),
+        expected_version: 1,
+    };
+
+    client.update_pool_metadata(&admin, &s, &update);
+    let meta = client.get_pool(&s);
+
+    assert_eq!(meta.risk_tier, symbol_short!("low"));
+    assert_eq!(meta.strategy, symbol_short!("stable"));
+    assert_eq!(meta.lockup_days, 7);
+    assert_eq!(meta.fee_bps, 125);
+    assert_eq!(meta.accepted_asset, approved_asset);
+    assert_eq!(meta.operational_status, symbol_short!("paused"));
+    assert_eq!(meta.metadata_version, 2);
+    assert!(meta.metadata_updated_at_ledger >= meta.deployed_at_ledger);
+}
+
+#[test]
+fn update_pool_metadata_rejects_stale_versions() {
+    let (env, client, admin, _wasm_hash) = setup();
+    let pool_admin = Address::generate(&env);
+    let approved_asset = Address::generate(&env);
+    client.approve_asset(&admin, &approved_asset);
+
+    let s = salt(&env, 9);
+    client.deploy_pool(&admin, &s, &pool_admin, &approved_asset);
+
+    let stale = PoolMetadataUpdate {
+        risk_tier: symbol_short!("low"),
+        strategy: symbol_short!("stable"),
+        lockup_days: 30,
+        fee_bps: 50,
+        accepted_asset: approved_asset.clone(),
+        operational_status: symbol_short!("active"),
+        expected_version: 99,
+    };
+
+    assert_eq!(
+        client.try_update_pool_metadata(&admin, &s, &stale),
+        Err(Ok(Error::MetadataStale))
+    );
 }
 
 #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,6 +126,20 @@ The frontend is authoritative for:
 - Wallet connection state and signed transaction submission.
 - Local view state until the backend or contract confirms final results.
 
+### Canonical vault metadata
+
+Vault discovery metadata is sourced from the factory registry and indexed event stream, not from local mock data. The canonical fields are:
+
+- `risk_tier`
+- `strategy`
+- `lockup_days`
+- `fee_bps`
+- `accepted_asset`
+- `operational_status`
+- `metadata_version`
+
+The factory persists this metadata with each pool record and increments a version whenever the metadata is updated. Indexers and the API layer only surface the latest versioned record so stale snapshots are rejected during reconciliation and rendered as out-of-date instead of silently replacing the canonical metadata.
+
 ## Configuration boundaries
 
 VaultQuest deployments are boundary-driven by configuration:

--- a/stellar-wallet-connect/src/vault/contract/types.ts
+++ b/stellar-wallet-connect/src/vault/contract/types.ts
@@ -26,6 +26,14 @@ export interface PoolSummary {
   opensAt: string | null;
   locksAt: string | null;
   drawsAt: string | null;
+  /** Canonical discoverable vault metadata from the factory/indexer. */
+  riskTier?: string;
+  strategy?: string;
+  lockupDays?: number;
+  feeBps?: number;
+  acceptedAsset?: string;
+  operationalStatus?: string;
+  metadataVersion?: number;
 }
 
 export interface SavedPoolEntry extends PoolSummary {

--- a/stellar-wallet-connect/src/vault/data/apiClient.ts
+++ b/stellar-wallet-connect/src/vault/data/apiClient.ts
@@ -20,6 +20,17 @@ export interface TransactionStatusView {
 
 type ApiEnvelope<T> = { data: T };
 
+export interface VaultMetadataRecord {
+  id: string;
+  risk_tier?: string | null;
+  strategy?: string | null;
+  lockup_days?: number | null;
+  fee_bps?: number | null;
+  accepted_asset?: string | null;
+  operational_status?: string | null;
+  metadata_version?: number | null;
+}
+
 type SavedPoolApiRecord = {
   id: string;
   wallet_address: string;
@@ -138,6 +149,23 @@ export class VaultApiClient {
     const body = await parseJsonResponse<ApiEnvelope<PoolSummary[]>>(
       await fetch(this.url("/pools"), { signal: options?.signal }),
       "Pool discovery request failed",
+    );
+    return body.data.map((pool) => ({
+      ...pool,
+      riskTier: pool.riskTier ?? pool.risk_tier ?? undefined,
+      strategy: pool.strategy ?? pool.strategy_name ?? undefined,
+      lockupDays: pool.lockupDays ?? pool.lockup_days ?? undefined,
+      feeBps: pool.feeBps ?? pool.fee_bps ?? undefined,
+      acceptedAsset: pool.acceptedAsset ?? pool.accepted_asset ?? undefined,
+      operationalStatus: pool.operationalStatus ?? pool.operational_status ?? undefined,
+      metadataVersion: pool.metadataVersion ?? pool.metadata_version ?? undefined,
+    }));
+  }
+
+  async listVaultMetadata(options?: { signal?: AbortSignal }): Promise<VaultMetadataRecord[]> {
+    const body = await parseJsonResponse<ApiEnvelope<VaultMetadataRecord[]>>(
+      await fetch(this.url("/vault-metadata"), { signal: options?.signal }),
+      "Vault metadata request failed",
     );
     return body.data;
   }


### PR DESCRIPTION
Closes #650 

## Summary

- Add canonical vault metadata to the factory registry so vault discovery can rely on contract-backed fields instead of mock-only data.
- Extend the factory metadata schema to include risk tier, strategy, lockup, fee, accepted asset, operational status, and version tracking.
- Add versioned metadata updates with stale-version rejection to make metadata changes auditable and safe for indexers and API consumers.
- Expose the metadata through the wallet API/client layer and surface it in the dashboard metadata panel.
- Document the metadata source-of-truth flow in the architecture docs.

## Validation

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `pnpm audit` run for dependencies
- [ ] No raw secrets committed
- [ ] Additional contract/backend checks listed below when applicable

## UI Evidence

- [ ] Screenshots attached
- [x] Not applicable

## Notes

- This change introduces canonical vault discovery metadata at the factory layer and versioned update semantics for future metadata changes.
- Metadata updates are gated by the current version so stale indexer or API snapshots are rejected instead of silently overwriting the latest canonical record.
- No new environment variables, contract IDs, or deployment steps were introduced by this change.
- Before/after screenshots are not applicable for this patch because the UI change is limited to metadata exposure and dashboard display, without a user-facing redesign.