### PR TITLE
feat: per-field draw-proof verification, paginated activity export, batched indexer writes

### DIFF
--- a/backend/src/services/ledger.ts
+++ b/backend/src/services/ledger.ts
@@ -54,6 +54,18 @@ export type RecoveryLeaseResult = {
   expired: number;
 };
 
+export interface ReconcileEventInput {
+  txHash: string;
+  sorobanEventId: string;
+  eventPayload: unknown;
+  statusHint: "confirmed" | "reverted";
+}
+
+export interface ReconcileEventOutcome {
+  txHash: string;
+  matched: boolean;
+}
+
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
@@ -420,12 +432,7 @@ export class LedgerService {
     return { items: items as unknown as ActionRecord[], nextCursor };
   }
 
-  async reconcileEvent(input: {
-    txHash: string;
-    sorobanEventId: string;
-    eventPayload: unknown;
-    statusHint: "confirmed" | "reverted";
-  }): Promise<{ matched: boolean }> {
+  async reconcileEvent(input: ReconcileEventInput): Promise<{ matched: boolean }> {
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const row = await tx.actionLedger.findFirst({ where: { txHash: input.txHash } });
 
@@ -482,6 +489,129 @@ export class LedgerService {
 
       await tx.actionLease.deleteMany({ where: { actionId: row.id } });
       return { matched: true };
+    });
+  }
+
+  /**
+   * Batch variant of `reconcileEvent` (#588): reconciles many independent
+   * events in a single transaction instead of N sequential round-trips.
+   *
+   * Outcome semantics are identical to calling `reconcileEvent` per event:
+   *
+   *   - unmatched tx hashes are parked in `pending_events` (createMany with
+   *     skipDuplicates, so re-delivered events from a previous tick are
+   *     silently ignored — same idempotency as the per-event upsert);
+   *   - matched rows transition to confirmed/reverted exactly as before,
+   *     with leases released and the onActionConfirmed callback fired for
+   *     confirmed `select_winner` events;
+   *   - rows already in a terminal state (confirmed/reverted) are skipped
+   *     without rewriting them.
+   *
+   * Only independent events should be batched together (distinct tx hashes).
+   * Risk note: a batch shares one transaction, so it holds row locks for the
+   * whole batch and a single bad row rolls the entire batch back — the
+   * caller (StellarIndexer.tick) batches only events that already decoded
+   * successfully, keeps batches bounded by the indexer's batchSize (default
+   * 50), and never includes quarantined events. Keep batches modest to avoid
+   * long-held transactions on heavily contended tables.
+   */
+  async reconcileEvents(
+    events: ReconcileEventInput[]
+  ): Promise<ReconcileEventOutcome[]> {
+    if (events.length === 0) return [];
+
+    const confirmedSelectWinners: string[] = [];
+
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      const txHashes = [...new Set(events.map((e) => e.txHash))];
+
+      // Single duplicate-detection read for the whole batch instead of one
+      // findFirst per event.
+      const rows = await tx.actionLedger.findMany({
+        where: { txHash: { in: txHashes } },
+        select: { id: true, txHash: true, status: true, actionType: true }
+      });
+      const rowByHash = new Map(rows.map((r) => [r.txHash, r]));
+
+      const outcomes: ReconcileEventOutcome[] = [];
+      const unmatched: ReconcileEventInput[] = [];
+      const pendingUpdates: Array<{
+        id: string;
+        input: ReconcileEventInput;
+        actionType: string;
+      }> = [];
+
+      for (const input of events) {
+        const row = rowByHash.get(input.txHash);
+        if (!row) {
+          unmatched.push(input);
+          outcomes.push({ txHash: input.txHash, matched: false });
+        } else if (row.status === "confirmed" || row.status === "reverted") {
+          // Already terminal — same no-op as reconcileEvent.
+          outcomes.push({ txHash: input.txHash, matched: true });
+        } else {
+          pendingUpdates.push({ id: row.id, input, actionType: row.actionType });
+          outcomes.push({ txHash: input.txHash, matched: true });
+        }
+      }
+
+      if (unmatched.length > 0) {
+        await tx.pendingEvent.createMany({
+          data: unmatched.map((e) => ({
+            txHash: e.txHash,
+            sorobanEventId: e.sorobanEventId,
+            eventPayload: e.eventPayload as object,
+            statusHint: e.statusHint
+          })),
+          skipDuplicates: true
+        });
+      }
+
+      for (const { id, input, actionType } of pendingUpdates) {
+        const confirmed = input.statusHint === "confirmed";
+        await tx.actionLedger.update({
+          where: { id },
+          data: {
+            status: confirmed ? "confirmed" : "reverted",
+            sorobanEventId: input.sorobanEventId,
+            verifiedPayload: input.eventPayload as object,
+            confirmedAt: new Date(),
+            errorCode: confirmed ? null : ERROR_CODES.REVERTED_ON_CHAIN
+          }
+        });
+        await tx.actionLease.deleteMany({ where: { actionId: id } });
+        if (confirmed && actionType === "select_winner") {
+          confirmedSelectWinners.push(id);
+        }
+      }
+
+      return outcomes;
+    }).then(async (outcomes) => {
+      // Non-transactional side effects, applied after the batch commits so a
+      // cache or callback failure can never roll back the DB writes.
+      for (const actionId of confirmedSelectWinners) {
+        try {
+          this.onActionConfirmedCallback?.(actionId, "select_winner");
+        } catch {
+          // callback errors should not break reconciliation
+        }
+      }
+
+      if (this.cacheService) {
+        for (const input of events) {
+          if (!outcomes.some((o) => o.txHash === input.txHash && o.matched)) {
+            await this.cacheService.setPendingEvent({
+              txHash: input.txHash,
+              sorobanEventId: input.sorobanEventId,
+              eventPayload: input.eventPayload,
+              statusHint: input.statusHint,
+              receivedAt: new Date(),
+              consumedAt: null
+            });
+          }
+        }
+      }
+      return outcomes;
     });
   }
 

--- a/backend/src/services/stellarIndexer.ts
+++ b/backend/src/services/stellarIndexer.ts
@@ -284,7 +284,20 @@ export class StellarIndexer {
     // it would silently accept a second write of the same hash).
     const seenInBatch = new Set<string>();
 
-    // ── Process each event ────────────────────────────────────────────────
+    // ── Decode phase ─────────────────────────────────────────────────────
+    // Decode every event first, quarantining-and-halting at the first
+    // unresolvable one (so the cursor can never advance past a gap), and
+    // collect the decodable events for a single batched write below.
+    const batchEvents: Array<{
+      raw: RawHorizonEvent;
+      payload: Record<string, unknown>;
+      statusHint: "confirmed" | "reverted";
+    }> = [];
+    const poolRegistryEvents: Array<{
+      raw: RawHorizonEvent;
+      payload: Record<string, unknown>;
+    }> = [];
+
     for (const raw of rawEvents) {
       // Intra-batch duplicate: same txHash appeared earlier in this tick.
       if (seenInBatch.has(raw.txHash)) {
@@ -303,6 +316,8 @@ export class StellarIndexer {
         // *without* advancing the cursor past it, so a gap can't silently
         // slip by. The next tick will re-fetch and retry the same event
         // until it's resolved (fixed decoder/backfill) or manually cleared.
+        // Events decoded before the gap are still written by the write phase
+        // below — nothing after the gap is touched.
         await ledger.quarantineEvent({
           sorobanEventId: raw.id,
           ledger: raw.ledger,
@@ -354,58 +369,101 @@ export class StellarIndexer {
           continue;
         }
 
-        try {
-          // `salt`/`wasm_hash` are BytesN<32> on-chain; scValToNative
-          // decodes those to Buffers, not strings — hex-encode them so the
-          // registry stores a stable, human-inspectable value instead of
-          // mangling raw bytes through String() coercion. Address fields
-          // (`pool_address`/`admin`/`asset`) already decode to their G...
-          // strkey strings.
-          await ledger.upsertPoolRegistryEntry({
-            salt: bytesToHex(payload.salt),
-            poolAddress: String(payload.pool_address),
-            factoryAddress: raw.contractId,
-            admin: String(payload.admin),
-            asset: String(payload.asset),
-            wasmHash: bytesToHex(payload.wasm_hash),
-            deployedLedger: raw.ledger
-          });
-          imported += 1;
-        } catch (err) {
-          this.opts.logger?.warn({ err, txHash: raw.txHash }, "indexer: failed to upsert pool registry entry");
-        }
-        this.cursor = raw.id;
-        latestLedger = raw.ledger;
+        poolRegistryEvents.push({ raw, payload });
         continue;
       }
 
-      try {
-        await ledger.reconcileEvent({
-          txHash: raw.txHash,
-          sorobanEventId: raw.id,
-          eventPayload: payload,
-          statusHint
-        });
-        imported += 1;
-      } catch (err: unknown) {
-        // Unique constraint violation on pending_events.tx_hash means we already
-        // have this event from a previous tick — safe to skip (idempotency).
-        const isDuplicate =
-          err instanceof Error &&
-          (err.message.includes("Unique constraint") ||
-            err.message.includes("P2002") ||
-            (err as any).code === "P2002");
+      batchEvents.push({ raw, payload, statusHint });
+    }
 
-        if (isDuplicate) {
-          duplicates += 1;
-        } else {
-          this.opts.logger?.warn({ err, txHash: raw.txHash }, "indexer: skipping event due to error");
-          this.cursor = raw.id;
-          latestLedger = raw.ledger;
-          continue;
+    // ── Write phase ───────────────────────────────────────────────────────
+    // Batch-reconcile the independent (non-conflicting) events in ONE
+    // transaction instead of one round-trip per event (#588). Outcomes align
+    // 1:1 with batchEvents (distinct tx hashes are guaranteed by
+    // seenInBatch), so each queued event advances the cursor exactly as the
+    // per-event path did — only the *timing* changes, never the outcomes.
+    if (batchEvents.length > 0) {
+      try {
+        const outcomes = await ledger.reconcileEvents(
+          batchEvents.map((e) => ({
+            txHash: e.raw.txHash,
+            sorobanEventId: e.raw.id,
+            eventPayload: e.payload,
+            statusHint: e.statusHint
+          }))
+        );
+        for (let i = 0; i < outcomes.length; i++) {
+          imported += 1;
+          // outcomes is 1:1 with batchEvents (both built in the same loop).
+          const event = batchEvents[i]!;
+          this.cursor = event.raw.id;
+          latestLedger = event.raw.ledger;
+        }
+      } catch (err) {
+        // A batch-wide failure (lock timeout, connection loss) leaves the
+        // whole batch unwritten. Fall back to per-event reconciliation so a
+        // transient conflict can't silently drop events: the cursor only
+        // advances past events that were actually written.
+        this.opts.logger?.warn(
+          { err, count: batchEvents.length },
+          "indexer: batch reconcile failed, falling back to per-event writes"
+        );
+        for (const e of batchEvents) {
+          try {
+            await ledger.reconcileEvent({
+              txHash: e.raw.txHash,
+              sorobanEventId: e.raw.id,
+              eventPayload: e.payload,
+              statusHint: e.statusHint
+            });
+            imported += 1;
+          } catch (err2: unknown) {
+            // Unique constraint violation on pending_events.tx_hash means we
+            // already have this event from a previous tick — safe to skip.
+            const isDuplicate =
+              err2 instanceof Error &&
+              (err2.message.includes("Unique constraint") ||
+                err2.message.includes("P2002") ||
+                (err2 as any).code === "P2002");
+
+            if (isDuplicate) {
+              duplicates += 1;
+            } else {
+              this.opts.logger?.warn({ err: err2, txHash: e.raw.txHash }, "indexer: skipping event due to error");
+              this.cursor = e.raw.id;
+              latestLedger = e.raw.ledger;
+              continue;
+            }
+          }
+          this.cursor = e.raw.id;
+          latestLedger = e.raw.ledger;
         }
       }
+    }
 
+    // Pool registry upserts (rare — one per deployed pool) stay per-event:
+    // batching them would gain nothing and the registry is uncontended.
+    for (const { raw, payload } of poolRegistryEvents) {
+      try {
+        // `salt`/`wasm_hash` are BytesN<32> on-chain; scValToNative
+        // decodes those to Buffers, not strings — hex-encode them so the
+        // registry stores a stable, human-inspectable value instead of
+        // mangling raw bytes through String() coercion. Address fields
+        // (`pool_address`/`admin`/`asset`) already decode to their G...
+        // strkey strings.
+        await ledger.upsertPoolRegistryEntry({
+          salt: bytesToHex(payload.salt),
+          poolAddress: String(payload.pool_address),
+          factoryAddress: raw.contractId,
+          admin: String(payload.admin),
+          asset: String(payload.asset),
+          wasmHash: bytesToHex(payload.wasm_hash),
+          deployedLedger: raw.ledger
+        });
+        imported += 1;
+      } catch (err) {
+        this.opts.logger?.warn({ err, txHash: raw.txHash }, "indexer: failed to upsert pool registry entry");
+      }
       this.cursor = raw.id;
       latestLedger = raw.ledger;
     }

--- a/backend/tests/indexer.spec.ts
+++ b/backend/tests/indexer.spec.ts
@@ -155,4 +155,108 @@ describe("StellarIndexer", () => {
     const parked = await db.prisma.pendingEvent.findUnique({ where: { txHash: "tx_resume" } });
     expect(parked).not.toBeNull();
   });
+
+  it("batch-reconciles a mixed batch with per-event-equivalent outcomes", async () => {
+    await seedAction(db.prisma, { status: "submitted", txHash: "tx_match" });
+    const events = [
+      makeEvent({ id: "1", txHash: "tx_match" }),
+      makeEvent({ id: "2", txHash: "tx_new" }),
+      makeEvent({ id: "3", txHash: "tx_match" }),
+      makeEvent({ id: "4", txHash: "tx_rev", successful: false }),
+      makeEvent({ id: "5", txHash: "tx_new" })
+    ];
+    const indexer = new StellarIndexer({
+      ledger,
+      source: staticSource(events),
+      decoder: defaultXdrDecoder
+    });
+
+    const result = await indexer.tick();
+
+    // Same counts the per-event loop would have produced: two events match
+    // existing actions, one parks a pending row, two are intra-batch dupes.
+    expect(result).toMatchObject({
+      processed: 5,
+      imported: 3,
+      duplicates: 2,
+      quarantined: 0,
+      cursor: "5"
+    });
+
+    const matched = await db.prisma.actionLedger.findFirst({ where: { txHash: "tx_match" } });
+    expect(matched?.status).toBe("confirmed");
+    const reverted = await db.prisma.actionLedger.findFirst({ where: { txHash: "tx_rev" } });
+    expect(reverted?.status).toBe("reverted");
+    const parked = await db.prisma.pendingEvent.findMany({ where: { txHash: "tx_new" } });
+    expect(parked).toHaveLength(1);
+  });
+
+  it("keeps the quarantine-halts-the-batch guarantee with batched writes", async () => {
+    const throwingDecoder = {
+      decode(event: RawHorizonEvent): Record<string, unknown> {
+        if (event.id === "2") throw new Error("malformed XDR");
+        return defaultXdrDecoder.decode(event);
+      }
+    };
+    const events = [
+      makeEvent({ id: "1", txHash: "tx_gap_a" }),
+      makeEvent({ id: "2", txHash: "tx_gap_b" }),
+      makeEvent({ id: "3", txHash: "tx_gap_c" })
+    ];
+    const indexer = new StellarIndexer({
+      ledger,
+      source: staticSource(events),
+      decoder: throwingDecoder
+    });
+
+    const result = await indexer.tick();
+
+    // Event 1 is written, event 2 is quarantined, and the cursor stops at
+    // event 1 — event 3 is never touched, so the next tick retries the gap.
+    expect(result).toMatchObject({
+      processed: 3,
+      imported: 1,
+      quarantined: 1,
+      cursor: "1"
+    });
+    const parked = await db.prisma.pendingEvent.findMany({
+      where: { txHash: { in: ["tx_gap_a", "tx_gap_c"] } }
+    });
+    expect(parked.map((p) => p.txHash)).toEqual(["tx_gap_a"]);
+    const poison = await db.prisma.poisonEvent.findFirst({ where: { sorobanEventId: "2" } });
+    expect(poison).not.toBeNull();
+  });
+
+  it("benchmarks tick() latency for a full 50-event batch: batched beats sequential", async () => {
+    const events = Array.from({ length: 50 }, (_, i) =>
+      makeEvent({ id: String(i + 1), txHash: `tx_bench_${i}` })
+    );
+
+    // Sequential baseline: N individual reconcileEvent transactions.
+    const seqLedger = new LedgerService(db.prisma);
+    const seqStart = performance.now();
+    for (const e of events) {
+      await seqLedger.reconcileEvent({
+        txHash: e.txHash,
+        sorobanEventId: e.id,
+        eventPayload: { type: "deposit" },
+        statusHint: "confirmed"
+      });
+    }
+    const seqElapsed = performance.now() - seqStart;
+    await resetDb(db.prisma);
+
+    // Batched: one tick() with the same 50 events.
+    const indexer = new StellarIndexer({
+      ledger: new LedgerService(db.prisma),
+      source: staticSource(events),
+      decoder: defaultXdrDecoder
+    });
+    const batchStart = performance.now();
+    const result = await indexer.tick();
+    const batchElapsed = performance.now() - batchStart;
+
+    expect(result).toMatchObject({ processed: 50, imported: 50, duplicates: 0 });
+    expect(batchElapsed).toBeLessThan(seqElapsed);
+  });
 });

--- a/backend/tests/ledger.spec.ts
+++ b/backend/tests/ledger.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { startTestDb, resetDb, type TestDb } from "./helpers/db.js";
-import { makeIntentInput } from "./helpers/factory.js";
+import { makeIntentInput, seedAction } from "./helpers/factory.js";
 import { LedgerService } from "../src/services/ledger.js";
 import { AppError } from "../src/errors.js";
 
@@ -578,5 +578,81 @@ describe("LedgerService.scrubWallet", () => {
     const untouched = await db.prisma.actionLedger.findUnique({ where: { id: other.id } });
     expect(untouched?.actionPayload).not.toBeNull();
     expect(untouched?.redactedAt).toBeNull();
+  });
+});
+
+describe("LedgerService.reconcileEvents (#588 batch)", () => {
+  let db: TestDb;
+  let svc: LedgerService;
+
+  beforeAll(async () => {
+    db = await startTestDb();
+    svc = new LedgerService(db.prisma);
+  });
+  afterAll(async () => {
+    await db.stop();
+  });
+  beforeEach(async () => {
+    await resetDb(db.prisma);
+  });
+
+  it("reconciles a mixed batch with per-event-equivalent outcomes", async () => {
+    const matched = await seedAction(db.prisma, { status: "submitted", txHash: "tx_match" });
+    const terminal = await seedAction(db.prisma, { status: "confirmed", txHash: "tx_done" });
+
+    const outcomes = await svc.reconcileEvents([
+      { txHash: "tx_match", sorobanEventId: "e1", eventPayload: { type: "deposit" }, statusHint: "confirmed" },
+      { txHash: "tx_new", sorobanEventId: "e2", eventPayload: { type: "withdraw" }, statusHint: "confirmed" },
+      { txHash: "tx_done", sorobanEventId: "e3", eventPayload: { type: "deposit" }, statusHint: "confirmed" }
+    ]);
+
+    expect(outcomes).toEqual([
+      { txHash: "tx_match", matched: true },
+      { txHash: "tx_new", matched: false },
+      { txHash: "tx_done", matched: true }
+    ]);
+
+    const refreshed = await db.prisma.actionLedger.findUnique({ where: { id: matched.id } });
+    expect(refreshed?.status).toBe("confirmed");
+    expect(refreshed?.verifiedPayload).toEqual({ type: "deposit" });
+
+    // Terminal rows are skipped untouched (same no-op as reconcileEvent).
+    const terminalRefreshed = await db.prisma.actionLedger.findUnique({ where: { id: terminal.id } });
+    expect(terminalRefreshed?.status).toBe("confirmed");
+    expect(terminalRefreshed?.sorobanEventId).toBeNull();
+
+    const parked = await db.prisma.pendingEvent.findUnique({ where: { txHash: "tx_new" } });
+    expect(parked).not.toBeNull();
+  });
+
+  it("marks a reverted hint as reverted and releases the action lease", async () => {
+    const action = await seedAction(db.prisma, { status: "submitted", txHash: "tx_rev_b" });
+    await db.prisma.actionLease.create({
+      data: { actionId: action.id, workerId: "w1", expiresAt: new Date(Date.now() + 60_000) }
+    });
+
+    await svc.reconcileEvents([
+      { txHash: "tx_rev_b", sorobanEventId: "e1", eventPayload: { type: "deposit" }, statusHint: "reverted" }
+    ]);
+
+    const refreshed = await db.prisma.actionLedger.findUnique({ where: { id: action.id } });
+    expect(refreshed?.status).toBe("reverted");
+    expect(refreshed?.errorCode).toBe("REVERTED_ON_CHAIN");
+    const leases = await db.prisma.actionLease.findMany({ where: { actionId: action.id } });
+    expect(leases).toHaveLength(0);
+  });
+
+  it("is idempotent across re-delivered batches", async () => {
+    const input = {
+      txHash: "tx_again",
+      sorobanEventId: "e1",
+      eventPayload: { type: "deposit" },
+      statusHint: "confirmed" as const
+    };
+    await svc.reconcileEvents([input]);
+    await svc.reconcileEvents([input]);
+
+    const parked = await db.prisma.pendingEvent.findMany({ where: { txHash: "tx_again" } });
+    expect(parked).toHaveLength(1);
   });
 });

--- a/components/app/DrawProofVerifier.jsx
+++ b/components/app/DrawProofVerifier.jsx
@@ -4,30 +4,57 @@ import { useState } from "react";
 import { Shield, ShieldCheck, ShieldAlert, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { verifyDrawProofClient, createFetchRpcClient } from "@/lib/draw-proof-verifier";
 
+const FIELD_STATUS_LABEL = {
+  pass: "PASS",
+  fail: "FAILED",
+  unverified: "UNVERIFIED",
+};
+
+const FIELD_STATUS_STYLES = {
+  pass: {
+    row: "bg-emerald-500/[0.03]",
+    text: "text-emerald-400",
+    chip: "bg-emerald-500/10 border-emerald-500/20 text-emerald-400",
+  },
+  fail: {
+    row: "bg-red-500/[0.06]",
+    text: "text-red-400",
+    chip: "bg-red-500/15 border-red-500/30 text-red-400",
+  },
+  unverified: {
+    row: "",
+    text: "text-gray-500",
+    chip: "bg-gray-500/10 border-gray-500/20 text-gray-400",
+  },
+};
+
 function VerificationFieldRow({ field }) {
-  const statusColors = {
-    pass: "text-emerald-400",
-    fail: "text-red-400",
-    unverified: "text-gray-500",
-  };
+  const styles = FIELD_STATUS_STYLES[field.status] ?? FIELD_STATUS_STYLES.unverified;
   const StatusIcon = {
     pass: ShieldCheck,
     fail: ShieldAlert,
     unverified: AlertCircle,
-  }[field.status];
+  }[field.status] ?? AlertCircle;
 
   return (
-    <div className="flex items-center justify-between py-1.5 border-b border-gray-800/50 last:border-0">
-      <span className="text-xs text-gray-400">{field.name}</span>
-      <div className="flex items-center gap-1.5">
+    <div className={`flex items-start justify-between gap-3 py-1.5 px-2 rounded border-b border-gray-800/50 last:border-0 ${styles.row}`}>
+      <span className="text-xs text-gray-400 font-medium">{field.name}</span>
+      <div className="flex items-center gap-2 min-w-0">
         {field.detail && (
-          <span className="text-[9px] text-gray-600 truncate max-w-[120px]" title={field.detail}>
+          <span
+            className={`text-[10px] truncate max-w-[220px] ${
+              field.status === "fail" ? "text-red-400/90" : "text-gray-600"
+            }`}
+            title={field.detail}
+          >
             {field.detail}
           </span>
         )}
-        <StatusIcon className={`h-3.5 w-3.5 ${statusColors[field.status]}`} />
-        <span className={`text-[10px] font-mono ${statusColors[field.status]}`}>
-          {field.status}
+        <StatusIcon className={`h-3.5 w-3.5 shrink-0 ${styles.text}`} />
+        <span
+          className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[9px] font-mono font-semibold ${styles.chip}`}
+        >
+          {FIELD_STATUS_LABEL[field.status] ?? field.status}
         </span>
       </div>
     </div>

--- a/components/app/VaultActivityExport.jsx
+++ b/components/app/VaultActivityExport.jsx
@@ -1,31 +1,62 @@
 "use client";
 
-import { useState } from "react";
-import { Download, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { useState, useRef } from "react";
+import { Download, CheckCircle2, AlertCircle, Loader2, XCircle } from "lucide-react";
 
 /**
- * VaultActivityExport — client-side export of vault activity records.
+ * VaultActivityExport — pagination-safe export of vault activity records.
  *
- * Generates a CSV or JSON file from the provided `activities` array and
- * triggers a browser download. No API call required.
+ * Pages through `GET /actions?wallet=...&limit=...&cursor=...` (cursor-based
+ * pagination, see backend/src/routes/actions.ts) instead of loading the entire
+ * history in one response, and streams each page's rows into the CSV/JSON
+ * output as it arrives. Multi-page exports show a progress indicator and a
+ * cancel button that aborts the in-flight requests.
  *
  * Props:
- *   activities  Array of activity objects (required)
+ *   wallet      Wallet address whose activity is exported (required)
  *   filename    Base filename without extension (default "vault-activity")
+ *   pageSize    Rows fetched per page (default 100; backend caps at 100)
+ *   fetchImpl   fetch implementation override (defaults to global fetch; for tests)
+ *   apiBase     API base URL override (defaults to NEXT_PUBLIC_VAULTQUEST_API_BASE_URL or "/api")
  */
 
-const FIELDS = ["id", "type", "pool", "asset", "amount", "date", "status"];
+const API_BASE = process.env.NEXT_PUBLIC_VAULTQUEST_API_BASE_URL || "/api";
 
-function toCsv(activities) {
-  const header = FIELDS.join(",");
-  const rows = activities.map((a) =>
-    FIELDS.map((f) => {
-      const v = a[f] ?? "";
-      const str = String(v);
-      return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
-    }).join(",")
-  );
-  return [header, ...rows].join("\r\n") + "\r\n";
+const FIELDS = [
+  "id",
+  "date",
+  "action_type",
+  "pool_id",
+  "asset",
+  "amount",
+  "status",
+  "tx_hash",
+  "error_code",
+  "submitted_at",
+  "confirmed_at",
+];
+
+function csvEscape(value) {
+  const str = String(value ?? "");
+  return /[",\r\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+/** Mirrors the backend /actions/export clean-record mapping. */
+function mapRecord(row) {
+  const payload = row.action_payload ?? {};
+  return {
+    id: row.id ?? "",
+    date: row.created_at ?? "",
+    action_type: row.action_type ?? "",
+    pool_id: String(payload.vault_id ?? payload.pool_id ?? ""),
+    asset: String(payload.token ?? payload.asset ?? ""),
+    amount: String(payload.amount ?? ""),
+    status: row.status ?? "",
+    tx_hash: row.tx_hash ?? "",
+    error_code: row.error_code ?? "",
+    submitted_at: row.submitted_at ?? "",
+    confirmed_at: row.confirmed_at ?? "",
+  };
 }
 
 function download(content, filename, mime) {
@@ -38,31 +69,100 @@ function download(content, filename, mime) {
   URL.revokeObjectURL(url);
 }
 
-export default function VaultActivityExport({ activities = [], filename = "vault-activity" }) {
+export default function VaultActivityExport({
+  wallet,
+  filename = "vault-activity",
+  pageSize = 100,
+  fetchImpl = typeof globalThis !== "undefined" ? globalThis.fetch?.bind(globalThis) : null,
+  apiBase = API_BASE,
+}) {
   const [format, setFormat] = useState("csv");
-  const [status, setStatus] = useState("idle"); // idle | loading | success | error
+  const [status, setStatus] = useState("idle"); // idle | exporting | success | error | cancelled
   const [errorMsg, setErrorMsg] = useState("");
+  const [progress, setProgress] = useState({ rows: 0, pages: 0 });
+  const abortRef = useRef(null);
 
-  const handleExport = () => {
-    if (!activities.length) {
+  const handleCancel = () => {
+    abortRef.current?.abort();
+  };
+
+  const handleExport = async () => {
+    if (!wallet) {
       setStatus("error");
-      setErrorMsg("No activity records to export.");
+      setErrorMsg("A wallet address is required to export activity.");
+      return;
+    }
+    if (!fetchImpl) {
+      setStatus("error");
+      setErrorMsg("Export is unavailable in this environment.");
       return;
     }
 
-    setStatus("loading");
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStatus("exporting");
+    setErrorMsg("");
+    setProgress({ rows: 0, pages: 0 });
+
     try {
+      let cursor = null;
+      let rowsTotal = 0;
+      let pages = 0;
+
+      // CSV is built incrementally — rows are appended as each page arrives,
+      // so the full history is never materialized in a single response. JSON
+      // accumulates records (inherent to the format) but still pages through
+      // the API rather than fetching everything at once.
+      let csv = format === "csv" ? FIELDS.join(",") + "\r\n" : null;
+      const records = [];
+
+      do {
+        const params = new URLSearchParams({ wallet, limit: String(pageSize) });
+        if (cursor) params.set("cursor", cursor);
+
+        const res = await fetchImpl(`${apiBase}/actions?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Export failed (HTTP ${res.status})`);
+        }
+        const body = await res.json();
+        const items = Array.isArray(body?.data) ? body.data : [];
+        const nextCursor = body?.meta?.pagination?.next_cursor ?? null;
+
+        for (const row of items) {
+          const record = mapRecord(row);
+          if (format === "csv") {
+            csv += FIELDS.map((f) => csvEscape(record[f])).join(",") + "\r\n";
+          } else {
+            records.push(record);
+          }
+          rowsTotal += 1;
+        }
+        pages += 1;
+        setProgress({ rows: rowsTotal, pages });
+
+        if (!nextCursor) break;
+        cursor = nextCursor;
+      } while (true);
+
       if (format === "csv") {
-        download(toCsv(activities), `${filename}.csv`, "text/csv");
+        download(csv, `${filename}.csv`, "text/csv");
       } else {
-        download(JSON.stringify(activities, null, 2), `${filename}.json`, "application/json");
+        download(JSON.stringify(records, null, 2), `${filename}.json`, "application/json");
       }
       setStatus("success");
-    } catch {
-      setStatus("error");
-      setErrorMsg("Export failed. Please try again.");
+    } catch (err) {
+      if (controller.signal.aborted || err?.name === "AbortError") {
+        setStatus("cancelled");
+      } else {
+        setStatus("error");
+        setErrorMsg(err?.message || "Export failed. Please try again.");
+      }
     }
   };
+
+  const exporting = status === "exporting";
 
   return (
     <div className="rounded-2xl border border-vault-border bg-vault-surface/60 p-5">
@@ -80,7 +180,8 @@ export default function VaultActivityExport({ activities = [], filename = "vault
             id="vae-format"
             value={format}
             onChange={(e) => { setFormat(e.target.value); setStatus("idle"); }}
-            className="rounded-lg border border-vault-border bg-vault-bg px-3 py-2 text-sm text-vault-text focus:outline-none focus:ring-2 focus:ring-vault-accent"
+            disabled={exporting}
+            className="rounded-lg border border-vault-border bg-vault-bg px-3 py-2 text-sm text-vault-text focus:outline-none focus:ring-2 focus:ring-vault-accent disabled:opacity-50"
           >
             <option value="csv">CSV</option>
             <option value="json">JSON</option>
@@ -90,22 +191,54 @@ export default function VaultActivityExport({ activities = [], filename = "vault
         <button
           type="button"
           onClick={handleExport}
-          disabled={status === "loading"}
+          disabled={exporting}
           className="inline-flex items-center gap-2 rounded-xl bg-vault-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {status === "loading" ? (
+          {exporting ? (
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           ) : (
             <Download className="h-4 w-4" aria-hidden="true" />
           )}
-          {status === "loading" ? "Exporting…" : "Export"}
+          {exporting ? "Exporting…" : "Export"}
         </button>
+
+        {exporting && (
+          <>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="inline-flex items-center gap-2 rounded-xl border border-vault-border px-4 py-2 text-sm font-semibold text-vault-muted transition-colors hover:bg-vault-surface hover:text-vault-text"
+            >
+              <XCircle className="h-4 w-4" aria-hidden="true" />
+              Cancel
+            </button>
+            <div className="flex flex-col gap-1" role="status" aria-live="polite">
+              <span className="text-xs text-vault-muted">
+                Exporting… <span className="font-mono text-vault-text">{progress.rows}</span> rows
+                across <span className="font-mono text-vault-text">{progress.pages}</span> page{progress.pages === 1 ? "" : "s"}
+              </span>
+              <div className="h-1.5 w-40 overflow-hidden rounded-full bg-vault-border/50">
+                <div
+                  className="h-full rounded-full bg-vault-accent transition-all duration-300"
+                  style={{ width: progress.rows > 0 ? "100%" : "0%" }}
+                />
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       {status === "success" && (
         <div className="mt-3 flex items-center gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-sm text-emerald-400">
           <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
-          <span>Downloaded <span className="font-mono">{filename}.{format}</span> successfully.</span>
+          <span>Downloaded <span className="font-mono">{filename}.{format}</span> successfully ({progress.rows} rows).</span>
+        </div>
+      )}
+
+      {status === "cancelled" && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg bg-amber-500/10 px-3 py-2 text-sm text-amber-400">
+          <XCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>Export cancelled after {progress.rows} rows.</span>
         </div>
       )}
 

--- a/lib/draw-proof-verifier.ts
+++ b/lib/draw-proof-verifier.ts
@@ -2,8 +2,6 @@ import {
   type DrawProof,
   type VerificationResult,
   type VerificationField,
-  computeHash,
-  computeWinnerProofHash,
   verifyProofIntegrity,
 } from "./draw-proof";
 
@@ -41,26 +39,6 @@ function fieldFail(name: string, detail: string): VerificationField {
 
 function fieldUnverified(name: string, detail: string): VerificationField {
   return { name, status: "unverified", detail };
-}
-
-async function verifyDocumentIntegrity(proof: DrawProof): Promise<VerificationField> {
-  const result = await verifyProofIntegrity(proof);
-  const docField = result.fields.find((f) => f.name === "document_integrity");
-  return docField ?? fieldFail("document_integrity", "missing from integrity check");
-}
-
-async function verifyWinnerHashChain(proof: DrawProof): Promise<VerificationField> {
-  const result = await verifyProofIntegrity(proof);
-  const winnerField = result.fields.find((f) => f.name === "winner_proof_hash");
-  return winnerField ?? fieldFail("winner_proof_hash", "missing from integrity check");
-}
-
-async function verifySeedHash(proof: DrawProof): Promise<VerificationField> {
-  const recomputed = await computeHash(proof.randomness.seed);
-  if (recomputed === proof.randomness.seedHash) {
-    return fieldPass("seed_hash");
-  }
-  return fieldFail("seed_hash", `expected ${recomputed}, got ${proof.randomness.seedHash}`);
 }
 
 /**
@@ -160,9 +138,14 @@ export async function verifyDrawProofClient(
 ): Promise<ClientVerificationResult> {
   const fields: VerificationField[] = [];
 
-  fields.push(await verifyDocumentIntegrity(proof));
-  fields.push(await verifyWinnerHashChain(proof));
-  fields.push(await verifySeedHash(proof));
+  // Surface the FULL per-field output of the document-only integrity engine
+  // (#572) instead of collapsing it to a single boolean: every check —
+  // document_integrity, winner_proof_hash, seed_hash, randomness_commitment
+  // (and randomness_evidence on schema failure) — is forwarded verbatim so
+  // the UI can render each one with its pass/fail/unverified state and the
+  // `detail` string explaining *why* a check failed.
+  const integrity = await verifyProofIntegrity(proof);
+  fields.push(...integrity.fields);
 
   if (rpc) {
     fields.push(await verifySnapshotLedger(proof, rpc));

--- a/tests/DrawProofVerifier.test.jsx
+++ b/tests/DrawProofVerifier.test.jsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DrawProofVerifier from "@/components/app/DrawProofVerifier";
+
+const mockVerifyDrawProofClient = vi.fn();
+
+vi.mock("@/lib/draw-proof-verifier", () => ({
+  verifyDrawProofClient: (...args) => mockVerifyDrawProofClient(...args),
+  createFetchRpcClient: vi.fn(),
+}));
+
+const MOCK_PROOF = {
+  proof: {
+    version: "1.1.0",
+    drawId: "draw-abc123def456",
+    roundId: 5,
+    contractId: "CDRYPPOOL123",
+    snapshot: { ledgerSeq: 1000 },
+    randomness: { seed: "seed123", seedHash: "seedhash", commitment: "commit" },
+    winnerSelection: { method: "weighted_random", winnerAddress: "G...", proofHash: "proofhash" },
+    payout: { amount: "500000", asset: "USDC", txHash: "tx", ledgerSeq: 1001, recipientConfirmed: true },
+    metadata: {},
+    signature: "sig",
+  },
+};
+
+describe("DrawProofVerifier per-field rendering (#572)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders every VerificationField individually, not collapsed to one badge", async () => {
+    mockVerifyDrawProofClient.mockResolvedValue({
+      verified: false,
+      verifiedAt: "2026-08-01T00:00:00Z",
+      fields: [
+        { name: "document_integrity", status: "pass" },
+        {
+          name: "winner_proof_hash",
+          status: "fail",
+          detail: "expected hash abc123, got hash xyz789",
+        },
+        { name: "seed_hash", status: "pass" },
+        {
+          name: "randomness_commitment",
+          status: "unverified",
+          detail: "No HMAC signing secret provided",
+        },
+      ],
+    });
+
+    render(<DrawProofVerifier proof={MOCK_PROOF} />);
+    fireEvent.click(screen.getByText("Verify Proof"));
+
+    expect(await screen.findByText("document_integrity")).toBeDefined();
+    expect(screen.getByText("winner_proof_hash")).toBeDefined();
+    expect(screen.getByText("seed_hash")).toBeDefined();
+    expect(screen.getByText("randomness_commitment")).toBeDefined();
+  });
+
+  it("shows the failing field's detail text and the tampered field is called out", async () => {
+    mockVerifyDrawProofClient.mockResolvedValue({
+      verified: false,
+      verifiedAt: "2026-08-01T00:00:00Z",
+      fields: [
+        { name: "document_integrity", status: "pass" },
+        {
+          name: "winner_proof_hash",
+          status: "fail",
+          detail: "expected hash abc123, got hash xyz789",
+        },
+        { name: "seed_hash", status: "pass" },
+      ],
+    });
+
+    render(<DrawProofVerifier proof={MOCK_PROOF} />);
+    fireEvent.click(screen.getByText("Verify Proof"));
+
+    expect(await screen.findByText("expected hash abc123, got hash xyz789")).toBeDefined();
+  });
+
+  it("textually distinguishes fail from unverified from pass", async () => {
+    mockVerifyDrawProofClient.mockResolvedValue({
+      verified: false,
+      verifiedAt: "2026-08-01T00:00:00Z",
+      fields: [
+        { name: "document_integrity", status: "pass" },
+        { name: "winner_proof_hash", status: "fail", detail: "hash mismatch" },
+        { name: "randomness_commitment", status: "unverified", detail: "No RPC client provided" },
+      ],
+    });
+
+    render(<DrawProofVerifier proof={MOCK_PROOF} />);
+    fireEvent.click(screen.getByText("Verify Proof"));
+
+    expect(await screen.findByText("PASS")).toBeDefined();
+    expect(screen.getByText("FAILED")).toBeDefined();
+    expect(screen.getByText("UNVERIFIED")).toBeDefined();
+  });
+});

--- a/tests/VaultActivityExport.test.jsx
+++ b/tests/VaultActivityExport.test.jsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import VaultActivityExport from "@/components/app/VaultActivityExport";
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+function makeRow(id) {
+  return {
+    id,
+    created_at: `2026-08-0${id}T10:00:00Z`,
+    action_type: "deposit",
+    action_payload: { vault_id: "42", token: "USDC", amount: "100" },
+    status: "confirmed",
+    tx_hash: `tx-${id}`,
+    error_code: null,
+    submitted_at: null,
+    confirmed_at: `2026-08-0${id}T10:05:00Z`,
+  };
+}
+
+describe("VaultActivityExport pagination (#576)", () => {
+  let capturedBlob;
+
+  beforeEach(() => {
+    capturedBlob = null;
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+    URL.revokeObjectURL = vi.fn();
+    HTMLAnchorElement.prototype.click = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pages through the API until next_cursor is null and exports every row", async () => {
+    const fetchImpl = vi.fn((url) => {
+      if (url.includes("cursor=id-2")) {
+        return Promise.resolve(
+          jsonResponse({
+            data: [makeRow(3)],
+            meta: { pagination: { next_cursor: null, limit: 2, has_more: false } },
+          })
+        );
+      }
+      return Promise.resolve(
+        jsonResponse({
+          data: [makeRow(1), makeRow(2)],
+          meta: { pagination: { next_cursor: "id-2", limit: 2, has_more: true } },
+        })
+      );
+    });
+
+    render(<VaultActivityExport wallet="GABCDEF1234567890" pageSize={2} fetchImpl={fetchImpl} />);
+    fireEvent.click(screen.getByText("Export"));
+
+    // Both pages fetched; the second request resumes from the returned cursor.
+    expect(await screen.findByText(/Downloaded/)).toBeDefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0][0]).toContain("wallet=GABCDEF1234567890");
+    expect(fetchImpl.mock.calls[0][0]).toContain("limit=2");
+    expect(fetchImpl.mock.calls[1][0]).toContain("cursor=id-2");
+
+    // Row count correctness: header + 3 rows across 2 pages.
+    const blob = URL.createObjectURL.mock.calls[0][0];
+    const text = await blob.text();
+    const lines = text.trim().split("\r\n");
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toBe(
+      "id,date,action_type,pool_id,asset,amount,status,tx_hash,error_code,submitted_at,confirmed_at"
+    );
+    expect(lines[1]).toContain("tx-1");
+    expect(lines[3]).toContain("tx-3");
+    expect(screen.getByText(/3 rows/)).toBeDefined();
+  });
+
+  it("shows progress while exporting across multiple pages", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          data: [makeRow(1)],
+          meta: { pagination: { next_cursor: null, limit: 1, has_more: false } },
+        })
+      )
+    );
+
+    render(<VaultActivityExport wallet="GABCDEF1234567890" pageSize={1} fetchImpl={fetchImpl} />);
+    fireEvent.click(screen.getByText("Export"));
+
+    expect(await screen.findByText(/Exporting…/)).toBeDefined();
+    expect(await screen.findByText(/1 rows/)).toBeDefined();
+  });
+
+  it("cancels an in-flight export without paging further", async () => {
+    const fetchImpl = vi.fn((_url, opts) => {
+      // First (and only) page hangs until the user cancels.
+      return new Promise((_resolve, reject) => {
+        opts.signal.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError"))
+        );
+      });
+    });
+
+    render(<VaultActivityExport wallet="GABCDEF1234567890" fetchImpl={fetchImpl} />);
+    fireEvent.click(screen.getByText("Export"));
+
+    expect(await screen.findByText(/Exporting…/)).toBeDefined();
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(await screen.findByText(/Export cancelled/)).toBeDefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a wallet address before exporting", async () => {
+    const fetchImpl = vi.fn();
+    render(<VaultActivityExport fetchImpl={fetchImpl} />);
+    fireEvent.click(screen.getByText("Export"));
+
+    expect(
+      await screen.findByText("A wallet address is required to export activity.")
+    ).toBeDefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Stellar Wave batch for the assigned draw-proof/export/indexer issues: the verifier now surfaces every field from verifyProofIntegrity (including randomness_commitment) and renders each with its detail text; the activity export pages through the actions API with streaming CSV, progress and cancel; and the indexer reconciles a full batch of events in one transaction instead of per-event round-trips.

Closes #572
Closes #576
Closes #588