### PR TITLE
test(dashboard): cover health failure states

### DIFF
--- a/components/app/ProtocolHealthDashboard.test.jsx
+++ b/components/app/ProtocolHealthDashboard.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "../../tests/test-utils";
+import { render, screen, fireEvent, waitFor } from "../../tests/test-utils";
 import ProtocolHealthDashboard from "./ProtocolHealthDashboard";
 
 describe("ProtocolHealthDashboard", () => {
@@ -54,5 +54,50 @@ describe("ProtocolHealthDashboard", () => {
 
     expect(screen.queryByText(/super_secret_token_12345/)).not.toBeInTheDocument();
     expect(screen.getByTestId("rpc-error")).toHaveTextContent("***REDACTED***");
+  });
+
+  it("keeps healthy cards visible when one service fails", () => {
+    render(
+      <ProtocolHealthDashboard
+        healthData={{ ...healthyData, backend: { status: "unavailable", error: "backend down" } }}
+      />
+    );
+
+    expect(screen.getByTestId("card-rpc")).toBeInTheDocument();
+    expect(screen.getByTestId("card-indexer")).toBeInTheDocument();
+    expect(screen.getByTestId("backend-error")).toHaveTextContent("backend down");
+  });
+
+  it("shows each service failure instead of an endless loading state", () => {
+    const failed = {
+      rpc: { status: "unavailable", error: "rpc down" },
+      backend: { status: "unavailable", error: "api down" },
+      indexer: { status: "unavailable", error: "indexer down" },
+      contracts: { status: "unavailable", error: "contracts down" },
+    };
+
+    render(<ProtocolHealthDashboard healthData={failed} />);
+
+    expect(screen.getAllByTestId("status-unavailable")).toHaveLength(4);
+    expect(screen.getByTestId("rpc-error")).toHaveTextContent("rpc down");
+    expect(screen.getByTestId("contracts-error")).toHaveTextContent("contracts down");
+  });
+
+  it("always clears the refresh state when a slow refresh rejects", async () => {
+    const onRefresh = vi.fn(() => Promise.reject(new Error("timeout")));
+    render(<ProtocolHealthDashboard healthData={healthyData} onRefresh={onRefresh} />);
+
+    const refresh = screen.getByTestId("refresh-health-btn");
+    fireEvent.click(refresh);
+    expect(refresh).toBeDisabled();
+    await waitFor(() => expect(refresh).toBeEnabled());
+  });
+
+  it("degrades gracefully when a response has malformed service data", () => {
+    expect(() =>
+      render(<ProtocolHealthDashboard healthData={{ rpc: { status: "degraded" }, indexer: null }} />)
+    ).not.toThrow();
+    expect(screen.getByTestId("card-rpc")).toBeInTheDocument();
+    expect(screen.getByTestId("card-indexer")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Cover partial service failure while retaining healthy dashboard cards.
- Cover all-service failure without an endless loading state.
- Cover refresh timeout cleanup and malformed service payloads.

Fixes #575

## Verification
- `git diff --check` passed.
- Focused Vitest execution was attempted but Vitest is unavailable in this checkout; please run CI.