### PR TITLE
fix: distinguish missing pool metrics, wire round snapshot into draw proof, warn on uneconomical claims

### DIFF
--- a/backend/src/services/drawProofService.ts
+++ b/backend/src/services/drawProofService.ts
@@ -95,10 +95,12 @@ export class DrawProofService {
     let poolState: Record<string, unknown> = {};
     let payoutTxHash = action.txHash || "";
     let payoutLedgerSeq = drawLedger + 1;
+    let roundPrincipalSnapshot: string | undefined;
 
     try {
       participants = await this.fetchParticipants(contractId, drawLedger);
       poolState = await this.fetchPoolState(contractId);
+      roundPrincipalSnapshot = await this.fetchRoundPrincipalSnapshot(contractId, roundId);
       if (action.txHash) {
         const tx = await this.rpc.getTransaction(action.txHash);
         if (tx) {
@@ -139,6 +141,7 @@ export class DrawProofService {
       payoutAsset: String(payload.asset || "USDC"),
       payoutConfirmed: true,
       contractSpecHash: options.contractSpecHash || "unknown",
+      ...(roundPrincipalSnapshot !== undefined && { roundPrincipalSnapshot }),
     };
 
     const proof = await assembleDrawProof(input);
@@ -369,6 +372,30 @@ export class DrawProofService {
       return JSON.parse(data.value) as Record<string, unknown>;
     } catch {
       return {};
+    }
+  }
+
+  /**
+   * Reads the contract's own `Round.principal_snapshot` for `roundId` (#642)
+   * — the deterministic cutoff balance the contract freezes at `lock_round`
+   * — so it can be recorded on the draw proof and later cross-checked
+   * against the off-chain `totalDeposits` figure. Returns `undefined` (never
+   * a fabricated value) when the round can't be fetched, e.g. it predates
+   * round-scoped accounting or the RPC call fails.
+   */
+  private async fetchRoundPrincipalSnapshot(
+    contractId: string,
+    roundId: number
+  ): Promise<string | undefined> {
+    if (!this.rpc) return undefined;
+
+    try {
+      const data = await this.rpc.getContractData(contractId, `Round:${roundId}`);
+      const round = JSON.parse(data.value) as Record<string, unknown>;
+      const snapshot = round.principal_snapshot ?? round.principalSnapshot;
+      return snapshot === undefined || snapshot === null ? undefined : String(snapshot);
+    } catch {
+      return undefined;
     }
   }
 

--- a/backend/tests/drawProofService.spec.ts
+++ b/backend/tests/drawProofService.spec.ts
@@ -151,6 +151,37 @@ describe("DrawProofService", () => {
       expect(prisma.drawProof.create).toHaveBeenCalled();
     });
 
+    it("records the contract's on-chain Round.principal_snapshot on the proof when available (#642)", async () => {
+      const prisma = makeMockPrisma({
+        action: makeSelectWinnerAction(),
+      });
+      const rpc = makeRpc({
+        getContractData: vi.fn().mockImplementation((_contractId: string, key: string) => {
+          if (key === "Round:1") {
+            return Promise.resolve({ value: JSON.stringify({ principal_snapshot: "3500000" }) });
+          }
+          return Promise.reject(new Error("not found"));
+        }),
+      });
+      const svc = new DrawProofService(prisma, rpc);
+      const result = await svc.generateProof({ actionId: "action-123" });
+
+      expect(result).not.toBeNull();
+      expect(result!.proofJson.snapshot.roundPrincipalSnapshot).toBe("3500000");
+    });
+
+    it("omits roundPrincipalSnapshot (never fabricates one) when the contract round data can't be fetched", async () => {
+      const prisma = makeMockPrisma({
+        action: makeSelectWinnerAction(),
+      });
+      // Default makeRpc() rejects every getContractData call.
+      const svc = new DrawProofService(prisma, makeRpc());
+      const result = await svc.generateProof({ actionId: "action-123" });
+
+      expect(result).not.toBeNull();
+      expect(result!.proofJson.snapshot.roundPrincipalSnapshot).toBeUndefined();
+    });
+
     it("returns existing proof if already generated", async () => {
       const existingProof = {
         id: "existing-uuid",

--- a/lib/draw-proof-verifier.ts
+++ b/lib/draw-proof-verifier.ts
@@ -125,6 +125,61 @@ async function verifySnapshotLedger(
   }
 }
 
+/**
+ * Cross-checks the proof's `snapshot.totalDeposits` (summed off-chain from
+ * participant data) against the drip-pool contract's own
+ * `Round.principal_snapshot` for this round (#642) — the deterministic
+ * cutoff balance the contract freezes at `lock_round`, before which no late
+ * deposit can be counted. Without this check, a proof's `totalDeposits`
+ * figure is trusted purely from the off-chain participants list; this reads
+ * the contract's frozen storage directly and fails the check if they
+ * disagree, so eligible-balance evidence is independently verifiable rather
+ * than only self-consistent.
+ *
+ * `unverified` (not `fail`) when the proof predates #642 and never recorded
+ * `roundPrincipalSnapshot` — there is nothing to cross-check, not a mismatch.
+ */
+async function verifyRoundSnapshot(
+  proof: DrawProof,
+  rpc: StellarRpcClient
+): Promise<VerificationField> {
+  if (!proof.snapshot.roundPrincipalSnapshot) {
+    return fieldUnverified(
+      "round_snapshot",
+      "Proof does not record a roundPrincipalSnapshot (pre-#642 proof format)"
+    );
+  }
+
+  try {
+    const data = await rpc.getContractData(proof.contractId, `Round:${proof.roundId}`);
+    const round = JSON.parse(data.value) as Record<string, unknown>;
+    const onChainSnapshot = String(
+      round.principal_snapshot ?? round.principalSnapshot ?? ""
+    );
+
+    if (!onChainSnapshot) {
+      return fieldUnverified(
+        "round_snapshot",
+        `Contract round ${proof.roundId} has no principal_snapshot field in storage`
+      );
+    }
+
+    if (onChainSnapshot !== proof.snapshot.roundPrincipalSnapshot) {
+      return fieldFail(
+        "round_snapshot",
+        `expected on-chain principal_snapshot ${onChainSnapshot}, proof recorded ${proof.snapshot.roundPrincipalSnapshot}`
+      );
+    }
+
+    return fieldPass("round_snapshot");
+  } catch (err) {
+    return fieldUnverified(
+      "round_snapshot",
+      `RPC error: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
 // ─── Main Verifier ────────────────────────────────────────────────────────────
 
 export interface ClientVerificationResult extends VerificationResult {
@@ -151,10 +206,12 @@ export async function verifyDrawProofClient(
     fields.push(await verifySnapshotLedger(proof, rpc));
     fields.push(await verifyPayoutTransaction(proof, rpc));
     fields.push(await verifyRandomnessReveal(proof, rpc));
+    fields.push(await verifyRoundSnapshot(proof, rpc));
   } else {
     fields.push(fieldUnverified("snapshot_ledger", "No RPC client provided"));
     fields.push(fieldUnverified("payout_tx", "No RPC client provided"));
     fields.push(fieldUnverified("randomness_reveal", "No RPC client provided"));
+    fields.push(fieldUnverified("round_snapshot", "No RPC client provided"));
   }
 
   // Randomness evidence must be independently confirmed on-chain: without an

--- a/lib/draw-proof.ts
+++ b/lib/draw-proof.ts
@@ -9,6 +9,17 @@ const SnapshotSchema = z.object({
   participantCount: z.number().int().nonnegative(),
   totalDeposits: z.string().min(1),
   poolHash: z.string().min(1),
+  /**
+   * The drip-pool contract's own `Round.principal_snapshot` (#642) — the
+   * deterministic cutoff balance the contract freezes at `lock_round`, before
+   * `totalDeposits` above is ever computed off-chain from participant data.
+   * Optional so older proofs (pre-#642) still validate; when present it lets
+   * a verifier cross-check `totalDeposits` against the contract's own frozen
+   * eligibility snapshot for this round via `getContractData` (see
+   * `verifyRoundSnapshot` in draw-proof-verifier.ts) instead of trusting the
+   * off-chain sum alone.
+   */
+  roundPrincipalSnapshot: z.string().min(1).optional(),
 });
 
 const RandomnessSchema = z.object({
@@ -357,6 +368,13 @@ export interface DrawProofInput {
   payoutAsset: string;
   payoutConfirmed: boolean;
   contractSpecHash: string;
+  /**
+   * The contract's own `Round.principal_snapshot` for `roundId`, read via
+   * `getContractData` (#642). Optional: absent when the caller couldn't
+   * fetch on-chain round state, in which case the proof simply omits
+   * `snapshot.roundPrincipalSnapshot` rather than fabricating a value.
+   */
+  roundPrincipalSnapshot?: string;
 }
 
 export interface AssembleDrawProofOptions {
@@ -417,6 +435,9 @@ export async function assembleDrawProof(
       participantCount: input.participants.length,
       totalDeposits,
       poolHash,
+      ...(input.roundPrincipalSnapshot !== undefined && {
+        roundPrincipalSnapshot: input.roundPrincipalSnapshot,
+      }),
     },
     randomness: {
       source: input.randomnessSource,

--- a/stellar-wallet-connect/src/vault/components/PoolComparisonView.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolComparisonView.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PoolComparisonView } from "./PoolComparisonView";
+import type { PoolSummary } from "../contract/types";
+
+function makePool(overrides: Partial<PoolSummary> = {}): PoolSummary {
+  return {
+    id: "pool-1",
+    name: "Weekly USDC",
+    status: "open",
+    tvl: "1000",
+    asset: "USDC",
+    participantCount: 12,
+    expectedYield: "5.2% APY",
+    prize: "500 USDC",
+    opensAt: "2026-01-01T00:00:00Z",
+    locksAt: "2026-01-08T00:00:00Z",
+    drawsAt: "2026-01-09T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("PoolComparisonView", () => {
+  it("renders present metric values normally", () => {
+    const pool = makePool();
+    render(
+      <PoolComparisonView
+        pools={[pool]}
+        selectedIds={["pool-1"]}
+        onToggleSelect={() => {}}
+        onClear={() => {}}
+      />,
+    );
+    expect(screen.getByText("5.2% APY")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText(/1,000\.00 USDC/)).toBeInTheDocument();
+  });
+
+  it("renders a real zero TVL/participant count as the actual zero, not unavailable", () => {
+    const pool = makePool({ tvl: "0", participantCount: 0 });
+    render(
+      <PoolComparisonView
+        pools={[pool]}
+        selectedIds={["pool-1"]}
+        onToggleSelect={() => {}}
+        onClear={() => {}}
+      />,
+    );
+    // A genuine zero TVL still renders as a real "0.00 USDC" amount.
+    expect(screen.getByText(/0\.00 USDC/)).toBeInTheDocument();
+    // A genuine zero participant count still renders as "0", not "—".
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders missing/unavailable metrics as an explicit unavailable state, never a numeric zero", () => {
+    const pool = makePool({
+      tvl: "" as unknown as string,
+      participantCount: undefined as unknown as number,
+      expectedYield: undefined as unknown as string,
+    });
+    render(
+      <PoolComparisonView
+        pools={[pool]}
+        selectedIds={["pool-1"]}
+        onToggleSelect={() => {}}
+        onClear={() => {}}
+      />,
+    );
+    // Missing TVL/participants/yield must never silently render as "0.00 USDC" / "0" / blank.
+    expect(screen.queryByText(/0\.00 USDC/)).not.toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+    // Three distinct unavailable cells: TVL, Participants, Expected yield.
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("treats a NaN-producing TVL string as unavailable rather than coercing to zero", () => {
+    const pool = makePool({ tvl: "not-a-number" });
+    render(
+      <PoolComparisonView
+        pools={[pool]}
+        selectedIds={["pool-1"]}
+        onToggleSelect={() => {}}
+        onClear={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/0\.00/)).not.toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows an empty state when there are no pools", () => {
+    render(
+      <PoolComparisonView
+        pools={[]}
+        selectedIds={[]}
+        onToggleSelect={() => {}}
+        onClear={() => {}}
+      />,
+    );
+    expect(screen.getByText(/no pools to compare/i)).toBeInTheDocument();
+  });
+
+  it("toggles pool selection", () => {
+    const onToggleSelect = vi.fn();
+    const pool = makePool();
+    render(
+      <PoolComparisonView
+        pools={[pool]}
+        selectedIds={[]}
+        onToggleSelect={onToggleSelect}
+        onClear={() => {}}
+      />,
+    );
+    screen.getByRole("button", { name: /weekly usdc/i }).click();
+    expect(onToggleSelect).toHaveBeenCalledWith("pool-1");
+  });
+});

--- a/stellar-wallet-connect/src/vault/components/PoolComparisonView.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolComparisonView.tsx
@@ -21,20 +21,59 @@ interface ComparisonRow {
   render: (pool: PoolSummary) => ReactNode;
 }
 
+/** Sentinel for a comparison cell whose underlying metric is missing/unavailable
+ * rather than a real, present value. Rendered as "—" so it can never be
+ * mistaken for a real zero (#630). */
+const UNAVAILABLE = "—";
+
+/**
+ * True when a raw metric value from the pool feed represents "no data yet"
+ * rather than a real, present value of zero. Distinguishes `null`/`undefined`,
+ * an empty string, and `NaN`/non-finite numbers (all of which mean "unknown")
+ * from an actual `0` (a legitimate reading), which numeric coercion alone
+ * cannot tell apart — e.g. `Number("")` is `0`, not `NaN` (#630).
+ */
+function isMissingMetric(value: string | number | null | undefined): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") {
+    if (value.trim() === "") return true;
+    return !Number.isFinite(Number(value));
+  }
+  return !Number.isFinite(value);
+}
+
+/** Renders a TVL/yield-style metric as "—" when unavailable, otherwise formats it normally. */
+function renderAmountMetric(value: string | undefined, asset: string): ReactNode {
+  if (isMissingMetric(value)) return UNAVAILABLE;
+  return formatAmount(value as string, asset);
+}
+
+/** Renders a free-text metric (e.g. an expected-yield blurb) as "—" when unavailable. */
+function renderTextMetric(value: string | undefined): ReactNode {
+  if (value === null || value === undefined || value.trim() === "") return UNAVAILABLE;
+  return value;
+}
+
+/** Renders a count metric as "—" when unavailable, never coercing missing data to "0". */
+function renderCountMetric(value: number | null | undefined): ReactNode {
+  if (isMissingMetric(value)) return UNAVAILABLE;
+  return String(value);
+}
+
 const ROWS: ComparisonRow[] = [
   { label: "Status", render: (p) => {
     return (
       <PoolStatusBadge status={p.status} />
     );
   }},
-  { label: "TVL", render: (p) => formatAmount(p.tvl, p.asset) },
+  { label: "TVL", render: (p) => renderAmountMetric(p.tvl, p.asset) },
   { label: "Asset", render: (p) => p.asset },
-  { label: "Participants", render: (p) => String(p.participantCount) },
-  { label: "Expected yield", render: (p) => p.expectedYield },
-  { label: "Prize", render: (p) => p.prize ?? "—" },
-  { label: "Opens", render: (p) => p.opensAt ? formatDate(p.opensAt) : "—" },
-  { label: "Locks", render: (p) => p.locksAt ? formatDate(p.locksAt) : "—" },
-  { label: "Draws", render: (p) => p.drawsAt ? formatDate(p.drawsAt) : "—" },
+  { label: "Participants", render: (p) => renderCountMetric(p.participantCount) },
+  { label: "Expected yield", render: (p) => renderTextMetric(p.expectedYield) },
+  { label: "Prize", render: (p) => p.prize ?? UNAVAILABLE },
+  { label: "Opens", render: (p) => p.opensAt ? formatDate(p.opensAt) : UNAVAILABLE },
+  { label: "Locks", render: (p) => p.locksAt ? formatDate(p.locksAt) : UNAVAILABLE },
+  { label: "Draws", render: (p) => p.drawsAt ? formatDate(p.drawsAt) : UNAVAILABLE },
 ];
 
 export const PoolComparisonView: FC<PoolComparisonViewProps> = ({

--- a/stellar-wallet-connect/src/vault/components/RewardHistory.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/RewardHistory.test.tsx
@@ -48,4 +48,78 @@ describe("RewardHistory", () => {
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute("href", expect.stringContaining("/tx/txhash123456789"));
   });
+
+  describe("uneconomical claim warning (#644)", () => {
+    it("shows a warning badge for a small XLM reward below the estimated claim fee", () => {
+      const smallReward: RewardHistoryEntry[] = [
+        {
+          id: "r-small",
+          poolId: "pool-1",
+          poolName: "XLM Drip",
+          cycleEndedAt: "2026-05-09T00:00:00Z",
+          rewardAmount: "0.001",
+          asset: "XLM",
+          status: "won",
+          winnerAddress: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          txHash: null,
+        },
+      ];
+      render(<RewardHistory entries={smallReward} onClaim={() => {}} />);
+      expect(screen.getAllByText(/may cost more to claim/i).length).toBeGreaterThan(0);
+    });
+
+    it("shows no warning badge for a normal-sized XLM reward", () => {
+      const normalReward: RewardHistoryEntry[] = [
+        {
+          id: "r-normal",
+          poolId: "pool-1",
+          poolName: "XLM Drip",
+          cycleEndedAt: "2026-05-09T00:00:00Z",
+          rewardAmount: "42",
+          asset: "XLM",
+          status: "won",
+          winnerAddress: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          txHash: null,
+        },
+      ];
+      render(<RewardHistory entries={normalReward} onClaim={() => {}} />);
+      expect(screen.queryByText(/may cost more to claim/i)).not.toBeInTheDocument();
+    });
+
+    it("does not warn on a small non-XLM reward (no cross-asset fee comparison)", () => {
+      const smallUsdcReward: RewardHistoryEntry[] = [
+        {
+          id: "r-small-usdc",
+          poolId: "pool-1",
+          poolName: "USDC Drip",
+          cycleEndedAt: "2026-05-09T00:00:00Z",
+          rewardAmount: "0.001",
+          asset: "USDC",
+          status: "won",
+          winnerAddress: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+          txHash: null,
+        },
+      ];
+      render(<RewardHistory entries={smallUsdcReward} onClaim={() => {}} />);
+      expect(screen.queryByText(/may cost more to claim/i)).not.toBeInTheDocument();
+    });
+
+    it("does not warn on a zero-amount reward", () => {
+      const zeroReward: RewardHistoryEntry[] = [
+        {
+          id: "r-zero",
+          poolId: "pool-1",
+          poolName: "XLM Drip",
+          cycleEndedAt: "2026-05-09T00:00:00Z",
+          rewardAmount: "0",
+          asset: "XLM",
+          status: "no_win",
+          winnerAddress: null,
+          txHash: null,
+        },
+      ];
+      render(<RewardHistory entries={zeroReward} />);
+      expect(screen.queryByText(/may cost more to claim/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
+++ b/stellar-wallet-connect/src/vault/components/RewardHistory.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { ExternalLink, History, Trophy } from "lucide-react";
+import { AlertTriangle, ExternalLink, History, Trophy } from "lucide-react";
 import {
   EmptyState,
   ErrorState,
@@ -38,6 +38,43 @@ export interface RewardHistoryProps {
   partialError?: Error | null;
   refetch?: () => void;
 }
+
+/**
+ * Rough, purely-informational estimate of the Stellar network fee for one
+ * claim transaction, in XLM (#644). Mirrors the same "small, local, clearly
+ * approximate" pattern as `GAS_BUFFER` in DepositModal.tsx — this is a UX
+ * safety rail, not a fee oracle: real fees vary with network congestion and
+ * this repo has no live fee-estimation service to query instead.
+ */
+const ESTIMATED_CLAIM_FEE_XLM = 0.01;
+
+/**
+ * True when a reward is denominated in XLM and its amount is below the
+ * rough estimated network fee for the claim transaction that pays it out —
+ * i.e. claiming it may cost more in fees than the reward is worth (#644).
+ *
+ * Deliberately XLM-only: the fee is paid in XLM but a reward can be
+ * denominated in any asset (USDC, etc.), and comparing a USDC amount
+ * against an XLM fee estimate without a price oracle would be a meaningless
+ * (and potentially misleading) cross-asset comparison, so non-XLM rewards
+ * never trigger this warning.
+ */
+function isUneconomicalClaim(entry: RewardHistoryEntry): boolean {
+  if (entry.asset.toUpperCase() !== "XLM") return false;
+  const amount = Number(entry.rewardAmount);
+  if (!Number.isFinite(amount)) return false;
+  return amount > 0 && amount < ESTIMATED_CLAIM_FEE_XLM;
+}
+
+const UneconomicalClaimBadge: FC = () => (
+  <span
+    className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-300"
+    title={`This reward is smaller than the estimated ~${ESTIMATED_CLAIM_FEE_XLM} XLM network fee to claim it — claiming may cost more than it's worth.`}
+  >
+    <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+    May cost more to claim
+  </span>
+);
 
 const OUTCOME_BADGE: Record<RewardOutcome, { label: string; className: string }> = {
   won: { label: "Won", className: "bg-emerald-500/15 text-emerald-300" },
@@ -182,7 +219,12 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
               <tr key={entry.id} className="border-b border-red-900/20 last:border-0">
                 <td className="px-4 py-3 font-medium text-white">{entry.poolName}</td>
                 <td className="px-4 py-3 text-gray-300">{formatDate(entry.cycleEndedAt)}</td>
-                <td className="px-4 py-3 text-gray-300">{formatAmount(entry.rewardAmount, entry.asset)}</td>
+                <td className="px-4 py-3 text-gray-300">
+                  <div className="flex flex-col gap-1">
+                    <span>{formatAmount(entry.rewardAmount, entry.asset)}</span>
+                    {isUneconomicalClaim(entry) && <UneconomicalClaimBadge />}
+                  </div>
+                </td>
                 <td className="px-4 py-3 font-mono text-gray-300">
                   {entry.winnerAddress ? truncateAddress(entry.winnerAddress) : "—"}
                 </td>
@@ -237,7 +279,10 @@ export const RewardHistory: FC<RewardHistoryProps> = ({
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-gray-400">Reward</dt>
-                <dd className="text-gray-200">{formatAmount(entry.rewardAmount, entry.asset)}</dd>
+                <dd className="flex flex-col items-end gap-1 text-gray-200">
+                  <span>{formatAmount(entry.rewardAmount, entry.asset)}</span>
+                  {isUneconomicalClaim(entry) && <UneconomicalClaimBadge />}
+                </dd>
               </div>
               <div className="flex justify-between gap-2">
                 <dt className="text-gray-400">Winner</dt>

--- a/tests/draw-proof.test.ts
+++ b/tests/draw-proof.test.ts
@@ -16,6 +16,7 @@ import {
   type ParticipantEntry,
   type TicketWeight,
 } from "@/lib/draw-proof";
+import { verifyDrawProofClient, type StellarRpcClient } from "@/lib/draw-proof-verifier";
 
 const PARTICIPANTS: ParticipantEntry[] = [
   { address: "addr-b", deposit: "1000000", lockupMultiplier: 150 },
@@ -467,6 +468,108 @@ describe("assembleDrawProof", () => {
     expect(proof.snapshot.participantCount).toBe(1);
     const result = await verifyProofIntegrity(proof, SIGNING_SECRET);
     expect(result.verified).toBe(true);
+  });
+
+  // ─── roundPrincipalSnapshot wiring (#642) ───────────────────────────────────
+  // The drip-pool contract already freezes a deterministic cutoff balance
+  // (`Round.principal_snapshot`) at `lock_round`. These tests confirm that
+  // value is wired into the proof's snapshot rather than silently dropped.
+
+  it("records roundPrincipalSnapshot on the proof when the caller supplies it", async () => {
+    const proof = await assembleSignedProof(
+      await makeInput({ roundPrincipalSnapshot: "3500000" })
+    );
+    expect(proof.snapshot.roundPrincipalSnapshot).toBe("3500000");
+  });
+
+  it("omits roundPrincipalSnapshot when the caller has no on-chain round data (never fabricates one)", async () => {
+    const proof = await assembleSignedProof(await makeInput());
+    expect(proof.snapshot.roundPrincipalSnapshot).toBeUndefined();
+  });
+});
+
+// ─── verifyDrawProofClient: round snapshot cross-check (#642) ────────────────
+
+function makeMockRpc(overrides: Partial<StellarRpcClient> = {}): StellarRpcClient {
+  return {
+    getLedger: async (sequence: number) => ({
+      id: "ledger-id",
+      sequence,
+      closedAt: "2026-07-24T00:00:00Z",
+      hash: "ledger-hash",
+    }),
+    getTransaction: async (hash: string) => ({
+      hash,
+      ledger: 1001,
+      successful: true,
+      status: "SUCCESS",
+    }),
+    getContractData: async () => ({ value: "{}", lastModifiedLedger: 1000 }),
+    ...overrides,
+  };
+}
+
+describe("verifyDrawProofClient — round snapshot cross-check", () => {
+  it("passes when the on-chain principal_snapshot matches the proof's recorded value", async () => {
+    const input = await makeInput({ roundPrincipalSnapshot: "3500000" });
+    const proof = await assembleSignedProof(input);
+
+    const rpc = makeMockRpc({
+      getContractData: async (_contractId, key) => {
+        if (key === "Round:1") {
+          return { value: JSON.stringify({ principal_snapshot: "3500000" }), lastModifiedLedger: 1000 };
+        }
+        return { value: "{}", lastModifiedLedger: 1000 };
+      },
+    });
+
+    const result = await verifyDrawProofClient(proof, rpc);
+    expect(result.fields).toContainEqual(
+      expect.objectContaining({ name: "round_snapshot", status: "pass" })
+    );
+  });
+
+  it("fails when the on-chain principal_snapshot disagrees with the proof's recorded value", async () => {
+    const input = await makeInput({ roundPrincipalSnapshot: "3500000" });
+    const proof = await assembleSignedProof(input);
+
+    const rpc = makeMockRpc({
+      getContractData: async (_contractId, key) => {
+        if (key === "Round:1") {
+          // A substituted/stale snapshot — the contract's frozen cutoff disagrees.
+          return { value: JSON.stringify({ principal_snapshot: "9999999" }), lastModifiedLedger: 1000 };
+        }
+        return { value: "{}", lastModifiedLedger: 1000 };
+      },
+    });
+
+    const result = await verifyDrawProofClient(proof, rpc);
+    expect(result.fields).toContainEqual(
+      expect.objectContaining({ name: "round_snapshot", status: "fail" })
+    );
+    expect(result.verified).toBe(false);
+  });
+
+  it("is unverified (not failed) for a pre-#642 proof with no recorded roundPrincipalSnapshot", async () => {
+    const input = await makeInput();
+    const proof = await assembleSignedProof(input);
+    expect(proof.snapshot.roundPrincipalSnapshot).toBeUndefined();
+
+    const rpc = makeMockRpc();
+    const result = await verifyDrawProofClient(proof, rpc);
+    expect(result.fields).toContainEqual(
+      expect.objectContaining({ name: "round_snapshot", status: "unverified" })
+    );
+  });
+
+  it("is unverified when no RPC client is provided at all", async () => {
+    const input = await makeInput({ roundPrincipalSnapshot: "3500000" });
+    const proof = await assembleSignedProof(input);
+
+    const result = await verifyDrawProofClient(proof);
+    expect(result.fields).toContainEqual(
+      expect.objectContaining({ name: "round_snapshot", status: "unverified" })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes 3 of 4 assigned issues with focused, baseline-scoped changes; the fourth (issue number 643, referenced below) is left open because no real cap/limit mechanism exists anywhere in the codebase to enforce or even validate against — inventing one from scratch was out of scope for a baseline pass. See the per-issue notes below, including one case where the issue named a deprecated file and the real fix lives elsewhere.

closes #630
closes #642
closes #644

## Changes

- **#630 — Pool comparison shows missing metrics as a literal zero**: `PoolComparisonView.tsx` rendered a missing/unavailable metric (empty-string TVL, `undefined` participant count, unset expected yield) as a literal `0`/`0.00`/blank, because numeric coercion treats an empty string as `0` — making "no data yet" indistinguishable from a genuine zero reading. Added `isMissingMetric()` plus per-row renderers that explicitly check null/undefined/empty-string/NaN before formatting, falling back to an explicit "—" cell instead of a numeric zero. A real zero value still renders as the actual zero. Scoped to this rendering-only bug — does not build a broader trusted-data-source/staleness architecture.

- **#642 — Draw proof doesn't reference a deterministic eligibility snapshot**: the `drip-pool` contract already has a real, deterministic cutoff snapshot for round eligibility — `Round.principal_snapshot`, frozen at `lock_round` (deposits after that point are rejected), publicly readable via the `round()` query — but it was never referenced by the draw proof, which computed `snapshot.totalDeposits` purely off-chain from a participants list with nothing to cross-check it against. Wired it in: `lib/draw-proof.ts` adds an optional `snapshot.roundPrincipalSnapshot` field (populated only from real on-chain data, never fabricated); `lib/draw-proof-verifier.ts` adds `verifyRoundSnapshot`, which reads the contract's `Round:<id>` storage and fails the check if it disagrees with the proof's recorded snapshot, returning `unverified` (not a hard failure) for proofs that predate this field or when no RPC client is available; `backend/src/services/drawProofService.ts` fetches the snapshot alongside its existing RPC calls and passes it through. No contract logic was touched — this only wires up an existing mechanism.

- **#644 — Claim flow doesn't communicate claim economics**: `RewardHistory.tsx` showed a claim button for every won reward regardless of size, with no indication that claiming a very small reward could cost more in network fees than the reward is worth. Added an informational-only "May cost more to claim" badge next to the reward amount when it's XLM-denominated and below a small, documented `ESTIMATED_CLAIM_FEE_XLM` estimate (mirrors the existing `GAS_BUFFER` pattern already used in `DepositModal.tsx`). Deliberately scoped to same-asset (XLM) comparisons only — a non-XLM reward is never flagged, since comparing it against an XLM-denominated fee without a price oracle would be a meaningless, possibly misleading comparison. Does not add real batched-claim contract functionality or a multi-select claim UX — the existing claim mechanism calls `onClaim(entry)` once per row with no selection state to safely hang a batch summary off.

## Not fixed — issue number 643 left open (please see note before closing)

**Issue number 643 — "Vault deposit limits do not enforce per-wallet concentration and protocol-wide caps across UI and contracts"** is not part of this PR. The issue's named contract file (`contracts/vault/src/lib.rs`) is explicitly deprecated and has no cap logic; the canonical `contracts/drip-pool/src/lib.rs` has no per-wallet or protocol-wide deposit cap either (only an unrelated `StrategyExposureCap` for strategy adapters, a different concept). `app/app/admin/settings/page.jsx`'s "Maximum deposit per vault: 250,000 XLM" display is 100% static hardcoded text — not fetched from or backed by any API or settings-persistence model; there is no `/admin/settings` route or model in the backend either. There is nothing real anywhere in the codebase to hang a client-side validation or preview off of. Building real cap enforcement (contract storage, admin-settings persistence, and UI wiring, all three needing to agree) is genuinely new functionality with real fund-safety implications, not a baseline-scoped fix — flagging for a maintainer's input on whether to scope this down for a future pass or leave it as a larger, separately-planned feature.

## Test plan

- `stellar-wallet-connect`: `npx vitest run src/vault/components/PoolComparisonView.test.tsx src/vault/components/RewardHistory.test.tsx` — 15/15 new tests passing.
- Root: `npx vitest run tests/draw-proof.test.ts` — 49 passed, 3 failed (all 3 confirmed pre-existing: reproduced identically against pure `upstream/main` versions of every file this PR touches, before any of these changes — an unrelated `proofStatus` assertion issue).
- `backend`: `npx vitest run tests/drawProofService.spec.ts` — 15/15 passing (2 new round-snapshot tests, 0 regressions).
- `npx tsc --noEmit` (root, `stellar-wallet-connect`, and `backend`) — identical pre-existing error sets before/after these changes in all three; zero new type errors introduced.

---
No lockfile or build-artifact drift (`pnpm install --frozen-lockfile` made no changes).
