### PR TITLE
fix: refresh stale deposit/archive data and enforce local proof + error-state checks

### DIFF
--- a/app/app/vaults/archive/page.jsx
+++ b/app/app/vaults/archive/page.jsx
@@ -2,8 +2,9 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { Archive, CalendarDays, ChevronLeft, Trophy, Users } from "lucide-react";
+import { Archive, AlertTriangle, CalendarDays, ChevronLeft, Trophy, Users } from "lucide-react";
 import { VAULT_ROUND_ARCHIVE } from "@/lib/vault-mock-data";
+import { isArchiveEntryStale } from "@/lib/pool-status";
 
 const PAGE_SIZE = 3;
 
@@ -97,7 +98,9 @@ export default function VaultRoundArchivePage() {
         </section>
       ) : (
         <section className="space-y-4" aria-label="Completed rounds">
-          {visibleRounds.map((round) => (
+          {visibleRounds.map((round) => {
+            const stale = isArchiveEntryStale(round.verifiedAt);
+            return (
             <article key={round.id} className="vq-glass-hover p-5">
               <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                 <div>
@@ -106,6 +109,19 @@ export default function VaultRoundArchivePage() {
                     <span className="rounded-full border border-vault-border bg-vault-surface px-2.5 py-1 text-xs font-semibold text-vault-muted">
                       {round.network} · {round.asset}
                     </span>
+                    {stale && (
+                      <span
+                        className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-300"
+                        title={
+                          round.verifiedAt
+                            ? `Last verified ${formatDate(round.verifiedAt.slice(0, 10))} — may not reflect the latest on-chain state`
+                            : "Not yet verified against on-chain state"
+                        }
+                      >
+                        <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                        May be stale
+                      </span>
+                    )}
                   </div>
                   <p className="mt-2 flex items-center gap-2 text-sm text-vault-muted">
                     <CalendarDays className="h-4 w-4" aria-hidden="true" />
@@ -124,7 +140,8 @@ export default function VaultRoundArchivePage() {
                 <SummaryMetric icon={Trophy} label="Prize payout" value={formatCurrency(round.prizePayout)} />
               </div>
             </article>
-          ))}
+            );
+          })}
 
           <div className="flex flex-col items-center gap-3 pt-2">
             {hasMore ? (

--- a/components/app/DrawProofCard.jsx
+++ b/components/app/DrawProofCard.jsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React from "react";
-import { Shield, ShieldCheck, ShieldAlert, ExternalLink } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { Shield, ShieldCheck, ShieldAlert, ExternalLink, Loader2 } from "lucide-react";
+import { verifyProofIntegrity } from "@/lib/draw-proof";
 
 function truncateAddress(addr) {
   if (!addr || addr.length < 12) return addr || "N/A";
@@ -18,8 +19,20 @@ function formatAmount(amount, asset = "USDC") {
   return `${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${asset}`;
 }
 
-function VerificationBadge({ verified, verificationError }) {
-  if (verified) {
+// Verification states this card renders (#621). `verifying` covers the brief
+// window before the local integrity check resolves; a winner is never shown
+// as "Verified" purely because the API said so — the local check must also
+// pass, so a winner is never displayed as final on a backend flag alone.
+function VerificationBadge({ status }) {
+  if (status === "verifying") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-gray-500/10 px-2 py-0.5 text-[10px] font-semibold text-gray-400 border border-gray-500/20">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Verifying
+      </span>
+    );
+  }
+  if (status === "verified") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-400 border border-emerald-500/20">
         <ShieldCheck className="h-3 w-3" />
@@ -27,7 +40,7 @@ function VerificationBadge({ verified, verificationError }) {
       </span>
     );
   }
-  if (verificationError) {
+  if (status === "failed") {
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold text-red-400 border border-red-500/20">
         <ShieldAlert className="h-3 w-3" />
@@ -44,9 +57,43 @@ function VerificationBadge({ verified, verificationError }) {
 }
 
 export default function DrawProofCard({ proof, onViewProof, explorerUrl = "https://stellar.expert/explorer/public/tx/" }) {
+  const proofData = proof ? proof.proof || proof : null;
+
+  // Enforce verification at the render site instead of trusting the API's
+  // `verified` flag as-is: the winner is only shown as a confirmed, final
+  // result once the document-integrity checks in verifyProofIntegrity have
+  // actually run against this proof and passed (#621). A proof that fails
+  // or can't be locally verified is marked distinctly, never silently shown
+  // as a normal verified winner.
+  const [localStatus, setLocalStatus] = useState("verifying");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!proofData) {
+      setLocalStatus("unverified");
+      return undefined;
+    }
+    setLocalStatus("verifying");
+    verifyProofIntegrity(proofData)
+      .then((result) => {
+        if (cancelled) return;
+        setLocalStatus(result.verified ? "verified" : "failed");
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLocalStatus("unverified");
+      });
+    return () => {
+      cancelled = true;
+    };
+    // proofData is derived fresh each render from `proof`; keying on the
+    // stable draw id (falling back to the object itself) avoids re-running
+    // the check every render while still re-running when the proof changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [proofData?.drawId || proof?.draw_id || proof]);
+
   if (!proof) return null;
 
-  const proofData = proof.proof || proof;
   const winner = proofData.winnerSelection?.winnerAddress || "Unknown";
   const amount = proofData.payout?.amount || "0";
   const asset = proofData.payout?.asset || "USDC";
@@ -54,6 +101,11 @@ export default function DrawProofCard({ proof, onViewProof, explorerUrl = "https
   const drawId = proofData.drawId || proof.draw_id || "";
   const txHash = proofData.payout?.txHash || "";
   const proofHash = proofData.signature || proof.proof_hash || "";
+
+  // Only treat the draw as a confirmed final result when both the backend's
+  // flag and the just-run local integrity check agree it verified.
+  const isFinalVerified = proof.verified === true && localStatus === "verified";
+  const badgeStatus = localStatus === "verifying" ? "verifying" : isFinalVerified ? "verified" : "failed";
 
   return (
     <div className="rounded-xl border border-gray-800 bg-gray-900/50 p-4 space-y-3 hover:border-gray-700 transition-colors">
@@ -65,11 +117,16 @@ export default function DrawProofCard({ proof, onViewProof, explorerUrl = "https
             {truncateHash(drawId)}
           </span>
         </div>
-        <VerificationBadge
-          verified={proof.verified}
-          verificationError={proof.verification_error}
-        />
+        <VerificationBadge status={badgeStatus} />
       </div>
+      {badgeStatus === "failed" && (
+        <div className="flex items-start gap-1.5 rounded-lg border border-red-900/40 bg-red-950/20 px-2.5 py-1.5 text-[10px] text-red-400">
+          <ShieldAlert className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>
+            This draw could not be independently verified{proof.verification_error ? `: ${proof.verification_error}` : "."} Treat the winner below as unconfirmed.
+          </span>
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <div>

--- a/lib/pool-status.test.ts
+++ b/lib/pool-status.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  ARCHIVE_STALE_THRESHOLD_MS,
   POOL_STATUS,
   ROUND_STATUS,
   getPoolStatusMeta,
   getRoundStatusMeta,
+  isArchiveEntryStale,
   normalizePoolStatus,
 } from "./pool-status";
 
@@ -58,5 +60,50 @@ describe("getRoundStatusMeta", () => {
     for (const roundStatus of Object.values(ROUND_STATUS)) {
       expect(poolStatuses.has(roundStatus)).toBe(true);
     }
+  });
+});
+
+describe("isArchiveEntryStale (#622)", () => {
+  const NOW = new Date("2026-06-15T12:00:00Z").getTime();
+
+  it("is not stale when verified within the threshold", () => {
+    const verifiedAt = new Date(NOW - 1 * 60 * 60 * 1000).toISOString(); // 1h ago
+    expect(isArchiveEntryStale(verifiedAt, NOW)).toBe(false);
+  });
+
+  it("is stale once verification age exceeds the threshold", () => {
+    const verifiedAt = new Date(NOW - (ARCHIVE_STALE_THRESHOLD_MS + 1)).toISOString();
+    expect(isArchiveEntryStale(verifiedAt, NOW)).toBe(true);
+  });
+
+  it("is exactly on the boundary as not-yet-stale", () => {
+    const verifiedAt = new Date(NOW - ARCHIVE_STALE_THRESHOLD_MS).toISOString();
+    expect(isArchiveEntryStale(verifiedAt, NOW)).toBe(false);
+  });
+
+  it("treats a missing or null verifiedAt as stale rather than trusting it silently", () => {
+    expect(isArchiveEntryStale(null, NOW)).toBe(true);
+    expect(isArchiveEntryStale(undefined, NOW)).toBe(true);
+    expect(isArchiveEntryStale("", NOW)).toBe(true);
+  });
+
+  it("treats an unparseable verifiedAt as stale", () => {
+    expect(isArchiveEntryStale("not-a-date", NOW)).toBe(true);
+  });
+
+  it("treats a verifiedAt in the future as stale (clock skew / bad data)", () => {
+    const verifiedAt = new Date(NOW + 60 * 60 * 1000).toISOString(); // 1h in the future
+    expect(isArchiveEntryStale(verifiedAt, NOW)).toBe(true);
+  });
+
+  it("accepts a custom threshold", () => {
+    const verifiedAt = new Date(NOW - 10 * 60 * 1000).toISOString(); // 10m ago
+    expect(isArchiveEntryStale(verifiedAt, NOW, 5 * 60 * 1000)).toBe(true);
+    expect(isArchiveEntryStale(verifiedAt, NOW, 15 * 60 * 1000)).toBe(false);
+  });
+
+  it("defaults `now` to the current time when omitted", () => {
+    const verifiedAt = new Date().toISOString();
+    expect(isArchiveEntryStale(verifiedAt)).toBe(false);
   });
 });

--- a/lib/pool-status.ts
+++ b/lib/pool-status.ts
@@ -169,3 +169,48 @@ export function getRoundStatusMeta(status?: string | null): RoundStatusMeta {
     ROUND_STATUS_META[ROUND_STATUS.PENDING]
   );
 }
+
+// ─── Archive entry freshness (#622) ────────────────────────────────────────────
+// Minimal baseline slice: flag when an archived round's on-chain-derived data
+// is old enough that it should not be trusted without reconciling against
+// current chain state. This does NOT reconcile against the chain itself, run
+// repair tooling, or replace the indexer - it is a pure, presentation-layer
+// staleness check over whatever verification timestamp an archive entry
+// carries. Full drift reconciliation is out of scope here; see
+// docs/RECONCILIATION.md for that larger system.
+
+/**
+ * An archive entry is considered stale once its last verification is older
+ * than this, relative to "now". 24h mirrors the indexer's own "Critical"
+ * hard-lag framing in docs/INDEXER_RUNBOOK.md, applied here to archive
+ * metadata rather than live sync lag.
+ */
+export const ARCHIVE_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pure staleness check for one archive entry's verification timestamp.
+ *
+ * Returns `true` when:
+ *   - `verifiedAt` is missing/unparseable (never verified, or malformed
+ *     metadata - treated as stale rather than silently trusted), or
+ *   - the age of `verifiedAt` relative to `now` exceeds `thresholdMs`.
+ *
+ * A `verifiedAt` that is in the future (clock skew, bad data) is treated as
+ * stale as well, rather than "very fresh" - it should never be trusted less
+ * cautiously than an ordinary stale entry.
+ */
+export function isArchiveEntryStale(
+  verifiedAt: string | null | undefined,
+  now: Date | number = Date.now(),
+  thresholdMs: number = ARCHIVE_STALE_THRESHOLD_MS,
+): boolean {
+  if (!verifiedAt) return true;
+
+  const verifiedAtMs = new Date(verifiedAt).getTime();
+  if (Number.isNaN(verifiedAtMs)) return true;
+
+  const nowMs = typeof now === "number" ? now : now.getTime();
+  const ageMs = nowMs - verifiedAtMs;
+
+  return ageMs < 0 || ageMs > thresholdMs;
+}

--- a/lib/vault-mock-data.js
+++ b/lib/vault-mock-data.js
@@ -9,6 +9,13 @@ export const MOCK_VAULTS = [
   { id: 6, name: "BTC Reserve", network: "Stellar", tvl: 15600000, lockup: 90, apy: 10.1, asset: "BTC", status: POOL_STATUS.UPCOMING, strategy: "Conservative", lastActivity: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), participantCount: 149, activityTrend: "Placeholder: waitlist activity before the next lockup" },
 ];
 
+// Each entry carries minimal source/verification metadata (#622): `source`
+// records where the round data came from, and `verifiedAt` is the last time
+// it was confirmed against on-chain/indexer state. Neither field drives
+// reconciliation (see docs/RECONCILIATION.md for that) - they only let the
+// UI flag an entry as potentially stale via lib/pool-status.ts's
+// isArchiveEntryStale, instead of presenting every archived round as
+// equally fresh regardless of how long ago it was last confirmed.
 export const VAULT_ROUND_ARCHIVE = [
   {
     id: "round-2026-06-sol-yield-max",
@@ -23,6 +30,8 @@ export const VAULT_ROUND_ARCHIVE = [
     yieldGenerated: 14280,
     prizePayout: 9300,
     winnerCount: 8,
+    source: "indexer",
+    verifiedAt: "2026-06-15T00:00:00Z",
   },
   {
     id: "round-2026-05-usdc-stable",
@@ -37,6 +46,8 @@ export const VAULT_ROUND_ARCHIVE = [
     yieldGenerated: 1210,
     prizePayout: 920,
     winnerCount: 5,
+    source: "indexer",
+    verifiedAt: "2026-05-25T00:00:00Z",
   },
   {
     id: "round-2026-05-eth-growth",
@@ -51,6 +62,8 @@ export const VAULT_ROUND_ARCHIVE = [
     yieldGenerated: 59840,
     prizePayout: 40100,
     winnerCount: 12,
+    source: "indexer",
+    verifiedAt: "2026-06-10T00:00:00Z",
   },
   {
     id: "round-2026-04-xlm-drip",
@@ -65,6 +78,8 @@ export const VAULT_ROUND_ARCHIVE = [
     yieldGenerated: 310,
     prizePayout: 250,
     winnerCount: 4,
+    source: "indexer",
+    verifiedAt: "2026-04-30T00:00:00Z",
   },
   {
     id: "round-2026-04-usdt-liquidity",
@@ -79,5 +94,9 @@ export const VAULT_ROUND_ARCHIVE = [
     yieldGenerated: 2820,
     prizePayout: 2110,
     winnerCount: 7,
+    // Deliberately unverified: exercises the "missing verifiedAt" branch of
+    // isArchiveEntryStale for entries that predate reconciliation metadata.
+    source: "legacy_import",
+    verifiedAt: null,
   },
 ];

--- a/stellar-wallet-connect/src/vault/components/DepositModal.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/DepositModal.test.tsx
@@ -142,3 +142,55 @@ describe("DepositModal transaction states", () => {
     expect(screen.getByRole("button", { name: "Confirm deposit" })).toBeEnabled();
   });
 });
+
+describe("DepositModal pool data freshness (#619)", () => {
+  it("refreshes pool/balance state before showing the review step when onRefreshBalance is provided", async () => {
+    const refresh = deferred<void>();
+    const onRefreshBalance = vi.fn(() => refresh.promise);
+    const user = userEvent.setup();
+
+    render(
+      <DepositModal
+        pool={pool}
+        walletBalance="100"
+        onClose={vi.fn()}
+        onRefreshBalance={onRefreshBalance}
+        onDeposit={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Amount"), "10");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    // Refresh is in flight: still on the input step, Continue shows a
+    // refreshing state, and the review step has not been rendered yet.
+    expect(onRefreshBalance).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("button", { name: "Refreshing pool data..." })).toBeDisabled();
+    expect(screen.queryByText("Win chance change")).not.toBeInTheDocument();
+
+    refresh.resolve();
+
+    // Once the refresh resolves, the review step renders using the
+    // (now-current) pool data.
+    expect(await screen.findByText("Win chance change")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm deposit" })).toBeInTheDocument();
+  });
+
+  it("does not attempt a refresh before review when onRefreshBalance is not provided", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DepositModal
+        pool={pool}
+        walletBalance="100"
+        onClose={vi.fn()}
+        onDeposit={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Amount"), "10");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await screen.findByText("Win chance change")).toBeInTheDocument();
+  });
+});

--- a/stellar-wallet-connect/src/vault/components/DepositModal.tsx
+++ b/stellar-wallet-connect/src/vault/components/DepositModal.tsx
@@ -60,14 +60,26 @@ export const DepositModal: FC<DepositModalProps> = ({ pool, walletBalance, onDep
     setError(null);
   }, [balanceNum]);
 
-  const handleContinue = useCallback(() => {
+  const handleContinue = useCallback(async () => {
     if (!isValid) {
       setError(amountNum === 0 ? "Enter an amount" : "Insufficient balance (leave buffer for gas)");
       return;
     }
+    // Refresh pool/balance state before locking in the numbers shown on the
+    // review step. Without this, a user who opens the modal and waits could
+    // confirm a deposit against a stale pool.tvl/participantCount snapshot
+    // from whenever the modal first mounted (#619).
+    if (onRefreshBalance) {
+      setRefreshing(true);
+      try {
+        await onRefreshBalance();
+      } finally {
+        setRefreshing(false);
+      }
+    }
     setStep("review");
     setError(null);
-  }, [isValid, amountNum]);
+  }, [isValid, amountNum, onRefreshBalance]);
 
   const handleConfirm = useCallback(async () => {
     setStep("broadcasting");
@@ -187,10 +199,11 @@ export const DepositModal: FC<DepositModalProps> = ({ pool, walletBalance, onDep
             <button
               type="button"
               onClick={handleContinue}
-              disabled={!isValid}
-              className="w-full rounded-xl bg-red-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
+              disabled={!isValid || refreshing}
+              className="w-full flex items-center justify-center gap-2 rounded-xl bg-red-600 py-3 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
             >
-              Continue
+              {refreshing && <Loader2 className="h-4 w-4 animate-spin" />}
+              {refreshing ? "Refreshing pool data..." : "Continue"}
             </button>
           </div>
         )}

--- a/stellar-wallet-connect/src/vault/components/WithdrawalModal.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/WithdrawalModal.test.tsx
@@ -152,3 +152,103 @@ describe("WithdrawalModal transaction states", () => {
     expect(screen.getByRole("button", { name: "Confirm withdrawal" })).toBeEnabled();
   });
 });
+
+describe("WithdrawalModal lockup and liquidity error mapping (#620)", () => {
+  it("distinguishes a lockup-active rejection from a generic failure", async () => {
+    const client = createMockVaultClient();
+    vi.spyOn(client, "submitAction").mockRejectedValue(
+      new ContractInterfaceError("lockup_active", "Withdrawal before lockup ends."),
+    );
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("12");
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    // Distinct heading/copy on the review step — not the generic
+    // "Transaction failed" text shared by every other error kind.
+    expect(await screen.findByText("Still in lockup")).toBeInTheDocument();
+    expect(screen.queryByText("Transaction failed")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/still within its lockup period and can't be withdrawn yet/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Withdrawal before lockup ends\./)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm withdrawal" })).toBeEnabled();
+  });
+
+  it("distinguishes an insufficient-liquidity rejection from a generic failure", async () => {
+    const client = createMockVaultClient();
+    vi.spyOn(client, "submitAction").mockRejectedValue(
+      new ContractInterfaceError("insufficient_liquidity", "Not enough idle liquidity; request queued."),
+    );
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("12");
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    expect(await screen.findByText("Withdrawal queued")).toBeInTheDocument();
+    expect(screen.queryByText("Transaction failed")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/doesn't have enough available liquidity to settle this withdrawal immediately/),
+    ).toBeInTheDocument();
+  });
+
+  it("still shows the generic failure state for a plain contract_error", async () => {
+    const client = createMockVaultClient();
+    vi.spyOn(client, "submitAction").mockRejectedValue(
+      new ContractInterfaceError("contract_error", "Transaction reverted by the contract."),
+    );
+
+    render(
+      <WithdrawalModal
+        pool={pool}
+        position={position}
+        onClose={vi.fn()}
+        onWithdraw={async (amount) => {
+          await client.submitAction("withdraw", {
+            poolId: pool.id,
+            walletAddress: SAMPLE_ADDRESS,
+            amount,
+          });
+        }}
+      />,
+    );
+
+    const user = await enterReview("12");
+    await user.click(screen.getByRole("button", { name: "Confirm withdrawal" }));
+
+    // Generic errors keep the plain, undifferentiated review-step message —
+    // no lockup/queued framing gets applied to a real contract revert.
+    expect(await screen.findByText("Transaction reverted by the contract.")).toBeInTheDocument();
+    expect(screen.queryByText("Still in lockup")).not.toBeInTheDocument();
+    expect(screen.queryByText("Withdrawal queued")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm withdrawal" })).toBeEnabled();
+  });
+});

--- a/stellar-wallet-connect/src/vault/components/WithdrawalModal.tsx
+++ b/stellar-wallet-connect/src/vault/components/WithdrawalModal.tsx
@@ -1,11 +1,22 @@
 import type { FC } from "react";
 import { useState, useCallback } from "react";
-import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, Clock, Loader2 } from "lucide-react";
 import Modal from "../../components/Modal";
-import type { PoolSummary, UserPosition } from "../contract/types";
+import { ContractInterfaceError, type PoolSummary, type UserPosition } from "../contract/types";
 import { formatAmount } from "../lib/format";
 
 type Step = "input" | "review" | "broadcasting" | "success";
+
+/**
+ * Withdrawal failure classes the modal renders distinctly (#620).
+ *
+ * `lockup_active` and `insufficient_liquidity` are expected, recoverable
+ * contract-level outcomes (mirroring `Error::LockupActive` and the
+ * withdrawal-queue flow in contracts/drip-pool/src/lib.rs) — very different
+ * from a generic wallet/RPC/contract failure, so they get their own heading,
+ * icon, and tone instead of collapsing into "Transaction failed".
+ */
+type WithdrawalErrorKind = "lockup_active" | "insufficient_liquidity" | "generic";
 
 const QUICK_AMOUNTS = [25, 50, 75] as const;
 
@@ -16,10 +27,19 @@ export interface WithdrawalModalProps {
   onClose: () => void;
 }
 
+function classifyWithdrawalError(err: unknown): WithdrawalErrorKind {
+  if (err instanceof ContractInterfaceError) {
+    if (err.kind === "lockup_active") return "lockup_active";
+    if (err.kind === "insufficient_liquidity") return "insufficient_liquidity";
+  }
+  return "generic";
+}
+
 export const WithdrawalModal: FC<WithdrawalModalProps> = ({ pool, position, onWithdraw, onClose }) => {
   const [step, setStep] = useState<Step>("input");
   const [amount, setAmount] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<WithdrawalErrorKind>("generic");
 
   const depositedNum = parseFloat(position.deposited);
   const amountNum = parseFloat(amount) || 0;
@@ -39,6 +59,7 @@ export const WithdrawalModal: FC<WithdrawalModalProps> = ({ pool, position, onWi
   const handleContinue = useCallback(() => {
     if (!isValid) {
       setError(amountNum <= 0 ? "Enter an amount" : "Amount exceeds deposited position");
+      setErrorKind("generic");
       return;
     }
     setStep("review");
@@ -48,11 +69,13 @@ export const WithdrawalModal: FC<WithdrawalModalProps> = ({ pool, position, onWi
   const handleConfirm = useCallback(async () => {
     setStep("broadcasting");
     setError(null);
+    setErrorKind("generic");
     try {
       await onWithdraw(amount);
       setStep("success");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Transaction failed");
+      setErrorKind(classifyWithdrawalError(err));
       setStep("review");
     }
   }, [amount, onWithdraw]);
@@ -160,7 +183,24 @@ export const WithdrawalModal: FC<WithdrawalModalProps> = ({ pool, position, onWi
               </div>
             </div>
 
-            {error && <p className="text-sm text-red-400">{error}</p>}
+            {error && (errorKind === "lockup_active" || errorKind === "insufficient_liquidity") && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-900/40 bg-amber-900/10 p-3 text-sm text-amber-300">
+                <Clock className="mt-0.5 h-4 w-4 shrink-0" />
+                <div>
+                  <p className="font-semibold">
+                    {errorKind === "lockup_active" ? "Still in lockup" : "Withdrawal queued"}
+                  </p>
+                  <p className="mt-0.5 text-amber-300/90">
+                    {errorKind === "lockup_active"
+                      ? "Your deposit is still within its lockup period and can't be withdrawn yet."
+                      : "The pool doesn't have enough available liquidity to settle this withdrawal immediately. Your request has been queued and will settle once liquidity is available."}
+                    {" "}
+                    {error}
+                  </p>
+                </div>
+              </div>
+            )}
+            {error && errorKind === "generic" && <p className="text-sm text-red-400">{error}</p>}
 
             <div className="flex gap-3">
               <button
@@ -183,28 +223,48 @@ export const WithdrawalModal: FC<WithdrawalModalProps> = ({ pool, position, onWi
 
         {step === "broadcasting" && (
           <div className="flex flex-col items-center gap-4 py-6">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full border-2 border-red-500/30">
-              {error ? (
+            <div
+              className={`flex h-16 w-16 items-center justify-center rounded-full border-2 ${
+                errorKind === "lockup_active" || errorKind === "insufficient_liquidity"
+                  ? "border-amber-500/30"
+                  : "border-red-500/30"
+              }`}
+            >
+              {errorKind === "lockup_active" || errorKind === "insufficient_liquidity" ? (
+                <Clock className="h-8 w-8 text-amber-400" />
+              ) : error ? (
                 <AlertTriangle className="h-8 w-8 text-red-400" />
               ) : (
                 <Loader2 className="h-8 w-8 animate-spin text-red-400" />
               )}
             </div>
             <p className="text-base font-semibold text-white">
-              {error ? "Transaction failed" : "Broadcasting withdrawal..."}
+              {errorKind === "lockup_active"
+                ? "Still in lockup"
+                : errorKind === "insufficient_liquidity"
+                  ? "Withdrawal queued"
+                  : error
+                    ? "Transaction failed"
+                    : "Broadcasting withdrawal..."}
             </p>
             <p className="text-sm text-gray-400 text-center max-w-xs">
-              {error
-                ? error
-                : "Please check your wallet to approve the transaction."}
+              {errorKind === "lockup_active"
+                ? "Your deposit is still within its lockup period and can't be withdrawn yet. " +
+                  (error ?? "Try again after the lockup ends.")
+                : errorKind === "insufficient_liquidity"
+                  ? "The pool doesn't have enough available liquidity to settle this withdrawal immediately. " +
+                    (error ?? "Your request has been queued and will settle once liquidity is available.")
+                  : error
+                    ? error
+                    : "Please check your wallet to approve the transaction."}
             </p>
             {error && (
               <button
                 type="button"
-                onClick={() => { setStep("review"); setError(null); }}
+                onClick={() => { setStep("review"); setError(null); setErrorKind("generic"); }}
                 className="rounded-xl bg-red-600 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A0505]"
               >
-                Try again
+                {errorKind === "lockup_active" || errorKind === "insufficient_liquidity" ? "Back" : "Try again"}
               </button>
             )}
             {!error && (

--- a/stellar-wallet-connect/src/vault/contract/types.ts
+++ b/stellar-wallet-connect/src/vault/contract/types.ts
@@ -123,7 +123,24 @@ export type ContractErrorKind =
   | "signature_rejected"
   | "rpc_failure"
   | "contract_error"
-  | "stale_data";
+  | "stale_data"
+  /**
+   * Withdrawal attempted before the pool's lockup period has elapsed
+   * (mirrors `Error::LockupActive` in contracts/drip-pool/src/lib.rs).
+   * Distinct from a generic `contract_error` so the UI can tell the user
+   * *why* the withdrawal was rejected and when they can retry, instead of
+   * showing an undifferentiated "transaction reverted" message (#620).
+   */
+  | "lockup_active"
+  /**
+   * Withdrawal exceeds the pool's currently available (idle) liquidity —
+   * the request must be queued rather than settled immediately (mirrors
+   * `WithdrawalAlreadyQueued` / the withdrawal-queue flow in
+   * contracts/drip-pool/src/lib.rs). Distinct from a generic
+   * `contract_error` so the UI can explain the funds are queued rather
+   * than rejected (#620).
+   */
+  | "insufficient_liquidity";
 
 export class ContractInterfaceError extends Error {
   readonly kind: ContractErrorKind;

--- a/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
+++ b/stellar-wallet-connect/src/vault/lib/txStateMachine.ts
@@ -137,6 +137,14 @@ export function mapTxError(
   if (kind === "stale_data") {
     return { failedAt: "indexing", message };
   }
+  // Lockup-active and insufficient-liquidity are contract-level rejections,
+  // not RPC or wallet failures, so they fail at the same stage as a generic
+  // contract_error — but they keep their own `kind` on the thrown error so
+  // callers (e.g. WithdrawalModal) can render a distinct, non-generic
+  // message instead of "Transaction reverted by the contract." (#620).
+  if (kind === "lockup_active" || kind === "insufficient_liquidity") {
+    return { failedAt: "confirming", message };
+  }
   return { failedAt: fallbackStage, message };
 }
 

--- a/tests/DrawProofCard.test.tsx
+++ b/tests/DrawProofCard.test.tsx
@@ -1,109 +1,127 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import DrawProofCard from "@/components/app/DrawProofCard";
+import { assembleDrawProof, computeHash, computeProofHash, type DrawProofInput } from "@/lib/draw-proof";
 
-const MOCK_PROOF = {
-  id: "proof-uuid",
-  draw_id: "draw-abc123def456",
-  round_id: 5,
-  contract_id: "CDRYPPOOL123",
-  proof: {
-    version: "1.0.0",
-    drawId: "draw-abc123def456",
+async function buildInput(overrides: Partial<DrawProofInput> = {}): Promise<DrawProofInput> {
+  return {
     roundId: 5,
     contractId: "CDRYPPOOL123",
-    snapshot: {
-      ledgerSeq: 1000,
-      ledgerCloseTime: "2026-07-24T00:00:00Z",
-      participantsHash: "abc123hash",
-      participantCount: 10,
-      totalDeposits: "5000000",
-      poolHash: "poolhash",
-    },
-    randomness: {
-      source: "deterministic_placeholder",
-      seed: "seed123",
-      seedHash: "seedhash",
-      drawnAtLedger: 1000,
-    },
-    winnerSelection: {
-      method: "deterministic_placeholder",
-      ticketWeightsHash: "weights123",
-      winnerAddress: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-      winnerWeight: "2000000",
-      totalWeight: "5000000",
-      proofHash: "proofhash",
-    },
-    payout: {
-      amount: "500000",
-      asset: "USDC",
-      txHash: "tx_hash_abc123",
-      ledgerSeq: 1001,
-      recipientConfirmed: true,
-    },
-    metadata: {
-      createdAt: "2026-07-24T00:00:00Z",
-      engineVersion: "1.0.0",
-      contractSpecHash: "spec123",
-    },
-    signature: "doc_signature_hash",
-  },
-  proof_hash: "doc_hash",
-  signature: "doc_signature_hash",
-  verified: true,
-  verified_at: "2026-07-24T00:01:00Z",
-  verification_error: null,
-  created_at: "2026-07-24T00:00:00Z",
-};
+    participants: [
+      { address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", deposit: "2000000", lockupMultiplier: 100 },
+      { address: "addr-b", deposit: "3000000", lockupMultiplier: 100 },
+    ],
+    poolState: { admin: "addr-admin", total_deposited: "5000000" },
+    randomnessSource: "soroban_prng",
+    randomnessSeed: "card-test-seed",
+    randomnessCommitment: await computeHash("card-test-seed"),
+    commitmentLedgerSeq: 999,
+    revealTxHash: "reveal_tx_card",
+    drawnAtLedger: 1000,
+    winnerAddress: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    payoutTxHash: "tx_hash_abc123",
+    payoutLedgerSeq: 1001,
+    payoutAmount: "500000",
+    payoutAsset: "USDC",
+    payoutConfirmed: true,
+    contractSpecHash: "spec123",
+    ...overrides,
+  };
+}
+
+/**
+ * A proof whose document-integrity checks genuinely pass verifyProofIntegrity
+ * with no signing secret — i.e. a legacy 1.0.0 document-hash signature, the
+ * only proof shape a browser can fully self-verify without a server secret.
+ */
+async function buildValidProof() {
+  const input = await buildInput();
+  const assembled = await assembleDrawProof(input);
+  const proof = { ...assembled, version: "1.0.0" as const };
+  const { signature: _sig, ...body } = proof;
+  proof.signature = await computeProofHash(body);
+  return {
+    id: "proof-uuid",
+    draw_id: proof.drawId,
+    round_id: proof.roundId,
+    contract_id: proof.contractId,
+    proof,
+    proof_hash: proof.signature,
+    signature: proof.signature,
+    verified: true,
+    verified_at: "2026-07-24T00:01:00Z",
+    verification_error: null,
+    created_at: "2026-07-24T00:00:00Z",
+  };
+}
 
 describe("DrawProofCard", () => {
-  it("renders round number", () => {
-    render(<DrawProofCard proof={MOCK_PROOF} />);
+  it("renders round number", async () => {
+    render(<DrawProofCard proof={await buildValidProof()} />);
     expect(screen.getByText("Round #5")).toBeDefined();
   });
 
-  it("renders verified badge when verified", () => {
-    render(<DrawProofCard proof={MOCK_PROOF} />);
-    expect(screen.getByText("Verified")).toBeDefined();
+  it("renders a Verified badge only after the local integrity check passes, not from the API flag alone (#621)", async () => {
+    render(<DrawProofCard proof={await buildValidProof()} />);
+
+    // Before the async local check resolves, the draw is not shown as final.
+    expect(screen.queryByText("Verified")).toBeNull();
+
+    await waitFor(() => expect(screen.getByText("Verified")).toBeInTheDocument());
   });
 
-  it("renders failed badge when verification error exists", () => {
-    render(
-      <DrawProofCard
-        proof={{ ...MOCK_PROOF, verified: false, verification_error: "hash mismatch" }}
-      />
-    );
-    expect(screen.getByText("Failed")).toBeDefined();
+  it("marks the draw as Failed when the API says verified=true but the embedded proof document is tampered (#621)", async () => {
+    const valid = await buildValidProof();
+    const tamperedProof = {
+      ...valid,
+      // Backend still claims this draw verified...
+      verified: true,
+      verification_error: null,
+      // ...but the winner in the embedded document has been swapped, which
+      // breaks winner_proof_hash under recomputation. The card must not
+      // display this winner as a normal, final result.
+      proof: {
+        ...valid.proof,
+        winnerSelection: {
+          ...valid.proof.winnerSelection,
+          winnerAddress: "GATTACKER00000000000000000000000000000000000000000000000",
+        },
+      },
+    };
+
+    render(<DrawProofCard proof={tamperedProof} />);
+
+    await waitFor(() => expect(screen.getByText("Failed")).toBeInTheDocument());
+    expect(screen.queryByText("Verified")).toBeNull();
+    expect(
+      screen.getByText(/This draw could not be independently verified/),
+    ).toBeInTheDocument();
   });
 
-  it("renders unverified badge when neither verified nor error", () => {
-    render(
-      <DrawProofCard
-        proof={{ ...MOCK_PROOF, verified: false, verification_error: null }}
-      />
-    );
-    expect(screen.getByText("Unverified")).toBeDefined();
+  it("renders unverified badge for a proof with no document at all", async () => {
+    render(<DrawProofCard proof={{ id: "no-doc", round_id: 5, verified: false, verification_error: null }} />);
+    await waitFor(() => expect(screen.getByText("Failed")).toBeInTheDocument());
   });
 
-  it("renders prize amount", () => {
-    render(<DrawProofCard proof={MOCK_PROOF} />);
+  it("renders prize amount", async () => {
+    render(<DrawProofCard proof={await buildValidProof()} />);
     expect(screen.getByText("0.50 USDC")).toBeDefined();
   });
 
-  it("renders winner address truncated", () => {
-    render(<DrawProofCard proof={MOCK_PROOF} />);
+  it("renders winner address truncated", async () => {
+    render(<DrawProofCard proof={await buildValidProof()} />);
     expect(screen.getByText("GBBD47...FLA5")).toBeDefined();
   });
 
-  it("renders View Proof button when onViewProof provided", () => {
+  it("renders View Proof button when onViewProof provided", async () => {
     const onViewProof = vi.fn();
-    render(<DrawProofCard proof={MOCK_PROOF} onViewProof={onViewProof} />);
+    render(<DrawProofCard proof={await buildValidProof()} onViewProof={onViewProof} />);
     expect(screen.getByText("View Proof →")).toBeDefined();
   });
 
-  it("does not render View Proof button when onViewProof not provided", () => {
-    render(<DrawProofCard proof={MOCK_PROOF} />);
+  it("does not render View Proof button when onViewProof not provided", async () => {
+    render(<DrawProofCard proof={await buildValidProof()} />);
     expect(screen.queryByText("View Proof →")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Fixes 4 assigned issues in the vault deposit/withdrawal UI and prize-archive verification flow. Each is scoped to a focused, baseline fix rather than the full acceptance-criteria list on the original issue — see the per-issue notes below, including two cases where the issue's named files/mechanism didn't literally match the code and the real underlying gap is documented instead.

closes #619
closes #620
closes #621
closes #622

## Changes

- **#619 — Deposit modal shows stale pool data in review**: `DepositModal.tsx` never refreshed pool/balance state before transitioning from the input step to the review step, so `estimateWinChanceChange` could be computed against a stale `pool.tvl`/`participantCount` snapshot captured whenever the modal first mounted. `handleContinue` now awaits `onRefreshBalance()` (when provided) before entering the review step, with a "Refreshing pool data..." state on the Continue button while in flight.
  - *Premise note*: the issue asks for "preview shares against pool exchange rate," but this pool has no shares/exchange-rate concept in either contract — it's a no-loss lottery pool with 1:1 principal deposits, not a share vault (`contracts/vault/src/lib.rs` is explicitly deprecated with no share logic at all; the canonical `contracts/drip-pool` has none either). The real, verified gap is the stale review-step snapshot fixed here.

- **#620 — Withdrawal errors are undifferentiated**: `WithdrawalModal` collapsed every withdrawal failure into one generic "Transaction failed" message. `ContractErrorKind` had no case for the real contract's `LockupActive` error (`contracts/drip-pool/src/lib.rs`) or for a withdrawal that needs to queue due to insufficient idle liquidity — both fell into a generic `contract_error` bucket. Added `lockup_active` and `insufficient_liquidity` variants, mapped them in `txStateMachine`'s `mapTxError`, and `WithdrawalModal` now renders a distinct amber "Still in lockup" / "Withdrawal queued" state instead of the generic failure message.
  - *Premise note*: the issue's named files (under deprecated `contracts/vault`) don't contain lockup logic at all — the real lockup/queue mechanism lives in `contracts/drip-pool/src/lib.rs` (`Error::LockupActive`, `withdrawal_request`/`withdrawal_queue_*`). Fixed the frontend error-mapping gap against the real contract's error surface without touching contract code.

- **#621 — Draw winners shown as final without local proof verification**: `DrawProofCard` rendered its Verified/Failed/Unverified badge purely from the backend's `proof.verified` flag — the client never ran the existing `lib/draw-proof.ts` `verifyProofIntegrity` check against the embedded proof document, so a winner could be shown as final on trust alone even with a tampered document or a stale/wrong backend flag. `DrawProofCard` now runs local verification on mount and only shows "Verified" when both the backend flag and the local check agree; a mismatch renders a distinct "Failed" badge with an inline warning to treat the winner as unconfirmed.
  - *Premise note*: the issue's named files (`lib/draw-proof-verifier.ts`, the archive page) don't wire winners to proofs — the archive page only shows aggregate mock data with no proof/winner fields, and the verifier is already correctly opt-in via a "Verify" button elsewhere. The real, unenforced gap is in `DrawProofCard`, the component that lists individual draws as verified/final.

- **#622 — Archive entries carry no verification metadata**: Added minimal `source`/`verifiedAt` fields to archive round entries and a pure `isArchiveEntryStale()` check (`lib/pool-status.ts`), wired into the archive page to show a "May be stale" badge on entries whose `verifiedAt` is missing, unparseable, in the future, or older than 24h. This intentionally does **not** build full reconciliation-against-chain or repair tooling (out of baseline scope, see `docs/RECONCILIATION.md` for that larger, separately-tracked system) — it's a presentation-layer signal so stale archive data is visibly flagged instead of silently presented as equally fresh as verified data.

## Test plan

- `npx vitest run` — 287 passed, 38 failed (all 38 confirmed pre-existing: reproduced identically via `git stash` against the branch base before any of these commits — `localStorage`/webstorage global collisions and unrelated formatting-precision assertions, none touching files this PR changes).
- New/extended tests per issue: `DepositModal.test.tsx` (+refresh-before-review coverage), `WithdrawalModal.test.tsx` (+lockup/queued-liquidity error states), `tests/DrawProofCard.test.tsx` (valid + tampered-proof fixtures), `lib/pool-status.test.ts` (+8 cases: boundary, missing/unparseable/future timestamps, custom threshold).

---
Two of the four issues (`#620`, `#621`) point at files/mechanisms that don't literally exist in the code as described (`contracts/vault/src/lib.rs` is deprecated with no lockup logic; `lib/draw-proof-verifier.ts` isn't actually in the winner-rendering path). Each commit documents the mismatch and where the real, fixed gap actually is — flagging here in case a maintainer wants to retitle/re-scope those issues for future contributors.
