### PR TITLE
fix(vault): drive onboarding checklist from real wallet and vault state

### DIFF
--- a/app/app/page.jsx
+++ b/app/app/page.jsx
@@ -3,10 +3,12 @@
 import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
-import { useAccount } from "wagmi";
+import { useAccount, useChainId } from "wagmi";
 import { useTranslation } from "next-i18next";
 import { Sparkles } from "lucide-react";
 import { VaultApiClient } from "@vaultquest/stellar-wallet-connect/src/vault/data/apiClient";
+import { usePortfolioSummary } from "@vaultquest/stellar-wallet-connect/src/vault/hooks";
+import { SUPPORTED_CHAINS } from "@/lib/wagmi";
 import OnboardingCards from "@/components/app/OnboardingCards";
 import PublicStatsBar from "@/components/app/PublicStatsBar";
 import VaultMetricsCards from "@/components/app/VaultMetricsCards";
@@ -97,12 +99,24 @@ function DashboardSkeleton() {
 export default function AppDashboardPage() {
   const { t } = useTranslation("common");
   const { isConnected, address, chain } = useAccount();
+  const chainId = useChainId();
   const { openConnectModal } = useConnectModal();
   const [onboardingStep, setOnboardingStep] = useState(0);
-  const [hasJoinedVault] = useState(false);
   const [onboardingForceOpen, setOnboardingForceOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [vaultMetadata, setVaultMetadata] = useState([]);
+
+  // Real wallet/vault state driving the onboarding checklist (#628) — no
+  // more hardcoded `useState(false)`. `usePortfolioSummary` reads
+  // GET /portfolio/summary, the same real deposit/position data
+  // `useAccount view`/the account page uses, so "has this wallet joined a
+  // vault" means exactly one thing across the app.
+  const portfolio = usePortfolioSummary(isConnected ? address : null);
+  const hasJoinedVault = Boolean(portfolio.data?.active_positions?.length);
+  // Matches UnsupportedNetworkBanner's own network-support check exactly,
+  // so the checklist's "correct network" step and the banner never
+  // disagree about whether the current chain is supported.
+  const networkSupported = SUPPORTED_CHAINS.some((c) => c.id === chainId);
 
   useEffect(() => {
     setMounted(true);
@@ -218,8 +232,13 @@ export default function AppDashboardPage() {
         {/* Left Column */}
         <main className="space-y-8 lg:col-span-8">
           <ActivitySummaryWidget />
-          <OnboardingChecklist walletConnected={isConnected} hasJoinedVault={hasJoinedVault} />
-          
+          <OnboardingChecklist
+            walletConnected={isConnected}
+            networkSupported={networkSupported}
+            hasDeposited={hasJoinedVault}
+            loading={isConnected && portfolio.loading && !portfolio.data}
+          />
+
           <FirstDepositOnboarding
             hasJoinedVault={hasJoinedVault && !onboardingForceOpen}
           />

--- a/stellar-wallet-connect/src/vault/components/OnboardingChecklist.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/OnboardingChecklist.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OnboardingChecklist, ONBOARDING_STORAGE_KEY } from "./OnboardingChecklist";
+
+function stepListItem(title: string) {
+  return screen.getByText(title).closest("li")!;
+}
+
+// jsdom's own `localStorage` global is unavailable under this project's
+// current Node/vitest combination ("localStorage is not available because
+// --localstorage-file was not provided" — a real, pre-existing environment
+// gap; see also the 4 pre-existing failures in txStateMachine.test.tsx that
+// hit the exact same root cause). Rather than touch the shared
+// tests/setup.ts (out of scope for #628, and other suites may depend on its
+// current behavior), this file provides its own minimal, in-memory
+// polyfill so its tests — including the "persists separately from protocol
+// state" acceptance criterion, which specifically exercises localStorage —
+// can actually run.
+function installLocalStorageStub() {
+  let store: Record<string, string> = {};
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    },
+  });
+}
+
+describe("OnboardingChecklist", () => {
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
+  describe("new, disconnected user", () => {
+    it("shows connect-wallet and correct-network as incomplete, and reports 0 of 5 steps complete", () => {
+      render(<OnboardingChecklist walletConnected={false} networkSupported={false} hasDeposited={false} />);
+
+      expect(screen.getByText("0 of 5 steps complete")).toBeInTheDocument();
+      expect(within(stepListItem("Connect a Stellar wallet")).queryByText(/complete/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("connected, funded, deposited user (#628 — driven by real state, not booleans)", () => {
+    it("marks connect-wallet, correct-network, and all deposit-gated steps complete", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={true} />);
+
+      expect(screen.getByText("5 of 5 steps complete")).toBeInTheDocument();
+      expect(screen.getByText(/All steps complete/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("network mismatch blocks progress with clear guidance (#628 acceptance criterion)", () => {
+    it("does NOT mark correct-network complete just because a wallet is connected on the wrong chain", () => {
+      // This is the exact regression #628 was filed against: the old
+      // isStepDone conflated "connect-wallet" and "correct-network" onto
+      // the same walletConnected boolean, so a wallet on an unsupported
+      // chain still showed "Use the supported network" as done.
+      render(<OnboardingChecklist walletConnected={true} networkSupported={false} hasDeposited={false} />);
+
+      expect(screen.getByText("1 of 5 steps complete")).toBeInTheDocument();
+    });
+
+    it("shows an alert explaining the network mismatch when connected to an unsupported network", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={false} hasDeposited={false} />);
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/unsupported network/i);
+    });
+
+    it("does not show the network-mismatch alert when no wallet is connected at all", () => {
+      render(<OnboardingChecklist walletConnected={false} networkSupported={false} hasDeposited={false} />);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("does not show the network-mismatch alert once on a supported network", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={false} />);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("labels vault steps as network-blocked with specific guidance while on an unsupported network", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={false} hasDeposited={false} />);
+
+      expect(within(stepListItem("Choose a vault")).getByText(/Switch to a supported network first\./i)).toBeInTheDocument();
+    });
+  });
+
+  describe("hasDeposited (real deposit state) vs. deprecated hasJoinedVault", () => {
+    it("treats hasDeposited=false as not-deposited even for a connected, correctly-networked wallet", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={false} />);
+
+      expect(screen.getByText("2 of 5 steps complete")).toBeInTheDocument();
+    });
+
+    it("falls back to the deprecated hasJoinedVault prop when hasDeposited is not provided", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasJoinedVault={true} />);
+
+      expect(screen.getByText("5 of 5 steps complete")).toBeInTheDocument();
+    });
+
+    it("prefers hasDeposited over hasJoinedVault when both are provided", () => {
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={false} hasJoinedVault={true} />);
+
+      expect(screen.getByText("2 of 5 steps complete")).toBeInTheDocument();
+    });
+  });
+
+  describe("disconnected user (no wallet at all)", () => {
+    it("does not treat a disconnected wallet with hasDeposited=true as network-blocked", () => {
+      // hasDeposited alone (e.g. a stale cache) should never fabricate
+      // progress on connect-wallet/correct-network — those are gated on
+      // walletConnected regardless of deposit history.
+      render(<OnboardingChecklist walletConnected={false} networkSupported={false} hasDeposited={true} />);
+
+      expect(screen.getByText("3 of 5 steps complete")).toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("renders a skeleton and no step content while loading", () => {
+      render(<OnboardingChecklist loading={true} />);
+
+      expect(screen.queryByText(/steps complete/)).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "First-time wallet checklist" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("dismissal persists separately from protocol state (#628 acceptance criterion)", () => {
+    it("collapses to a pill button after dismissal, independent of wallet/vault state", async () => {
+      const user = userEvent.setup();
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={false} />);
+
+      await user.click(screen.getByRole("button", { name: "Got it" }));
+
+      expect(screen.getByRole("button", { name: /Onboarding checklist/i })).toBeInTheDocument();
+      expect(localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe("true");
+    });
+
+    it("remains dismissed across a remount, and reopens on request without losing wallet/vault state", async () => {
+      const user = userEvent.setup();
+      localStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
+
+      render(<OnboardingChecklist walletConnected={true} networkSupported={true} hasDeposited={true} />);
+      expect(screen.getByRole("button", { name: /Onboarding checklist/i })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /Onboarding checklist/i }));
+
+      expect(screen.getByText("5 of 5 steps complete")).toBeInTheDocument();
+      expect(localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe("false");
+    });
+  });
+});

--- a/stellar-wallet-connect/src/vault/components/OnboardingChecklist.tsx
+++ b/stellar-wallet-connect/src/vault/components/OnboardingChecklist.tsx
@@ -21,16 +21,36 @@ function writeDismissed(value: boolean): void {
   localStorage.setItem(ONBOARDING_STORAGE_KEY, value ? "true" : "false");
 }
 
-function isStepDone(id: string, walletConnected: boolean, hasJoinedVault: boolean): boolean {
+/**
+ * Real onboarding progress, driven by actual wallet/vault state (#628) —
+ * this replaces the earlier version (#202) where "correct-network" and
+ * "connect-wallet" both collapsed onto the same `walletConnected` boolean
+ * (so a wallet on the wrong chain still showed the network step as done),
+ * and every vault-related step collapsed onto a single, often-hardcoded
+ * `hasJoinedVault` flag with no real deposit signal behind it.
+ *
+ * `networkSupported` is `true` when there's no wallet connected at all —
+ * "wrong network" isn't a meaningful state to show before a wallet exists,
+ * and the "connect-wallet" step being incomplete already communicates that.
+ */
+function isStepDone(
+  id: string,
+  walletConnected: boolean,
+  networkSupported: boolean,
+  hasDeposited: boolean,
+): boolean {
   switch (id) {
     case "connect-wallet": return walletConnected;
-    case "correct-network": return walletConnected;
-    case "choose-vault": return hasJoinedVault;
-    case "join-pool": return hasJoinedVault;
-    case "follow-rewards": return hasJoinedVault;
+    case "correct-network": return walletConnected && networkSupported;
+    case "choose-vault": return hasDeposited;
+    case "join-pool": return hasDeposited;
+    case "follow-rewards": return hasDeposited;
     default: return false;
   }
 }
+
+/** Steps whose progress requires the wallet to be on a supported network first. */
+const NETWORK_GATED_STEP_IDS = new Set(["choose-vault", "join-pool", "follow-rewards"]);
 
 function ChecklistSkeleton() {
   return (
@@ -57,6 +77,24 @@ function ChecklistSkeleton() {
 export interface OnboardingChecklistProps {
   className?: string;
   walletConnected?: boolean;
+  /**
+   * Whether the connected wallet is on a VaultQuest-supported network.
+   * Ignored while `walletConnected` is false. Defaults to `true` so a
+   * caller that hasn't wired real network detection yet doesn't
+   * regress to a permanently-blocked checklist — see #628.
+   */
+  networkSupported?: boolean;
+  /**
+   * Whether the wallet holds a real, confirmed deposit — drive this from
+   * actual backend/vault state (e.g. `usePortfolioSummary`'s
+   * `active_positions.length > 0`), never a hardcoded or locally-guessed
+   * value. Superseded `hasJoinedVault` (#202) is still accepted for
+   * backward compatibility but is deprecated: it conflated "joined a
+   * pool" with several unrelated later steps, and #628's audit found at
+   * least one call site where it was a permanently-`false` placeholder.
+   */
+  hasDeposited?: boolean;
+  /** @deprecated Use `hasDeposited`, which is what this actually maps to. */
   hasJoinedVault?: boolean;
   loading?: boolean;
 }
@@ -64,6 +102,8 @@ export interface OnboardingChecklistProps {
 export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({
   className = "",
   walletConnected = false,
+  networkSupported = true,
+  hasDeposited,
   hasJoinedVault = false,
   loading = false,
 }) => {
@@ -72,9 +112,14 @@ export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({
 
   if (loading) return <ChecklistSkeleton />;
 
+  // `hasDeposited` wins when provided; `hasJoinedVault` is the deprecated
+  // fallback for callers not yet migrated.
+  const deposited = hasDeposited ?? hasJoinedVault;
+  const networkBlocked = walletConnected && !networkSupported;
+
   const dismiss = () => { writeDismissed(true); setDismissed(true); setExpanded(false); };
   const revisit = () => { writeDismissed(false); setDismissed(false); setExpanded(true); };
-  const completedCount = STEPS.filter((s) => isStepDone(s.id, walletConnected, hasJoinedVault)).length;
+  const completedCount = STEPS.filter((s) => isStepDone(s.id, walletConnected, networkSupported, deposited)).length;
   const allDone = completedCount === STEPS.length;
 
   if (dismissed) {
@@ -108,6 +153,17 @@ export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({
 
       {expanded && (
         <>
+          {networkBlocked && (
+            <div
+              role="alert"
+              className="mt-4 flex items-start gap-3 rounded-xl border border-amber-500/40 bg-amber-900/20 p-3"
+            >
+              <Circle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" aria-hidden="true" />
+              <p className="text-sm leading-5 text-amber-200">
+                Your wallet is on an unsupported network — switch networks to unlock vault steps below.
+              </p>
+            </div>
+          )}
           {allDone ? (
             <div className="mt-4 flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-emerald-900/20 p-4">
               <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
@@ -116,15 +172,21 @@ export const OnboardingChecklist: FC<OnboardingChecklistProps> = ({
           ) : (
             <ol className="mt-4 grid gap-3 md:grid-cols-2">
               {STEPS.map((step) => {
-                const done = isStepDone(step.id, walletConnected, hasJoinedVault);
+                const done = isStepDone(step.id, walletConnected, networkSupported, deposited);
+                const blocked = !done && networkBlocked && NETWORK_GATED_STEP_IDS.has(step.id);
                 return (
-                  <li key={step.id} className="flex gap-3 rounded-xl border border-red-900/20 bg-black/20 p-3">
+                  <li
+                    key={step.id}
+                    className={`flex gap-3 rounded-xl border border-red-900/20 bg-black/20 p-3 ${blocked ? "opacity-60" : ""}`}
+                  >
                     {done
                       ? <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
                       : <Circle className="mt-0.5 h-4 w-4 shrink-0 text-gray-600" aria-hidden="true" />}
                     <div>
                       <h3 className={`text-sm font-semibold ${done ? "text-emerald-200" : "text-white"}`}>{step.title}</h3>
-                      <p className="mt-1 text-sm leading-5 text-gray-400">{step.body}</p>
+                      <p className="mt-1 text-sm leading-5 text-gray-400">
+                        {blocked ? "Switch to a supported network first." : step.body}
+                      </p>
                     </div>
                   </li>
                 );

--- a/stellar-wallet-connect/src/vault/data/apiClient.portfolio.test.ts
+++ b/stellar-wallet-connect/src/vault/data/apiClient.portfolio.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { VaultApiClient } from "./apiClient";
+
+const SAMPLE_ADDRESS = "GABCDEF1234567890123456789012345678901234567890123456789";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("VaultApiClient.getPortfolioSummary (#628)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests GET /portfolio/summary with the wallet as a query param, and returns the raw summary", async () => {
+    const summary = {
+      wallet_address: SAMPLE_ADDRESS,
+      total_deposits: 500,
+      active_positions: [{ vault_id: "vault-1", balance: 500, token: "USDC" }],
+      pending_rewards: 0,
+      claimable_amount: 0,
+      invalid_action_count: 0,
+      recent_activity: [],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: summary }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new VaultApiClient("/api");
+    const result = await client.getPortfolioSummary(SAMPLE_ADDRESS);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(`/api/portfolio/summary?wallet=${SAMPLE_ADDRESS}`);
+    expect(result).toEqual(summary);
+  });
+
+  it("returns the real zero-state shape for a wallet with no activity", async () => {
+    const zeroState = {
+      wallet_address: SAMPLE_ADDRESS,
+      total_deposits: 0,
+      active_positions: [],
+      pending_rewards: 0,
+      claimable_amount: 0,
+      invalid_action_count: 0,
+      recent_activity: [],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ data: zeroState })));
+
+    const client = new VaultApiClient("/api");
+    const result = await client.getPortfolioSummary(SAMPLE_ADDRESS);
+
+    expect(result.active_positions).toEqual([]);
+    expect(result.total_deposits).toBe(0);
+  });
+
+  it("throws with the backend's error message on a non-2xx response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ error: { code: "INVALID_PAYLOAD", message: "invalid wallet address" } }, 400),
+      ),
+    );
+
+    const client = new VaultApiClient("/api");
+
+    await expect(client.getPortfolioSummary("not-a-real-address")).rejects.toThrow(
+      "invalid wallet address",
+    );
+  });
+
+  it("falls back to a generic message when the error response has no parseable body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not json", { status: 500 })),
+    );
+
+    const client = new VaultApiClient("/api");
+
+    await expect(client.getPortfolioSummary(SAMPLE_ADDRESS)).rejects.toThrow(
+      "Portfolio summary request failed (500)",
+    );
+  });
+});

--- a/stellar-wallet-connect/src/vault/data/apiClient.ts
+++ b/stellar-wallet-connect/src/vault/data/apiClient.ts
@@ -31,6 +31,36 @@ export interface VaultMetadataRecord {
   metadata_version?: number | null;
 }
 
+export interface PortfolioActivePosition {
+  vault_id: string;
+  balance: number;
+  token: string;
+}
+
+export interface PortfolioRecentActivity {
+  id: string;
+  action_type: string;
+  status: string;
+  tx_hash: string | null;
+  created_at: string;
+  payload: unknown;
+}
+
+/**
+ * Matches GET /portfolio/summary's real response shape exactly — see
+ * backend/src/services/ledger.ts's getPortfolioSummary() and
+ * backend/tests/portfolio.spec.ts for the contract this mirrors.
+ */
+export interface PortfolioSummary {
+  wallet_address: string;
+  total_deposits: number;
+  active_positions: PortfolioActivePosition[];
+  pending_rewards: number;
+  claimable_amount: number;
+  invalid_action_count: number;
+  recent_activity: PortfolioRecentActivity[];
+}
+
 type SavedPoolApiRecord = {
   id: string;
   wallet_address: string;
@@ -166,6 +196,15 @@ export class VaultApiClient {
     const body = await parseJsonResponse<ApiEnvelope<VaultMetadataRecord[]>>(
       await fetch(this.url("/vault-metadata"), { signal: options?.signal }),
       "Vault metadata request failed",
+    );
+    return body.data;
+  }
+
+  async getPortfolioSummary(walletAddress: string, options?: { signal?: AbortSignal }): Promise<PortfolioSummary> {
+    const params = new URLSearchParams({ wallet: walletAddress });
+    const body = await parseJsonResponse<ApiEnvelope<PortfolioSummary>>(
+      await fetch(this.url("/portfolio/summary", params), { signal: options?.signal }),
+      "Portfolio summary request failed",
     );
     return body.data;
   }

--- a/stellar-wallet-connect/src/vault/data/queryKeys.ts
+++ b/stellar-wallet-connect/src/vault/data/queryKeys.ts
@@ -21,6 +21,7 @@ export const vaultQueryKeys = {
     ["vaultquest", "position", poolId, normalize(walletAddress)] as const,
   rewards: (walletAddress?: string | null) => ["vaultquest", "rewards", normalize(walletAddress)] as const,
   prizes: (walletAddress?: string | null) => ["vaultquest", "prizes", normalize(walletAddress)] as const,
+  portfolio: (walletAddress?: string | null) => ["vaultquest", "portfolio", normalize(walletAddress)] as const,
   savedPools: (walletAddress?: string | null, network?: string, contractId?: string) =>
     ["vaultquest", "saved-pools", normalize(walletAddress), network || "unknown", contractId || "unknown"] as const,
   transaction: (actionIdOrTxHash: string) => ["vaultquest", "transaction", actionIdOrTxHash] as const,

--- a/stellar-wallet-connect/src/vault/hooks.ts
+++ b/stellar-wallet-connect/src/vault/hooks.ts
@@ -18,7 +18,12 @@ import type {
   UserPosition,
   VaultContractClient,
 } from "./contract/types";
-import { VaultApiClient, isTerminalTransaction, type TransactionStatusView } from "./data/apiClient";
+import {
+  VaultApiClient,
+  isTerminalTransaction,
+  type PortfolioSummary,
+  type TransactionStatusView,
+} from "./data/apiClient";
 import { defaultVaultDataConfig } from "./data/config";
 import { useVaultQuery, vaultQueryClient, type QueryState } from "./data/queryClient";
 import { vaultQueryKeys } from "./data/queryKeys";
@@ -102,6 +107,38 @@ export function useRewardHistory(
 
   if (!walletAddress) {
     return { data: [], loading: false, stale: false, error: null, partialError: null, refetch: query.refetch };
+  }
+
+  return resourceFromQuery(query);
+}
+
+/**
+ * Real, backend-sourced portfolio state for a connected wallet — issue #628:
+ * `total_deposits`/`active_positions` come straight from
+ * GET /portfolio/summary's `ActionLedger` aggregation (deposits minus
+ * withdrawals, confirmed actions only), never a client-side placeholder
+ * boolean. Consumers that only need "has this wallet ever completed a
+ * deposit" should read `data.active_positions.length > 0` rather than
+ * re-deriving it, so the definition of "joined" lives in exactly one place.
+ */
+export function usePortfolioSummary(
+  walletAddress: string | null,
+  options: { apiBaseUrl?: string } = {},
+): AsyncResource<PortfolioSummary> {
+  const api = useMemo(() => createApiClient(options.apiBaseUrl), [options.apiBaseUrl]);
+
+  const query = useVaultQuery({
+    key: vaultQueryKeys.portfolio(walletAddress),
+    enabled: Boolean(walletAddress),
+    staleTimeMs: 30_000,
+    fetcher: async (opts) => {
+      if (!walletAddress) throw new Error("Connect a wallet to load portfolio data.");
+      return api.getPortfolioSummary(walletAddress, { signal: opts.signal });
+    },
+  });
+
+  if (!walletAddress) {
+    return { data: null, loading: false, stale: false, error: null, partialError: null, refetch: query.refetch };
   }
 
   return resourceFromQuery(query);

--- a/stellar-wallet-connect/src/vault/index.ts
+++ b/stellar-wallet-connect/src/vault/index.ts
@@ -7,8 +7,8 @@
 export * from "./contract/types";
 export { createMockVaultClient, SAMPLE_ADDRESS, type MockVaultConfig } from "./contract/mockClient";
 export * from "./lib/format";
-export { useAccountView, usePoolAction, usePoolDetail, usePoolDiscovery, usePrizeViews, useRewardHistory, useSavedPools, useTransactionStatus, invalidatePoolActionQueries, useActivityExport, type AccountView, type AsyncResource, type PoolActionFlow, type PoolDetailResource, type PoolDiscoveryOptions, type PrizeViewsOptions, type SavedPoolsResource, type TransactionStatusResource, type ExportFormat, type ExportState, type ActivityExportOptions, type ActivityExportResult } from "./hooks";
-export { VaultApiClient, isTerminalTransaction, type TransactionStatus, type TransactionStatusView } from "./data/apiClient";
+export { useAccountView, usePoolAction, usePoolDetail, usePoolDiscovery, usePortfolioSummary, usePrizeViews, useRewardHistory, useSavedPools, useTransactionStatus, invalidatePoolActionQueries, useActivityExport, type AccountView, type AsyncResource, type PoolActionFlow, type PoolDetailResource, type PoolDiscoveryOptions, type PrizeViewsOptions, type SavedPoolsResource, type TransactionStatusResource, type ExportFormat, type ExportState, type ActivityExportOptions, type ActivityExportResult } from "./hooks";
+export { VaultApiClient, isTerminalTransaction, type PortfolioSummary, type PortfolioActivePosition, type PortfolioRecentActivity, type TransactionStatus, type TransactionStatusView } from "./data/apiClient";
 export { createVaultDataConfig, defaultVaultDataConfig, type VaultDataConfig, type VaultFeatureFlags, type VaultNetworkConfig } from "./data/config";
 export { vaultQueryClient, useVaultQuery, type QueryState, type QueryStatus } from "./data/queryClient";
 export { vaultQueryKeys, serializeQueryKey, type VaultQueryKey } from "./data/queryKeys";


### PR DESCRIPTION
Closes #628

## Summary

Drives the vault onboarding checklist from real wallet and vault state instead of a hardcoded/local boolean, per the issue's three acceptance criteria.

## What was actually broken

`app/app/page.jsx` had:
```js
const [hasJoinedVault] = useState(false);
```
A setter-less `useState` — this value could **never change**, ever. It was then passed to both `OnboardingChecklist` and `FirstDepositOnboarding`, meaning both components permanently believed the connected wallet had never made a deposit, regardless of reality.

Separately, `OnboardingChecklist`'s `isStepDone` mapped both `"connect-wallet"` and `"correct-network"` onto the same `walletConnected` boolean — so a wallet connected to an unsupported chain still showed "Use the supported network" as complete.

## What changed

- **`app/app/page.jsx`**: `hasJoinedVault` is now derived from a new `usePortfolioSummary(address)` hook — real data from `GET /portfolio/summary` (`active_positions.length > 0`), the same endpoint `backend/tests/portfolio.spec.ts` already covers on the backend side. `networkSupported` is now derived from `useChainId()` + `SUPPORTED_CHAINS`, the exact same check `components/app/UnsupportedNetworkBanner.jsx` already uses — so the checklist and the banner can never disagree.
- **`OnboardingChecklist.tsx`**: takes real `networkSupported` and `hasDeposited` props now, each driving its own steps. `hasJoinedVault` is kept as a deprecated fallback (still works, `hasDeposited` wins when both given) so this isn't a breaking change for any other caller. Added a `role="alert"` network-mismatch banner and per-step "Switch to a supported network first" guidance while a connected wallet is on the wrong chain (the "clear guidance" acceptance criterion).
- **`apiClient.ts` / `hooks.ts` / `queryKeys.ts`**: new `getPortfolioSummary()` / `usePortfolioSummary()`, following the exact conventions every other method/hook in this module already uses. `PortfolioSummary`'s shape matches the real backend response (`backend/src/services/ledger.ts`'s `getPortfolioSummary`) exactly, not a guessed one.

"Persist completed educational steps separately from protocol state" was already true before this change — the `ONBOARDING_STORAGE_KEY` dismissal flag has never touched wallet/vault state — and a new test now asserts that explicitly rather than leaving it implicit.

## Pre-existing issues found along the way (disclosed, not fixed here — out of scope)

- `PoolDetail.test.tsx` fails to even parse — truncated mid-file, confirmed present on `upstream/main` (not something I touched).
- jsdom's global `localStorage` is unavailable under this project's current Node/vitest combination (`localStorage is not available because --localstorage-file was not provided`) — independently breaks 4 existing `txStateMachine.test.tsx` tests. My own new tests needed to exercise `localStorage` for the dismissal-persistence acceptance criterion, so `OnboardingChecklist.test.tsx` includes a small, self-contained in-memory polyfill scoped to that one file rather than touching the shared `tests/setup.ts`.
- Several pre-existing `PoolStatus`/`PoolSummary` type mismatches surfaced by `tsc --noEmit` (`SavedPoolsWatchlist.tsx`, `PoolComparisonView.tsx`, `apiClient.ts`'s existing `listPools()`, `hooks.ts`'s `TimelineStage`) — confirmed present on a clean `upstream/main` checkout.
- `pnpm run lint` (`next lint`) itself currently fails with `Invalid project directory provided, no such directory: .../lint` — a Next 16 CLI argument-parsing issue, reproduced on a clean checkout, unrelated to this PR. Used `eslint` directly against the touched files instead (see Verification).

## Verification

- **New tests**: `OnboardingChecklist.test.tsx` (14 tests) and `apiClient.portfolio.test.ts` (4 tests) — all pass.
- `pnpm exec vitest run stellar-wallet-connect`: **140 passed** (up from a clean-checkout baseline of 122), **13 failed** (unchanged — same pre-existing failures, verified against a true baseline with both my source changes AND new test files moved aside, since `git stash` alone doesn't remove untracked files).
- `pnpm exec vitest run` (whole repo): **350 passed** (up from 332), same 13 pre-existing failures — zero regressions.
- `pnpm exec eslint` on every touched/added file: clean except one pre-existing `react/no-unescaped-entities` error on a line I didn't modify, confirmed present on `upstream/main` at the equivalent (pre-line-shift) location.

## Testing requirements checklist (from the issue)

- [x] Checklist updates after wallet funding and first deposit — via `usePortfolioSummary`'s real `active_positions`
- [x] Network mismatch blocks progress with clear guidance — new alert + per-step messaging
- [x] Tests cover new, funded, deposited, and disconnected users — see `OnboardingChecklist.test.tsx`'s describe blocks
