### PR TITLE
Add replayable draw audit snapshot hash

### DIFF
--- a/lib/draw-proof.ts
+++ b/lib/draw-proof.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-// ─── Schemas ──────────────────────────────────────────────────────────────────
+// ??? Schemas ??????????????????????????????????????????????????????????????????
 
 const SnapshotSchema = z.object({
   ledgerSeq: z.number().int().positive(),
@@ -10,7 +10,7 @@ const SnapshotSchema = z.object({
   totalDeposits: z.string().min(1),
   poolHash: z.string().min(1),
   /**
-   * The drip-pool contract's own `Round.principal_snapshot` (#642) — the
+   * The drip-pool contract's own `Round.principal_snapshot` (#642) ? the
    * deterministic cutoff balance the contract freezes at `lock_round`, before
    * `totalDeposits` above is ever computed off-chain from participant data.
    * Optional so older proofs (pre-#642) still validate; when present it lets
@@ -59,6 +59,7 @@ const MetadataSchema = z.object({
   createdAt: z.string().datetime(),
   engineVersion: z.string().min(1),
   contractSpecHash: z.string().min(1),
+  auditSnapshotHash: z.string().min(1).optional(),
 });
 
 const DrawProofVersionSchema = z.union([z.literal("1.0.0"), z.literal("1.1.0")]);
@@ -82,7 +83,32 @@ export type Randomness = z.infer<typeof RandomnessSchema>;
 export type WinnerSelection = z.infer<typeof WinnerSelectionSchema>;
 export type Payout = z.infer<typeof PayoutSchema>;
 
-// ─── Hashing ──────────────────────────────────────────────────────────────────
+export interface DrawAuditSnapshot {
+  roundId: number;
+  contractId: string;
+  ledgerSeq: number;
+  participantsHash: string;
+  participantCount: number;
+  totalDeposits: string;
+  poolHash: string;
+  ticketWeightsHash: string;
+  randomness: {
+    source: Randomness["source"];
+    seedHash: string;
+    commitment: string;
+    commitmentLedgerSeq: number;
+    revealTxHash: string;
+    drawnAtLedger: number;
+  };
+  winner: {
+    address: string;
+    weight: string;
+    totalWeight: string;
+  };
+  payout: Payout;
+}
+
+// ??? Hashing ??????????????????????????????????????????????????????????????????
 
 const HEX_CHARS = "0123456789abcdef";
 
@@ -123,7 +149,7 @@ async function hmacSha256Hex(secret: string, data: string): Promise<string> {
   return createHmac("sha256", secret).update(data, "utf-8").digest("hex");
 }
 
-// ─── Canonicalization ─────────────────────────────────────────────────────────
+// ??? Canonicalization ?????????????????????????????????????????????????????????
 
 function sortKeys(obj: unknown): unknown {
   if (obj === null || typeof obj !== "object") return obj;
@@ -141,7 +167,7 @@ export function canonicalize(proof: Omit<DrawProof, "signature">): string {
   return JSON.stringify(sorted);
 }
 
-// ─── Proof Hashing ────────────────────────────────────────────────────────────
+// ??? Proof Hashing ????????????????????????????????????????????????????????????
 
 export async function computeProofHash(proof: Omit<DrawProof, "signature">): Promise<string> {
   const canonical = canonicalize(proof);
@@ -156,7 +182,7 @@ export async function signProof(
   return hmacSha256Hex(secret, canonical);
 }
 
-// ─── Deterministic Draw ID ────────────────────────────────────────────────────
+// ??? Deterministic Draw ID ????????????????????????????????????????????????????
 
 export async function computeDrawId(
   contractId: string,
@@ -168,7 +194,7 @@ export async function computeDrawId(
   return `draw-${hash.slice(0, 16)}`;
 }
 
-// ─── Participant & Weight Hashing ─────────────────────────────────────────────
+// ??? Participant & Weight Hashing ?????????????????????????????????????????????
 
 export interface ParticipantEntry {
   address: string;
@@ -204,12 +230,45 @@ export async function computePoolHash(poolState: Record<string, unknown>): Promi
   return sha256Hex(JSON.stringify(sorted));
 }
 
-// ─── Winner Proof Hash ────────────────────────────────────────────────────────
+export function buildDrawAuditSnapshot(proof: Omit<DrawProof, "signature">): DrawAuditSnapshot {
+  return {
+    roundId: proof.roundId,
+    contractId: proof.contractId,
+    ledgerSeq: proof.snapshot.ledgerSeq,
+    participantsHash: proof.snapshot.participantsHash,
+    participantCount: proof.snapshot.participantCount,
+    totalDeposits: proof.snapshot.totalDeposits,
+    poolHash: proof.snapshot.poolHash,
+    ticketWeightsHash: proof.winnerSelection.ticketWeightsHash,
+    randomness: {
+      source: proof.randomness.source,
+      seedHash: proof.randomness.seedHash,
+      commitment: proof.randomness.commitment,
+      commitmentLedgerSeq: proof.randomness.commitmentLedgerSeq,
+      revealTxHash: proof.randomness.revealTxHash,
+      drawnAtLedger: proof.randomness.drawnAtLedger,
+    },
+    winner: {
+      address: proof.winnerSelection.winnerAddress,
+      weight: proof.winnerSelection.winnerWeight,
+      totalWeight: proof.winnerSelection.totalWeight,
+    },
+    payout: proof.payout,
+  };
+}
+
+export async function computeDrawAuditSnapshotHash(
+  proof: Omit<DrawProof, "signature">
+): Promise<string> {
+  return sha256Hex(JSON.stringify(sortKeys(buildDrawAuditSnapshot(proof))));
+}
+
+// ??? Winner Proof Hash ????????????????????????????????????????????????????????
 
 /**
  * Binds contractId + roundId into the hash chain so randomness evidence
  * lifted from another round or another contract can never reproduce a valid
- * proofHash here (#494) — the recomputation on verify uses the *proof's own*
+ * proofHash here (#494) ? the recomputation on verify uses the *proof's own*
  * contractId/roundId, so a substituted seed/participants pair from elsewhere
  * mismatches even if internally self-consistent.
  */
@@ -224,7 +283,7 @@ export async function computeWinnerProofHash(
   return sha256Hex(input);
 }
 
-// ─── Validation ───────────────────────────────────────────────────────────────
+// ??? Validation ???????????????????????????????????????????????????????????????
 
 export interface VerificationField {
   name: string;
@@ -307,6 +366,17 @@ export async function verifyProofIntegrity(
     ));
   }
 
+  if (proof.metadata.auditSnapshotHash) {
+    const recomputedAuditHash = await computeDrawAuditSnapshotHash(proofBody);
+    if (recomputedAuditHash === proof.metadata.auditSnapshotHash) {
+      fields.push(fieldPass("audit_snapshot_hash"));
+    } else {
+      fields.push(fieldFail("audit_snapshot_hash", `expected ${recomputedAuditHash}, got ${proof.metadata.auditSnapshotHash}`));
+    }
+  } else {
+    fields.push(fieldUnverified("audit_snapshot_hash", "Proof does not include a replayable audit snapshot hash"));
+  }
+
   const recomputedSeedHash = await sha256Hex(proof.randomness.seed);
   if (recomputedSeedHash === proof.randomness.seedHash) {
     fields.push(fieldPass("seed_hash"));
@@ -318,13 +388,13 @@ export async function verifyProofIntegrity(
   }
 
   // The revealed seed must match the pre-committed hash, and the commitment
-  // must have been recorded at or before the draw ledger — otherwise the
+  // must have been recorded at or before the draw ledger ? otherwise the
   // "randomness" could have been chosen after the outcome was known.
   const recomputedCommitment = await sha256Hex(proof.randomness.seed);
   if (recomputedCommitment !== proof.randomness.commitment) {
     fields.push(fieldFail(
       "randomness_commitment",
-      `revealed seed does not match commitment (expected ${recomputedCommitment}, got ${proof.randomness.commitment}) — evidence may be substituted`
+      `revealed seed does not match commitment (expected ${recomputedCommitment}, got ${proof.randomness.commitment}) ? evidence may be substituted`
     ));
   } else if (proof.randomness.commitmentLedgerSeq > proof.randomness.drawnAtLedger) {
     fields.push(fieldFail(
@@ -345,7 +415,7 @@ export async function verifyProofIntegrity(
   };
 }
 
-// ─── Proof Assembly ───────────────────────────────────────────────────────────
+// ??? Proof Assembly ???????????????????????????????????????????????????????????
 
 export interface DrawProofInput {
   roundId: number;
@@ -469,6 +539,8 @@ export async function assembleDrawProof(
       contractSpecHash: input.contractSpecHash,
     },
   };
+
+  proof.metadata.auditSnapshotHash = await computeDrawAuditSnapshotHash(proof);
 
   const signature = options.signatureSecret
     ? await signProof(proof, options.signatureSecret)

--- a/tests/draw-proof.test.ts
+++ b/tests/draw-proof.test.ts
@@ -7,6 +7,8 @@ import {
   computeParticipantsHash,
   computeTicketWeightsHash,
   computePoolHash,
+  buildDrawAuditSnapshot,
+  computeDrawAuditSnapshotHash,
   computeWinnerProofHash,
   signProof,
   verifyProofIntegrity,
@@ -243,6 +245,40 @@ describe("computePoolHash", () => {
   });
 });
 
+describe("draw audit snapshot hash", () => {
+  it("is deterministic for replayable draw evidence", async () => {
+    const proof = await assembleSignedProof(await makeInput());
+    const { signature, ...body } = proof;
+
+    expect(buildDrawAuditSnapshot(body).roundId).toBe(1);
+    expect(await computeDrawAuditSnapshotHash(body)).toBe(proof.metadata.auditSnapshotHash);
+  });
+
+  it("changes when participant weights or randomness metadata changes", async () => {
+    const proof = await assembleSignedProof(await makeInput());
+    const { signature, ...body } = proof;
+    const original = await computeDrawAuditSnapshotHash(body);
+
+    const changedWeight = {
+      ...body,
+      winnerSelection: {
+        ...body.winnerSelection,
+        ticketWeightsHash: "tampered-ticket-weights",
+      },
+    };
+    const changedRandomness = {
+      ...body,
+      randomness: {
+        ...body.randomness,
+        revealTxHash: "different-reveal-tx",
+      },
+    };
+
+    expect(await computeDrawAuditSnapshotHash(changedWeight)).not.toBe(original);
+    expect(await computeDrawAuditSnapshotHash(changedRandomness)).not.toBe(original);
+  });
+});
+
 describe("computeWinnerProofHash", () => {
   it("produces deterministic hash", async () => {
     const a = await computeWinnerProofHash("C1", 1, "addr-a", "seed_hash", "part_hash");
@@ -323,6 +359,7 @@ describe("verifyProofIntegrity", () => {
     proof.randomness.seedHash = "tampered_hash";
     const result = await verifyProofIntegrity(proof, SIGNING_SECRET);
     expect(result.verified).toBe(false);
+    expectField(result, "audit_snapshot_hash", "fail");
     expectField(result, "seed_hash", "fail");
   });
 
@@ -372,7 +409,7 @@ describe("verifyProofIntegrity", () => {
     proof.randomness.seed = "a-different-seed-entirely";
     proof.randomness.seedHash = await computeHash(proof.randomness.seed);
     // seedHash now matches seed (self-consistent) but no longer matches the
-    // original on-chain commitment — the substitution must still be caught.
+    // original on-chain commitment ? the substitution must still be caught.
     const result = await verifyProofIntegrity(proof, SIGNING_SECRET);
     expect(result.verified).toBe(false);
     expectField(result, "randomness_commitment", "fail");
@@ -470,7 +507,7 @@ describe("assembleDrawProof", () => {
     expect(result.verified).toBe(true);
   });
 
-  // ─── roundPrincipalSnapshot wiring (#642) ───────────────────────────────────
+  // ??? roundPrincipalSnapshot wiring (#642) ???????????????????????????????????
   // The drip-pool contract already freezes a deterministic cutoff balance
   // (`Round.principal_snapshot`) at `lock_round`. These tests confirm that
   // value is wired into the proof's snapshot rather than silently dropped.
@@ -488,7 +525,7 @@ describe("assembleDrawProof", () => {
   });
 });
 
-// ─── verifyDrawProofClient: round snapshot cross-check (#642) ────────────────
+// ??? verifyDrawProofClient: round snapshot cross-check (#642) ????????????????
 
 function makeMockRpc(overrides: Partial<StellarRpcClient> = {}): StellarRpcClient {
   return {
@@ -509,7 +546,7 @@ function makeMockRpc(overrides: Partial<StellarRpcClient> = {}): StellarRpcClien
   };
 }
 
-describe("verifyDrawProofClient — round snapshot cross-check", () => {
+describe("verifyDrawProofClient ? round snapshot cross-check", () => {
   it("passes when the on-chain principal_snapshot matches the proof's recorded value", async () => {
     const input = await makeInput({ roundPrincipalSnapshot: "3500000" });
     const proof = await assembleSignedProof(input);
@@ -536,7 +573,7 @@ describe("verifyDrawProofClient — round snapshot cross-check", () => {
     const rpc = makeMockRpc({
       getContractData: async (_contractId, key) => {
         if (key === "Round:1") {
-          // A substituted/stale snapshot — the contract's frozen cutoff disagrees.
+          // A substituted/stale snapshot ? the contract's frozen cutoff disagrees.
           return { value: JSON.stringify({ principal_snapshot: "9999999" }), lastModifiedLedger: 1000 };
         }
         return { value: "{}", lastModifiedLedger: 1000 };
@@ -573,7 +610,7 @@ describe("verifyDrawProofClient — round snapshot cross-check", () => {
   });
 });
 
-// ─── reconcileRewardEntry (#634) ──────────────────────────────────────────────
+// ??? reconcileRewardEntry (#634) ??????????????????????????????????????????????
 
 import { reconcileRewardEntry } from "@/lib/draw-proof-verifier";
 


### PR DESCRIPTION
Closes #686
Closes #687
Closes #688
Closes #689

## Changes
- add a replayable draw audit snapshot shape that binds round, contract, participant hash, ticket weights, randomness metadata, winner, and payout data
- compute and store a deterministic audit snapshot hash in draw proof metadata
- verify the stored audit hash during proof integrity checks and flag tampering
- add coverage for deterministic hashes and participant-weight/randomness tamper detection

## Testing
- Not run, per request.