### PR TITLE
fix(tooling): fix PoolDetail test syntax, localStorage polyfill, and SWC types (#680)

### DIFF
--- a/stellar-wallet-connect/src/vault/components/PoolComparisonView.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolComparisonView.tsx
@@ -2,7 +2,7 @@ import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
 import { Columns, Plus, X } from "lucide-react";
 import { EmptyState, LoadingState, StaleIndicator } from "../../components/FallbackStates";
-import type { PoolStatus, PoolSummary } from "../contract/types";
+import type { PoolSummary } from "../contract/types";
 import { formatAmount, formatDate } from "../lib/format";
 import { formatYieldLabel, YIELD_LABEL_TOOLTIP } from "../../../../lib/formatting";
 import PoolStatusBadge from "./PoolStatusBadge";

--- a/stellar-wallet-connect/src/vault/components/PoolDetail.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolDetail.test.tsx
@@ -143,22 +143,27 @@ describe("PoolDetail", () => {
       render(<PoolDetail pool={basePool} tvlConfidence="conflicting" />);
       expect(screen.getByLabelText(/providers disagree/i)).toBeInTheDocument();
     });
-  it("does not show a pause banner or hide actions for a non-paused pool", () => {
-    render(<PoolDetail pool={basePool} position={null} />);
-    expect(screen.queryByText(/pool paused for recovery/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /join pool/i })).toBeInTheDocument();
   });
 
-  it("shows a pause banner and hides join when the pool is in emergency mode", () => {
-    render(<PoolDetail pool={{ ...basePool, isEmergency: true }} position={null} />);
-    expect(screen.getByText(/pool paused for recovery/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /join pool/i })).not.toBeInTheDocument();
-  });
+  describe("emergency pause banner and actions", () => {
+    it("does not show a pause banner or hide actions for a non-paused pool", () => {
+      render(<PoolDetail pool={basePool} position={null} />);
+      expect(screen.queryByText(/pool paused for recovery/i)).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /join pool/i })).toBeInTheDocument();
+    });
 
-  it("still shows withdraw (not gated on-chain) when paused and joined", () => {
-    render(<PoolDetail pool={{ ...basePool, isEmergency: true }} position={joined} />);
-    expect(screen.getByText(/pool paused for recovery/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /withdraw/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /add deposit/i })).not.toBeInTheDocument();
+    it("shows a pause banner and hides join when the pool is in emergency mode", () => {
+      render(<PoolDetail pool={{ ...basePool, isEmergency: true }} position={null} />);
+      expect(screen.getByText(/pool paused for recovery/i)).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /join pool/i })).not.toBeInTheDocument();
+    });
+
+    it("still shows withdraw (not gated on-chain) when paused and joined", () => {
+      render(<PoolDetail pool={{ ...basePool, isEmergency: true }} position={joined} />);
+      expect(screen.getByText(/pool paused for recovery/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /withdraw/i })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /add deposit/i })).not.toBeInTheDocument();
+    });
   });
 });
+

--- a/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
+++ b/stellar-wallet-connect/src/vault/components/PoolDetail.tsx
@@ -8,7 +8,7 @@ import {
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
 import { DataRefreshControl } from "../../components/DataRefreshControl";
-import type { PoolActionType, PoolStatus, PoolSummary, UserPosition } from "../contract/types";
+import type { PoolActionType, PoolSummary, UserPosition } from "../contract/types";
 import { formatAmount, formatDate, truncateAddress } from "../lib/format";
 import { OnboardingChecklist } from "./OnboardingChecklist";
 import { isNetworkMismatch } from "../../core/store.js";

--- a/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.test.tsx
+++ b/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.test.tsx
@@ -12,7 +12,11 @@ const mockEntries: SavedPoolEntry[] = [
     status: "open",
     tvl: "50000000",
     asset: "USDC",
+    participantCount: 10,
     expectedYield: "4.5%",
+    opensAt: "2026-08-01T00:00:00Z",
+    locksAt: "2026-08-08T00:00:00Z",
+    drawsAt: "2026-08-09T00:00:00Z",
     walletAddress: "GABC",
     savedAt: "2026-08-01T12:00:00Z",
     updatedAt: "2026-08-01T12:00:00Z"
@@ -23,7 +27,11 @@ const mockEntries: SavedPoolEntry[] = [
     status: "closed",
     tvl: "250000000",
     asset: "XLM",
+    participantCount: 25,
     expectedYield: "0%",
+    opensAt: "2026-07-01T00:00:00Z",
+    locksAt: "2026-07-08T00:00:00Z",
+    drawsAt: "2026-07-09T00:00:00Z",
     walletAddress: "GABC",
     savedAt: "2026-08-02T12:00:00Z",
     updatedAt: "2026-08-02T12:00:00Z"
@@ -34,12 +42,17 @@ const mockEntries: SavedPoolEntry[] = [
     status: "cancelled",
     tvl: "0",
     asset: "USDC",
+    participantCount: 0,
     expectedYield: "0%",
+    opensAt: "2026-06-01T00:00:00Z",
+    locksAt: "2026-06-08T00:00:00Z",
+    drawsAt: "2026-06-09T00:00:00Z",
     walletAddress: "GABC",
     savedAt: "2026-08-03T12:00:00Z",
     updatedAt: "2026-08-03T12:00:00Z"
   }
 ];
+
 
 describe("SavedPoolsWatchlist", () => {
   it("renders empty state when there are no entries", () => {

--- a/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.tsx
+++ b/stellar-wallet-connect/src/vault/components/SavedPoolsWatchlist.tsx
@@ -7,7 +7,7 @@ import {
   WalletDisconnectedState,
 } from "../../components/FallbackStates";
 import { DataRefreshControl } from "../../components/DataRefreshControl";
-import type { SavedPoolEntry, PoolStatus } from "../contract/types";
+import type { SavedPoolEntry } from "../contract/types";
 import { formatAmount, formatDate } from "../lib/format";
 import PoolStatusBadge from "./PoolStatusBadge";
 

--- a/stellar-wallet-connect/src/vault/contract/types.ts
+++ b/stellar-wallet-connect/src/vault/contract/types.ts
@@ -8,7 +8,7 @@
  * (create / join / drip / claim / withdraw) be tested without a live network.
  */
 
-export type PoolStatus = "open" | "locked" | "drawing" | "settled";
+export type PoolStatus = "open" | "locked" | "drawing" | "settled" | "closed" | "cancelled";
 
 export interface PoolSummary {
   id: string;

--- a/stellar-wallet-connect/src/vault/data/apiClient.ts
+++ b/stellar-wallet-connect/src/vault/data/apiClient.ts
@@ -150,16 +150,20 @@ export class VaultApiClient {
       await fetch(this.url("/pools"), { signal: options?.signal }),
       "Pool discovery request failed",
     );
-    return body.data.map((pool) => ({
-      ...pool,
-      riskTier: pool.riskTier ?? pool.risk_tier ?? undefined,
-      strategy: pool.strategy ?? pool.strategy_name ?? undefined,
-      lockupDays: pool.lockupDays ?? pool.lockup_days ?? undefined,
-      feeBps: pool.feeBps ?? pool.fee_bps ?? undefined,
-      acceptedAsset: pool.acceptedAsset ?? pool.accepted_asset ?? undefined,
-      operationalStatus: pool.operationalStatus ?? pool.operational_status ?? undefined,
-      metadataVersion: pool.metadataVersion ?? pool.metadata_version ?? undefined,
-    }));
+    return body.data.map((pool) => {
+      const raw = pool as PoolSummary & Record<string, unknown>;
+      return {
+        ...pool,
+        riskTier: pool.riskTier ?? (raw.risk_tier as string | undefined),
+        strategy: pool.strategy ?? (raw.strategy_name as string | undefined),
+        lockupDays: pool.lockupDays ?? (raw.lockup_days as number | undefined),
+        feeBps: pool.feeBps ?? (raw.fee_bps as number | undefined),
+        acceptedAsset: pool.acceptedAsset ?? (raw.accepted_asset as string | undefined),
+        operationalStatus: pool.operationalStatus ?? (raw.operational_status as string | undefined),
+        metadataVersion: pool.metadataVersion ?? (raw.metadata_version as number | undefined),
+      };
+    });
+
   }
 
   async listVaultMetadata(options?: { signal?: AbortSignal }): Promise<VaultMetadataRecord[]> {

--- a/stellar-wallet-connect/src/vault/hooks.ts
+++ b/stellar-wallet-connect/src/vault/hooks.ts
@@ -23,6 +23,7 @@ import { defaultVaultDataConfig } from "./data/config";
 import { useVaultQuery, vaultQueryClient, type QueryState } from "./data/queryClient";
 import { vaultQueryKeys } from "./data/queryKeys";
 import { useTxFlow, type TxFlowOptions, type TxFlowResult } from "./lib/txStateMachine";
+import type { TimelineStage } from "../components/TransactionTimeline";
 
 export interface AsyncResource<T> {
   data: T | null;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -22,3 +22,44 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
     unobserve: vi.fn(),
     disconnect: vi.fn(),
 }));
+
+// Polyfill localStorage & sessionStorage for tests under jsdom (#680)
+const createStorageMock = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = String(value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+};
+
+const localStorageMock = createStorageMock();
+const sessionStorageMock = createStorageMock();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});
+Object.defineProperty(global, 'sessionStorage', {
+  value: sessionStorageMock,
+  writable: true,
+});


### PR DESCRIPTION
Closes #680

## Summary
Resolves pre-existing tooling and testsuite defects across vitest, jsdom, and stellar-wallet-connect TypeScript definitions.

## Changes Made
- Added \localStorage\ and \sessionStorage\ polyfill in \	ests/setup.ts\ to unblock jsdom-based tests.
- Fixed truncated test block and missing \describe\ wrapper in \stellar-wallet-connect/src/vault/components/PoolDetail.test.tsx\.
- Extended \PoolStatus\ union type in \stellar-wallet-connect/src/vault/contract/types.ts\ with \closed\ and \cancelled\.
- Added missing \TimelineStage\ import in \stellar-wallet-connect/src/vault/hooks.ts\.
- Fixed snake_case mapping in \stellar-wallet-connect/src/vault/data/apiClient.ts\.
- Added missing required fields (\participantCount\, \opensAt\, \locksAt\, \drawsAt\) to fixtures in \SavedPoolsWatchlist.test.tsx\.
- Removed unused \PoolStatus\ imports across \PoolComparisonView.tsx\, \PoolDetail.tsx\, and \SavedPoolsWatchlist.tsx\.